### PR TITLE
Bug 1357875 - Use toLocalIterator instead of writing directly to `file://` via spark

### DIFF
--- a/mozetl/topline/topline_dashboard.py
+++ b/mozetl/topline/topline_dashboard.py
@@ -28,7 +28,7 @@ import click
 
 from pyspark.sql import SparkSession, functions as F
 from mozetl.topline.schema import topline_schema, historical_schema
-
+from mozetl import utils
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -122,16 +122,9 @@ def write_dashboard_data(df, bucket, prefix, mode):
 
     # create a temporary directory to dump files into
     path = tempfile.mkdtemp()
+    filepath = os.path.join(path, 'temp.csv')
 
-    # write dataframe to working directory
-    df.repartition(1).write.csv(path, header=True, mode="overwrite")
-
-    # find the file that was created
-    filepath = None
-    for name in os.listdir(path):
-        if name.endswith(".csv"):
-            filepath = os.path.join(path, name)
-            break
+    utils.write_csv(df, filepath)
 
     # name of the output key
     key = "{}/topline-{}.csv".format(prefix, mode)

--- a/mozetl/utils.py
+++ b/mozetl/utils.py
@@ -1,0 +1,12 @@
+import csv
+
+
+def write_csv(dataframe, path):
+    """ Write a dataframe to local disk. """
+
+    with open(path, 'wb') as fout:
+        writer = csv.writer(fout)
+        writer.writerow(dataframe.columns)
+        for row in dataframe.toLocalIterator():
+            row = [unicode(s).encode('utf-8') for s in row]
+            writer.writerow(row)

--- a/tests/test_topline_dashboard.py
+++ b/tests/test_topline_dashboard.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from click.testing import CliRunner
 
@@ -58,16 +59,25 @@ def snippets_to_df(spark, snippets, base_sample, schema):
     return spark.read.json(jsonRDD, schema=schema)
 
 
+def patch_iterator(monkeypatch, rows):
+    # toLocalIterator does not work when mocking with moto. Patch this
+    # to return the right result
+    def mock_iterator(self):
+        return rows
+    monkeypatch.setattr("pyspark.sql.DataFrame.toLocalIterator", mock_iterator)
+
+
 @pytest.fixture()
-def simple_df(spark):
+def simple_df(spark, monkeypatch):
     snippets = None
     input_df = snippets_to_df(spark, snippets,
                               default_sample, topline_schema)
+    patch_iterator(monkeypatch, input_df.collect())
     return input_df
 
 
 @pytest.fixture()
-def multi_df(spark):
+def multi_df(spark, monkeypatch):
     snippets = [
         {'geo': 'CA'},
         {'channel': 'release'},
@@ -75,6 +85,7 @@ def multi_df(spark):
     ]
     input_df = snippets_to_df(spark, snippets,
                               default_sample, topline_schema)
+    patch_iterator(monkeypatch, input_df.collect())
     return input_df
 
 
@@ -193,6 +204,16 @@ def test_cli_monthly(simple_df, tmpdir, monkeypatch):
         return "file://{}/{}".format(bucket, prefix)
     monkeypatch.setattr(topline, 'format_spark_path',
                         mock_format_spark_path)
+
+    # mock the write_csv to avoid the hoops that need to be jumped
+    # because of moto.
+    def mock_write_csv(df, path):
+        save = os.path.join(str(tmpdir), 'test_write_csv')
+        df.coalesce(1).write.csv('file://' + save,
+                                 header=True, mode="overwrite")
+        filename = [s for s in os.listdir(save) if s.endswith('.csv')][0]
+        os.rename(os.path.join(save, filename), path)
+    monkeypatch.setattr('mozetl.utils.write_csv', mock_write_csv)
 
     # write test data to local path
     input_bucket = str(tmpdir)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from pyspark.sql import SparkSession
+
+from mozetl import utils
+
+
+@pytest.fixture(scope="session")
+def spark(request):
+    spark = (SparkSession
+             .builder
+             .appName("test_utils")
+             .getOrCreate())
+
+    yield spark
+
+    spark.stop()
+
+
+def test_write_csv_ascii(spark, tmpdir):
+    test_data = ['hello', 'world']
+    input_data = [{'a': x} for x in test_data]
+    df = spark.createDataFrame(input_data)
+
+    path = str(tmpdir.join('test_data.csv'))
+    utils.write_csv(df, path)
+
+    with open(path, 'rb') as f:
+        data = f.read()
+
+    assert data.rstrip().split('\r\n')[1:] == test_data
+
+
+def test_write_csv_valid_unicode(spark, tmpdir):
+    test_data = [u'∆', u'∫', u'∬']
+    input_data = [{'a': x} for x in test_data]
+    df = spark.createDataFrame(input_data)
+
+    path = str(tmpdir.join('test_data.csv'))
+    utils.write_csv(df, path)
+
+    with open(path, 'rb') as f:
+        data = f.read().decode('utf-8')
+
+    assert data.rstrip().split('\r\n')[1:] == test_data


### PR DESCRIPTION
There are certain permission issues when deploying topline_dashboard due to permission errors with the spark executor. One alternative is to write the csv files to hdfs and copy over to local disk. This is not necessarily an elegant solution to the problem, so the tried solution is to use the collect (as long as this dataset stays within the size of the driver).

This patch works in practice, and was used to generate reports under `net-mozaws-prod-us-west-2-pipeline-analysis/amiyaguchi/topline-dashboard-data/`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozetl/27)
<!-- Reviewable:end -->
