### PR TITLE
Bug 1375725 - Port ToplineSummaryView to python_mozetl

### DIFF
--- a/mozetl/topline/topline_summary.py
+++ b/mozetl/topline/topline_summary.py
@@ -1,0 +1,298 @@
+import logging
+import operator
+from datetime import datetime
+
+import arrow
+import click
+from pyspark.sql import types, SparkSession, functions as F
+from pyspark.sql.window import Window
+
+from mozetl.topline.schema import topline_schema
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+countries = {
+    "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR", "AS",
+    "AT", "AU", "AW", "AX", "AZ", "BA", "BB", "BD", "BE", "BF", "BG",
+    "BH", "BI", "BJ", "BL", "BM", "BN", "BO", "BQ", "BR", "BS", "BT",
+    "BV", "BW", "BY", "BZ", "CA", "CC", "CD", "CF", "CG", "CH", "CI",
+    "CK", "CL", "CM", "CN", "CO", "CR", "CU", "CV", "CW", "CX", "CY",
+    "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "EH",
+    "ER", "ES", "ET", "FI", "FJ", "FK", "FM", "FO", "FR", "GA", "GB",
+    "GD", "GE", "GF", "GG", "GH", "GI", "GL", "GM", "GN", "GP", "GQ",
+    "GR", "GS", "GT", "GU", "GW", "GY", "HK", "HM", "HN", "HR", "HT",
+    "HU", "ID", "IE", "IL", "IM", "IN", "IO", "IQ", "IR", "IS", "IT",
+    "JE", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KP",
+    "KR", "KW", "KY", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS",
+    "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MF", "MG", "MH",
+    "MK", "ML", "MM", "MN", "MO", "MP", "MQ", "MR", "MS", "MT", "MU",
+    "MV", "MW", "MX", "MY", "MZ", "NA", "NC", "NE", "NF", "NG", "NI",
+    "NL", "NO", "NP", "NR", "NU", "NZ", "OM", "PA", "PE", "PF", "PG",
+    "PH", "PK", "PL", "PM", "PN", "PR", "PS", "PT", "PW", "PY", "QA",
+    "RE", "RO", "RS", "RU", "RW", "SA", "SB", "SC", "SD", "SE", "SG",
+    "SH", "SI", "SJ", "SK", "SL", "SM", "SN", "SO", "SR", "SS", "ST",
+    "SV", "SX", "SY", "SZ", "TC", "TD", "TF", "TG", "TH", "TJ", "TK",
+    "TL", "TM", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG",
+    "UM", "US", "UY", "UZ", "VA", "VC", "VE", "VG", "VI", "VN", "VU",
+    "WF", "WS", "YE", "YT", "ZA", "ZM", "ZW"
+}
+
+seconds_per_hour = 60 * 60
+seconds_per_day = seconds_per_hour * 24
+
+
+def column_like(name, patterns, default):
+    """ patterns: dict[label, list[match_expr]]"""
+    # start with the pyspark.sql.functions
+    op = F
+    for label in patterns:
+        cond = reduce(
+            operator.__or__,
+            [F.col(name).like(pat) for pat in patterns[label]]
+        )
+        op = op.when(cond, label)
+    return op.otherwise(default)
+
+
+def clean_input(dataframe, start, end):
+    input_columns = [
+        "client_id",
+        "timestamp",
+        "is_default_browser",
+        "search_counts",
+        "country",
+        "profile_creation_date",
+        "channel",
+        "os",
+        "hours",
+    ]
+    columns = {col: F.col(col) for col in input_columns}
+
+    # normalize countries against a whitelist
+    columns["country"] = (
+        F.when(F.col("country").isin(countries), F.col("country"))
+        .otherwise("Other")
+        .alias("country")
+    )
+
+    # clean operating system based on CEP naming scheme
+    pattern = {
+        "Windows": ["Windows%", "WINNT%"],
+        "Mac": ["Darwin%"],
+        "Linux": ["%Linux%", "%BSD%", "%SunOS%"],
+    }
+    columns["os"] = column_like("os", pattern, "Other")
+
+    # rename normalized channel to channel
+    columns["channel"] = F.col("normalized_channel")
+
+    # convert profile creation date into seconds (day -> seconds)
+    columns["profile_creation_date"] = (
+        F.when(F.col("profile_creation_date") >= 0,
+               F.col("profile_creation_date") * seconds_per_day)
+        .otherwise(0.0)
+        .cast(types.DoubleType())
+    )
+
+    # generate hours of usage from subsession length (seconds -> hours)
+    columns["hours"] = (
+        F.when((F.col("subsession_length") >= 0) &
+               (F.col("subsession_length") < 180 * seconds_per_day),
+               F.col("subsession_length") / seconds_per_hour)
+        .otherwise(0.0)
+        .cast(types.DoubleType())
+    )
+
+    # clean the dataset
+    clean = (
+        dataframe
+        .drop_duplicates(["document_id"])
+        .where(F.col("submission_date_s3") >= start)
+        .where(F.col("submission_date_s3") < end)
+        .select([expr.alias(name) for name, expr in columns.iteritems()])
+    )
+
+    return clean
+
+
+def search_aggregates(dataframe, attributes):
+    # search engines to pivot against
+    search_labels = ["google", "bing", "yahoo", "other"]
+
+    # patterns to filter search engines
+    patterns = {
+        "google": ["%Google%", "%google%"],
+        "bing": ["%Bing%", "%bing%"],
+        "yahoo": ["%Yahoo%", "%yahoo%"],
+    }
+
+    s_engine = (
+        column_like("search_count.engine", patterns, "other").alias("engine")
+    )
+    s_count = (
+        F.when(F.col("search_count.count") > 0, F.col("search_count.count"))
+        .otherwise(0)
+        .alias("count")
+    )
+
+    # generate the search aggregates by exploding and pivoting
+    search = (
+        dataframe
+        .withColumn("search_count", F.explode("search_counts"))
+        .select("country", "channel", "os", s_engine, s_count)
+        .groupBy(attributes)
+        .pivot("engine", search_labels)
+        .agg(F.sum("count"))
+        .na.fill(0, search_labels)
+    )
+
+    return search
+
+
+def hours_aggregates(dataframe, attributes):
+    """ Aggregate hours over the set of attributes"""
+    # simple aggregate
+    hours = dataframe.groupBy(attributes).agg(F.sum("hours").alias("hours"))
+    return hours
+
+
+def client_aggregates(dataframe, timestamp, attributes):
+    """Aggregates clients by properties such as being new or set as default. """
+
+    select_expr = {col: F.col(col) for col in attributes}
+
+    select_expr["new_client"] = F.when(
+        F.col("profile_creation_date") >= timestamp, 1).otherwise(0)
+
+    select_expr["default_client"] = F.when(
+        F.col("is_default_browser"), 1).otherwise(0)
+
+    select_expr["clientid_rank"] = F.row_number().over(
+        Window
+        .partitionBy("client_id")
+        .orderBy(F.desc("timestamp"))
+    )
+
+    clients = (
+        dataframe
+        .select([expr.alias(name) for name, expr in select_expr.iteritems()])
+        .where("clientid_rank = 1")
+        .groupBy(attributes)
+        .agg(
+            F.count("*").alias("actives"),
+            F.sum("new_client").alias("new_records"),
+            F.sum("default_client").alias("default")
+        )
+    )
+
+    return clients
+
+
+def transform(dataframe, start, mode):
+    # attributes that break down the aggregates
+    attributes = ["country", "channel", "os"]
+
+    end = get_end_date(start, mode)
+    # clean the dataset
+    df = clean_input(dataframe, start, end)
+
+    # find the timestamp in seconds to find new profiles
+    report_delta = datetime.strptime(start, "%Y%m%d") - datetime(1970, 1, 1)
+    report_timestamp = report_delta.total_seconds()
+
+    # generate aggregates
+    clients = client_aggregates(df, report_timestamp, attributes)
+    searches = search_aggregates(df, attributes)
+    hours = hours_aggregates(df, attributes)
+
+    # take the outer join of all aggregates and replace null values with zeros
+    return (
+        clients
+        .join(searches, attributes, "outer")
+        .join(hours, attributes, "outer")
+        .withColumnRenamed('country', 'geo')
+        .withColumn('crashes', F.lit(0L))
+        .na.fill(0)
+    )
+
+
+def get_end_date(ds_start, period):
+    """ Return the end date given the start date and period. """
+    date_start = arrow.get(ds_start, "YYYYMMDD")
+    if period == "monthly":
+        date_end = date_start.replace(months=+1)
+    else:
+        date_end = date_start.replace(days=+7)
+    ds_end = date_end.format("YYYYMMDD")
+
+    return ds_end
+
+
+def format_spark_path(bucket, prefix):
+    return "s3://{}/{}".format(bucket, prefix)
+
+
+def extract(spark, path):
+    """Extract the source dataframe from the spark compatible path.
+
+    spark: SparkSession
+    path: path to parquet files in s3
+    ds_start: inclusive date
+    """
+    return (
+        spark.read
+        .option("mergeSchema", "true")
+        .parquet(path)
+    )
+
+
+def save(dataframe, bucket, prefix, version, mode, start_date):
+    prefix = (
+        "{}/v{}/mode={}/report_start={}"
+        .format(prefix, version, mode, start_date)
+    )
+    location = format_spark_path(bucket, prefix)
+    logger.info("Writing topline summary to {}".format(location))
+
+    # report start is implicit in the partition path
+    fields = [col for col in topline_schema.names if col != "report_start"]
+    (
+        dataframe
+        .select(fields)
+        .repartition(1)
+        .write
+        .parquet(location)
+    )
+
+
+@click.command()
+@click.argument('start_date')
+@click.argument('mode', type=click.Choice(['weekly', 'monthly']))
+@click.argument('bucket')
+@click.argument('prefix')
+@click.option('--input_bucket',
+              default='telemetry-parquet',
+              help='Bucket of the input dataset')
+@click.option('--input_prefix',
+              default='main_summary/v4',
+              help='Prefix of the input dataset')
+def main(start_date, mode, bucket, prefix, input_bucket, input_prefix):
+    spark = (
+        SparkSession
+        .builder
+        .appName("topline_summary")
+        .getOrCreate()
+    )
+
+    version = 1
+    source_path = format_spark_path(input_bucket, input_prefix)
+
+    logger.info("Loading main_summary into memory...")
+    main_summary = extract(spark, source_path)
+
+    logger.info("Running the topline summary...")
+    rollup = transform(main_summary, start_date, mode)
+
+    logger.info("Saving rollup to disk...")
+    save(rollup, bucket, prefix, version, mode, start_date)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,28 @@ class DataFrameFactory:
         # if no schema is provided, the schema will be inferred
         return self.spark.createDataFrame(samples, schema)
 
+    def create_dataframe_with_key(self, snippets, base, key, key_func=None, schema=None):
+        """Generate dataframe with autoincrementing key function"""
+        def generate_keys():
+            num = 0
+            while True:
+                yield str(num)
+                num += 1
+
+        # default key function
+        if not key_func:
+            key_func = generate_keys
+
+        if not snippets:
+            snippets = [dict()]
+
+        # update each snippet with new key
+        gen = key_func()
+        for i in range(len(snippets)):
+            snippets[i].update({key: next(gen)})
+
+        return self.create_dataframe(snippets, base, schema)
+
 
 @pytest.fixture()
 def dataframe_factory(spark):

--- a/tests/test_topline_summary.py
+++ b/tests/test_topline_summary.py
@@ -1,0 +1,327 @@
+import functools
+import os
+
+import arrow
+import pytest
+from click.testing import CliRunner
+from pyspark.sql import functions as F, Row
+from pyspark.sql.types import (
+    StructField, StructType, StringType, BooleanType, ArrayType, LongType
+)
+
+from mozetl.topline import topline_summary as topline
+
+
+def generate_dates(submission_date_s3, ts_offset=0, creation_offset=0):
+    # convert submission_date into profile_creation_date and timestamps
+    submission = arrow.get(submission_date_s3, "YYYYMMDD")
+    creation = submission.replace(days=+creation_offset)
+    timestamp = submission.replace(days=+ts_offset)
+
+    # variables for conversion
+    epoch = arrow.get(0)
+    seconds_per_day = topline.seconds_per_day
+    nanoseconds_per_second = 10**9
+
+    date_snippet = {
+        "submission_date_s3": submission_date_s3,
+        "profile_creation_date": (
+            long((creation - epoch).total_seconds() / seconds_per_day)
+        ),
+        "timestamp": (
+            long((timestamp - epoch).total_seconds() * nanoseconds_per_second)
+        )
+    }
+
+    return date_snippet
+
+
+def search_row(engine='hooli', count=1, source='searchbar'):
+    return Row(
+        engine=unicode(engine),
+        source=unicode(source),
+        count=count
+    )
+
+
+schema = StructType([
+    StructField("document_id", StringType(), True),
+    StructField("client_id", StringType(), True),
+    StructField("timestamp", StringType(), True),
+    StructField("is_default_browser", BooleanType(), True),
+    StructField("search_counts",
+                ArrayType(
+                    StructType([
+                        StructField("engine", StringType(), True),
+                        StructField("source", StringType(), True),
+                        StructField("count", LongType(), True)
+                    ]), True),
+                True),
+    StructField("country", StringType(), True),
+    StructField("profile_creation_date", LongType(), True),
+    StructField("normalized_channel", StringType(), True),
+    StructField("os", StringType(), True),
+    StructField("subsession_length", LongType(), True),
+    StructField("submission_date_s3", StringType(), True),
+])
+
+
+start_ds = "20170601"
+end_ds = "20170608"
+
+default_sample = {
+    "document_id": "document-id",
+    "client_id": "client-id",
+    "timestamp": long(1.4962752e+18),
+    "is_default_browser": True,
+    "search_counts": [search_row()],
+    "country": "US",
+    "profile_creation_date": 17318,
+    "normalized_channel": "release",
+    "os": "Linux",
+    "subsession_length": 3600,
+    "submission_date_s3": "20170601",
+}
+default_sample.update(generate_dates(start_ds))
+
+
+@pytest.fixture()
+def generate_data(dataframe_factory):
+    return functools.partial(
+        dataframe_factory.create_dataframe_with_key,
+        base=default_sample,
+        key="document_id",
+        schema=schema
+    )
+
+
+@pytest.fixture()
+def cool_df(dataframe_factory):
+    rows = [
+        # exact
+        "ice",
+        "lice",
+        # prefixed
+        "glacier water",
+        "melting glaciers",
+        # suffixed
+        "gentoo penguin",
+        "penguin suit",
+        # anywhere
+        "dinosaurs are always cool",
+        "chickens are dinosaurs, somewhat"
+    ]
+    snippets = [{"items": row} for row in rows]
+    base = {"items": "foo"}
+    return dataframe_factory.create_dataframe(snippets, base)
+
+
+def test_column_like(cool_df):
+    pattern = {"cool": ["ice", "glacier%", "%penguin", "%dinosaurs%"]}
+    res = cool_df.select(
+        topline.column_like("items", pattern, "not cool").alias("items")
+    )
+
+    # lice, melting glaciers, and penguin suits are not cool
+    assert res.where("items='not cool'").count() == 3
+
+
+def test_deduplicate_documents(dataframe_factory):
+    snippets = [
+        {"document_id": "1"},
+        {"document_id": "2"},
+        {"document_id": "2"},
+
+    ]
+    df = dataframe_factory.create_dataframe(snippets, default_sample, schema=schema)
+
+    res = topline.clean_input(df, start_ds, end_ds)
+    assert res.count() == 2
+
+
+def test_clean_input_date_range(generate_data):
+    snippets = [
+        generate_dates("20170601"),
+        generate_dates("20170602"),
+        generate_dates("20170501"),
+        generate_dates("20170608")
+    ]
+
+    df = generate_data(snippets)
+    res = topline.clean_input(df, start_ds, end_ds)
+    assert res.count() == 2
+
+
+def test_clean_input_country(generate_data):
+    snippets = [
+        {"country": "INVALID"},
+        {"country": "US"}
+    ]
+
+    df = generate_data(snippets)
+    res = topline.clean_input(df, start_ds, end_ds)
+
+    assert res.where(F.col("country") == "Other").count() == 1
+
+
+def test_clean_input_profile_creation(generate_data):
+    snippets = [
+        {"profile_creation_date": 1},
+        {"profile_creation_date": -1},
+    ]
+
+    df = generate_data(snippets)
+    res = topline.clean_input(df, start_ds, end_ds)
+
+    total = res.select("profile_creation_date").groupBy().sum().first()[0]
+    assert total == topline.seconds_per_day
+
+
+def test_clean_input_os(generate_data):
+    oses = [
+        "Windows_NT", "WINNT", "Darwin", "Linux",   # 4
+        "xWindows", "Mac", "SUN", "BaDsTrInG",      # 4
+    ]
+    snippets = [{"os": os} for os in oses]
+    df = generate_data(snippets)
+    res = topline.clean_input(df, start_ds, end_ds)
+
+    assert res.where(F.col("os") == "Other").count() == 4
+    assert res.select("os").distinct().count() == 4
+
+
+def test_clean_input_hours(generate_data):
+    snippets = [
+        {"subsession_length": topline.seconds_per_hour},
+        {"subsession_length": 181 * topline.seconds_per_day},
+        {"subsession_length": -1 * topline.seconds_per_day},
+    ]
+
+    df = generate_data(snippets)
+    res = topline.clean_input(df, start_ds, end_ds)
+
+    total = res.select("hours").groupBy().sum().first()[0]
+    assert total == 1.0
+
+
+def test_transform_searches(generate_data):
+    snippets = [
+        {"search_counts": None},
+        {"search_counts": [search_row("google")]},
+        {
+            "country": "CA",
+            "search_counts": [
+                search_row("hooli"),
+                search_row("google")
+            ]
+        },
+    ]
+
+    df = generate_data(snippets)
+    res = topline.transform(df, start_ds, "weekly")
+
+    assert res.count() == 2
+    assert res.groupBy().sum().first()["sum(google)"] == 2
+    assert (
+        res
+        .groupBy("geo")
+        .sum()
+        .where(F.col("geo") == "CA")
+        .first()["sum(other)"]) == 1
+
+
+def test_transform_hours(generate_data):
+    snippets = [
+        {"country": "US", "subsession_length": topline.seconds_per_hour},
+        {"country": "CA", "subsession_length": topline.seconds_per_hour},
+        {"subsession_length": 181 * topline.seconds_per_day},
+        {"subsession_length": -1 * topline.seconds_per_day},
+    ]
+
+    df = generate_data(snippets)
+    res = topline.transform(df, start_ds, "weekly")
+
+    assert res.count() == 2
+    assert res.groupBy().sum().first()["sum(hours)"] == 2.0
+    assert (
+        res
+        .groupBy("geo")
+        .sum()
+        .where(F.col("geo") == "CA")
+        .first()["sum(hours)"]) == 1.0
+
+
+def test_transform_clients(generate_data):
+    submission_dates = generate_dates(start_ds)
+    snippets = [
+        # not new, default
+        {
+            "client_id": "0",
+            "profile_creation_date": 0,
+        },
+        # new, but duplicate
+        {
+            "client_id": "1"
+        },
+        {
+            "client_id": "1",
+            "timestamp": submission_dates["timestamp"] + 1,
+        },
+        # new, not default
+        {
+            "client_id": "2",
+            "is_default_browser": False
+        }
+    ]
+
+    df = generate_data(snippets)
+    res = topline.transform(df, start_ds, "weekly")
+
+    assert res.count() == 1
+    row = res.first()
+
+    assert row.actives == 3
+    assert row.new_records == 2
+    assert row.default == 2
+
+
+def test_job_weekly(spark, generate_data, monkeypatch, tmpdir):
+    test_bucket = str(tmpdir)
+    test_prefix = "prefix"
+
+    snippets = [
+        {"client_id": "1"},
+        {"client_id": "2"},
+        {"client_id": "3"},
+    ]
+
+    def mock_extract(spark_session, source_path):
+        return generate_data(snippets)
+    monkeypatch.setattr(topline, 'extract', mock_extract)
+
+    def mock_format_spark_path(bucket, prefix):
+        return "file://{}/{}".format(bucket, prefix)
+    monkeypatch.setattr(topline, 'format_spark_path', mock_format_spark_path)
+
+    runner = CliRunner()
+    args = [
+        start_ds,
+        "weekly",
+        test_bucket,
+        test_prefix,
+    ]
+
+    result = runner.invoke(topline.main, args)
+    assert result.exit_code == 0
+
+    # assert path was written
+    assert os.path.isdir("{}/{}/v1/mode=weekly/report_start={}"
+                         .format(test_bucket, test_prefix, start_ds))
+
+    # assert data can be read
+    path = mock_format_spark_path(test_bucket, test_prefix)
+    df = spark.read.parquet(path)
+    assert df.count() == 1
+
+    row = df.first()
+    assert row.actives == 3


### PR DESCRIPTION
[Bug 1375725](https://bugzilla.mozilla.org/show_bug.cgi?id=1375725)

The ToplineSummaryView is difficult to validate. I rewrote the job in pyspark -- the job was originally ported from python to scala because of regex performance with spark UDFs. The job can use pure dataframe constructs, preventing processing bottlenecks.

A bonus is that python_mozetl is easy to use as a library in jupyter (and presumably zeppelin). This has made validating the results of this job nicer to work with.