### PR TITLE
Pass arguments to containers testpilot etl job

### DIFF
--- a/mozetl/testpilot/containers.py
+++ b/mozetl/testpilot/containers.py
@@ -60,6 +60,6 @@ shield_etl_job = testpilot_etl_boilerplate(
 )
 
 
-def etl_job():
-    testpilot_etl_job()
-    shield_etl_job()
+def etl_job(sc, sqlContext, **kwargs):
+    testpilot_etl_job(sc, sqlContext, **kwargs)
+    shield_etl_job(sc, sqlContext, **kwargs)


### PR DESCRIPTION
The ETL job takes a few parameters that were dropped with the most recent revision:
https://github.com/mozilla/python_mozetl/blob/master/mozetl/testpilot/utils.py#L6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozetl/47)
<!-- Reviewable:end -->
