### PR TITLE
Fix issue #34 caused by missing mock dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,3 +20,4 @@ deps =
     pytest-cov
     coverage
     moto
+    mock


### PR DESCRIPTION
The update to mock 1.0.0 introduces a missing dependency, but also fixes
an older issue of mock not interacting well with pyspark. This removes
monkeypatching for older tests.

PR #32 should be addressed to fix tests that are failing due to a lack of rdd materialization in this pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozetl/36)
<!-- Reviewable:end -->
