### PR TITLE
Refactor tests and add utility function for uploading csv to s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ before_install:
     - export PATH=$HOME/.local/bin:$PATH
 install:
     - pip install tox-travis codecov
-    - "[ -f spark ] || mkdir spark && cd spark && wget http://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz && cd .."
-    - tar -xf ./spark/spark-2.0.0-bin-hadoop2.7.tgz
-    - export SPARK_HOME=`pwd`/spark-2.0.0-bin-hadoop2.7
+    - "[ -f spark ] || mkdir spark && cd spark && wget https://d3kbcqa49mib13.cloudfront.net/spark-2.0.2-bin-hadoop2.7.tgz && cd .."
+    - tar -xf ./spark/spark-2.0.2-bin-hadoop2.7.tgz
+    - export SPARK_HOME=`pwd`/spark-2.0.2-bin-hadoop2.7
     - export PYTHONPATH=${SPARK_HOME}/python/:$(echo ${SPARK_HOME}/python/lib/py4j-*-src.zip):${PYTHONPATH}
 script:
     - tox

--- a/mozetl/topline/topline_dashboard.py
+++ b/mozetl/topline/topline_dashboard.py
@@ -18,17 +18,13 @@ original data backed-up in `telemetry-parquet/topline_summary/v1`. This is all
 roll-ups up to the swap-over.
 """
 
-import tempfile
-import os
-import shutil
 import logging
 
-import boto3
 import click
-
 from pyspark.sql import SparkSession, functions as F
-from mozetl.topline.schema import topline_schema, historical_schema
+
 from mozetl import utils
+from mozetl.topline.schema import topline_schema, historical_schema
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -119,30 +115,9 @@ def reformat_data(df):
 
 def write_dashboard_data(df, bucket, prefix, mode):
     """ Write the dashboard data to a s3 location. """
-
-    # create a temporary directory to dump files into
-    path = tempfile.mkdtemp()
-    filepath = os.path.join(path, 'temp.csv')
-
-    utils.write_csv(df, filepath)
-
     # name of the output key
     key = "{}/topline-{}.csv".format(prefix, mode)
-
-    # create the s3 resource for this transaction
-    s3 = boto3.client('s3', region_name='us-west-2')
-
-    # write the contents of the file to right location
-    with open(filepath, 'rb') as data:
-        s3.put_object(Bucket=bucket,
-                      Key=key,
-                      Body=data,
-                      ACL='bucket-owner-full-control')
-
-    logger.info('Sucessfully wrote {} to {}'.format(key, bucket))
-
-    # clean up the temporary directory
-    shutil.rmtree(path)
+    utils.write_csv_to_s3(df, bucket, key)
 
 
 @click.command()

--- a/mozetl/utils.py
+++ b/mozetl/utils.py
@@ -1,12 +1,16 @@
 import csv
 import logging
+import os
+import shutil
+import tempfile
 
+import boto3
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def write_csv(dataframe, path):
+def write_csv(dataframe, path, header=True):
     """ Write a dataframe to local disk.
 
     Disclaimer: Do not write csv files larger than driver memory. This
@@ -20,7 +24,34 @@ def write_csv(dataframe, path):
 
     with open(path, 'wb') as fout:
         writer = csv.writer(fout)
-        writer.writerow(dataframe.columns)
+
+        if header:
+            writer.writerow(dataframe.columns)
+
         for row in dataframe.collect():
             row = [unicode(s).encode('utf-8') for s in row]
             writer.writerow(row)
+
+
+def write_csv_to_s3(dataframe, bucket, key, header=True):
+    path = tempfile.mkdtemp()
+    if not os.path.exists(path):
+        os.makedirs(path)
+    filepath = os.path.join(path, 'temp.csv')
+
+    write_csv(dataframe, filepath, header)
+
+    # create the s3 resource for this transaction
+    s3 = boto3.client('s3', region_name='us-west-2')
+
+    # write the contents of the file to right location
+    with open(filepath, 'rb') as data:
+        s3.put_object(Bucket=bucket,
+                      Key=key,
+                      Body=data,
+                      ACL='bucket-owner-full-control')
+
+    logger.info('Sucessfully wrote {} to {}'.format(key, bucket))
+
+    # clean up the temporary directory
+    shutil.rmtree(path)

--- a/tests/test_topline_dashboard.py
+++ b/tests/test_topline_dashboard.py
@@ -1,27 +1,12 @@
-import json
-
-from click.testing import CliRunner
+import functools
 
 import boto3
 import pytest
+from click.testing import CliRunner
 from moto import mock_s3
+
 from mozetl.topline import topline_dashboard as topline
 from mozetl.topline.schema import historical_schema, topline_schema
-from pyspark.sql import SparkSession
-
-
-@pytest.fixture(scope="session")
-def spark(request):
-    spark = (SparkSession
-             .builder
-             .appName("test_topline_dashboard")
-             .getOrCreate())
-
-    # teardown
-    request.addfinalizer(lambda: spark.stop())
-
-    return spark
-
 
 default_sample = {
     "geo": "US",
@@ -40,49 +25,34 @@ default_sample = {
 }
 
 
-def generate_samples(snippets, base_sample):
-    if snippets is None:
-        return [json.dumps(base_sample)]
-
-    samples = []
-    for snippet in snippets:
-        sample = base_sample.copy()
-        sample.update(snippet)
-        samples.append(json.dumps(sample))
-    return samples
-
-
-def snippets_to_df(spark, snippets, base_sample, schema):
-    samples = generate_samples(snippets, base_sample)
-    jsonRDD = spark.sparkContext.parallelize(samples)
-    return spark.read.json(jsonRDD, schema=schema)
+@pytest.fixture()
+def generate_data(dataframe_factory):
+    return functools.partial(
+        dataframe_factory.create_dataframe,
+        base=default_sample,
+        schema=topline_schema
+    )
 
 
 @pytest.fixture()
-def simple_df(spark):
-    snippets = None
-    input_df = snippets_to_df(spark, snippets,
-                              default_sample, topline_schema)
-    return input_df
+def simple_df(generate_data):
+    return generate_data(None)
 
 
 @pytest.fixture()
-def multi_df(spark):
+def multi_df(generate_data):
     snippets = [
         {'geo': 'CA'},
         {'channel': 'release'},
         {'os': 'Linux'}
     ]
-    input_df = snippets_to_df(spark, snippets,
-                              default_sample, topline_schema)
-    return input_df
+    return generate_data(snippets)
 
 
 # reformatted data filters out ROW into Other
-def test_reformat_filters_ROW(spark):
+def test_reformat_filters_ROW(generate_data):
     # Maldives is not a target region
-    input_df = snippets_to_df(spark, [{'geo': 'MV'}],
-                              default_sample, topline_schema)
+    input_df = generate_data([{'geo': 'MV'}])
     df = topline.reformat_data(input_df)
 
     assert df.where("geo='MV'").count() == 0
@@ -132,51 +102,6 @@ def test_reformat_conforms_to_historical_schema(simple_df):
     df = topline.reformat_data(simple_df)
 
     assert df.columns == historical_schema.names
-
-
-@mock_s3
-def test_write_dashboard_contains_csv(simple_df):
-    bucket = 'test-bucket'
-    prefix = 'test-prefix'
-
-    conn = boto3.resource('s3', region_name='us-west-2')
-    conn.create_bucket(Bucket=bucket)
-
-    # dataframe is not reformatted, but not necessary
-    topline.write_dashboard_data(simple_df, bucket, prefix, 'weekly')
-
-    body = (
-        conn
-        .Object(bucket, prefix + '/topline-weekly.csv')
-        .get()['Body']
-        .read().decode('utf-8')
-    )
-
-    # header + 1x row = 2
-    assert len(body.rstrip().split('\n')) == 2
-
-
-@mock_s3
-def test_write_dashboard_handles_existing_key(simple_df, multi_df):
-    bucket = 'test-bucket'
-    prefix = 'test-prefix'
-
-    conn = boto3.resource('s3', region_name='us-west-2')
-    conn.create_bucket(Bucket=bucket)
-
-    # dataframe is not reformatted, but not necessary
-    topline.write_dashboard_data(simple_df, bucket, prefix, 'weekly')
-    topline.write_dashboard_data(multi_df, bucket, prefix, 'weekly')
-
-    body = (
-        conn
-        .Object(bucket, prefix + '/topline-weekly.csv')
-        .get()['Body']
-        .read().decode('utf-8')
-    )
-
-    # header + 3x row = 4
-    assert len(body.rstrip().split('\n')) == 4
 
 
 @mock_s3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,27 +1,30 @@
 # -*- coding: utf-8 -*-
 
+import boto3
 import pytest
-from pyspark.sql import SparkSession
+from moto import mock_s3
 
 from mozetl import utils
 
-
-@pytest.fixture(scope="session")
-def spark(request):
-    spark = (SparkSession
-             .builder
-             .appName("test_utils")
-             .getOrCreate())
-
-    yield spark
-
-    spark.stop()
+default_sample = {
+    "test": "data",
+}
 
 
-def test_write_csv_ascii(spark, tmpdir):
+@pytest.fixture()
+def generate_data(dataframe_factory):
+    """Return a function that generates a dataframe from a list of strings."""
+
+    def create_dataframe_from_list(row=None):
+        snippets = None if row is None else [{'test': x} for x in row]
+        return dataframe_factory.create_dataframe(snippets, default_sample)
+
+    return create_dataframe_from_list
+
+
+def test_write_csv_ascii(generate_data, tmpdir):
     test_data = ['hello', 'world']
-    input_data = [{'a': x} for x in test_data]
-    df = spark.createDataFrame(input_data)
+    df = generate_data(test_data)
 
     path = str(tmpdir.join('test_data.csv'))
     utils.write_csv(df, path)
@@ -32,10 +35,9 @@ def test_write_csv_ascii(spark, tmpdir):
     assert data.rstrip().split('\r\n')[1:] == test_data
 
 
-def test_write_csv_valid_unicode(spark, tmpdir):
+def test_write_csv_valid_unicode(generate_data, tmpdir):
     test_data = [u'∆', u'∫', u'∬']
-    input_data = [{'a': x} for x in test_data]
-    df = spark.createDataFrame(input_data)
+    df = generate_data(test_data)
 
     path = str(tmpdir.join('test_data.csv'))
     utils.write_csv(df, path)
@@ -44,3 +46,66 @@ def test_write_csv_valid_unicode(spark, tmpdir):
         data = f.read().decode('utf-8')
 
     assert data.rstrip().split('\r\n')[1:] == test_data
+
+
+@mock_s3
+def test_write_csv_to_s3(generate_data):
+    bucket = 'test-bucket'
+    key = 'test.csv'
+
+    conn = boto3.resource('s3', region_name='us-west-2')
+    conn.create_bucket(Bucket=bucket)
+
+    utils.write_csv_to_s3(generate_data(["foo"]), bucket, key)
+
+    body = (
+        conn
+            .Object(bucket, key)
+            .get()['Body']
+            .read().decode('utf-8')
+    )
+
+    # header + 1x row = 2
+    assert len(body.rstrip().split('\n')) == 2
+
+
+@mock_s3
+def test_write_csv_to_s3_no_header(generate_data):
+    bucket = 'test-bucket'
+    key = 'test.csv'
+
+    conn = boto3.resource('s3', region_name='us-west-2')
+    conn.create_bucket(Bucket=bucket)
+
+    utils.write_csv_to_s3(generate_data(), bucket, key, header=False)
+
+    body = (
+        conn
+            .Object(bucket, key)
+            .get()['Body']
+            .read().decode('utf-8')
+    )
+
+    assert len(body.rstrip().split('\n')) == 1
+
+
+@mock_s3
+def test_write_csv_to_s3_existing(generate_data):
+    bucket = 'test-bucket'
+    key = 'test.csv'
+
+    conn = boto3.resource('s3', region_name='us-west-2')
+    conn.create_bucket(Bucket=bucket)
+
+    utils.write_csv_to_s3(generate_data(["foo"]), bucket, key)
+    utils.write_csv_to_s3(generate_data(["foo", "bar"]), bucket, key)
+
+    body = (
+        conn
+            .Object(bucket, key)
+            .get()['Body']
+            .read().decode('utf-8')
+    )
+
+    # header + 2x row = 3
+    assert len(body.rstrip().split('\n')) == 3


### PR DESCRIPTION
This addresses issue #21 among other things.

* Bump spark from 2.0.0 to 2.0.2
* Refactor spark session object into conftest.py
* Add `dataframe_factory` fixture for generating testing datasets from python dictionaries and fragments
* Refactor various tests to use `dataframe_factory`, generally using a helper function fixture that partially applies the base sample of the data and optionally the schema for the dataframe
* Add and test `utils.write_csv_to_s3`

