### PR TITLE
Use collect instead of toLocalIterator for write_csv

### DIFF
--- a/mozetl/utils.py
+++ b/mozetl/utils.py
@@ -7,17 +7,20 @@ logger = logging.getLogger(__name__)
 
 
 def write_csv(dataframe, path):
-    """ Write a dataframe to local disk. """
+    """ Write a dataframe to local disk.
+
+    Disclaimer: Do not write csv files larger than driver memory. This
+    is ~15GB for ec2 c3.xlarge (due to caching overhead).
+    """
 
     # NOTE: Before spark 2.1, toLocalIterator will timeout on some dataframes
-    # because rdd materialization can take a long time. Cache the dataframe
-    # into main memory, and materialize it with a count.
-    dataframe.cache()
+    # because rdd materialization can take a long time. Instead of using
+    # an iterator over all partitions, collect everything into driver memory.
     logger.info("Writing {} rows to {}".format(dataframe.count(), path))
 
     with open(path, 'wb') as fout:
         writer = csv.writer(fout)
         writer.writerow(dataframe.columns)
-        for row in dataframe.toLocalIterator():
+        for row in dataframe.collect():
             row = [unicode(s).encode('utf-8') for s in row]
             writer.writerow(row)


### PR DESCRIPTION
toLocalIterator causes intermittent issues because rdd materialization
is variable. Collect is more consistent at the cost of not being limited
to dataframes that can fit into driver memory.

This will spare headaches in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozetl/37)
<!-- Reviewable:end -->
