### PR TITLE
Bump main_summary to v4 in churn

### DIFF
--- a/mozetl/churn/churn.py
+++ b/mozetl/churn/churn.py
@@ -652,7 +652,7 @@ def adjust_start_date(start_date, use_lag):
               help="output prefix associated with the s3 bucket")
 @click.option('--input-bucket', default='telemetry-parquet',
               help="input bucket containing main_summary")
-@click.option('--input-prefix', default='main_summary/v3',
+@click.option('--input-prefix', default='main_summary/v4',
               help="input prefix containing main_summary")
 @click.option('--lag/--no-lag', default=True,
               help="account for the 10 day collection period")


### PR DESCRIPTION
Bumping the version for `main_summary` in churn.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozetl/41)
<!-- Reviewable:end -->
