### PR TITLE
Cache and materialize a dataframe before writing to disk

### DIFF
--- a/mozetl/utils.py
+++ b/mozetl/utils.py
@@ -1,8 +1,19 @@
 import csv
+import logging
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def write_csv(dataframe, path):
     """ Write a dataframe to local disk. """
+
+    # NOTE: Before spark 2.1, toLocalIterator will timeout on some dataframes
+    # because rdd materialization can take a long time. Cache the dataframe
+    # into main memory, and materialize it with a count.
+    dataframe.cache()
+    logger.info("Writing {} rows to {}".format(dataframe.count(), path))
 
     with open(path, 'wb') as fout:
         writer = csv.writer(fout)


### PR DESCRIPTION
Materializing the dataframe/rdd can take a while, which often causes
toLocalIterator to timeout. [1] This is solved on newer versions of
pyspark, but can be worked around by caching and materializing the
dataframe before calling toLocalIterator.

[1] https://issues.apache.org/jira/browse/SPARK-18281

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozetl/32)
<!-- Reviewable:end -->
