### PR TITLE
Fixes #22 - Add static files to setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include mozetl *.json

--- a/mozetl/topline/schema.py
+++ b/mozetl/topline/schema.py
@@ -1,9 +1,11 @@
 import json
-import os
 from pyspark.sql.types import StructType
 
+import pkg_resources
+import mozetl.topline
 
-def schema_from_json(path, relative=True):
+
+def schema_from_json(path):
     """ Create a pyspark schema from the json representation.
 
     The json representation must be from a StructType. This can be
@@ -16,14 +18,9 @@ def schema_from_json(path, relative=True):
     >>> json_data = spark.read.parquet(path).schema.json()
 
     :path str: Path the the json data
-    :relative bool: Use the relative path to the current file.
     """
-
-    if relative:
-        path = os.path.join(os.path.dirname(__file__), path)
-
-    with open(path) as json_data:
-        data = json.load(json_data)
+    json_data = pkg_resources.resource_stream(mozetl.topline.__name__, path)
+    data = json.load(json_data)
     return StructType.fromJson(data)
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     author_email='harterrt@mozilla.com',
     url='https://github.com/mozilla/python_mozetl.git',
     packages=find_packages(exclude=['tests']),
+    include_package_data=True,
     install_requires=[
         'python_moztelemetry',  # TODO: pin version
         'click',


### PR DESCRIPTION
This makes it possible to pass in `--py-files=dist/*.egg` to `spark-submit`.

This fixes issues involved with deployment via `bdist_egg`. Json files do not get distributed by default. This also changes relative paths to static assets to using package resources instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozetl/24)
<!-- Reviewable:end -->
