### PR TITLE
Set topline_summary mode to "overwrite"

### DIFF
--- a/mozetl/topline/topline_summary.py
+++ b/mozetl/topline/topline_summary.py
@@ -262,7 +262,7 @@ def save(dataframe, bucket, prefix, version, mode, start_date):
         .select(fields)
         .repartition(1)
         .write
-        .parquet(location)
+        .parquet(location, mode="overwrite")
     )
 
 


### PR DESCRIPTION
```
INFO:mozetl.topline.topline_summary:Loading main_summary into memory...
INFO:mozetl.topline.topline_summary:Running the topline summary...
INFO:mozetl.topline.topline_summary:Saving rollup to disk...
INFO:mozetl.topline.topline_summary:Writing topline summary to s3://telemetry-parquet/topline_summary/v1/v1/mode=weekly/report_start=20170618
Traceback (most recent call last):
  File "/mnt/analyses/python_mozetl/run.py", line 1, in <module>
    from mozetl.topline import topline_summary as ts; ts.main()
  File "/mnt/anaconda2/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/mnt/anaconda2/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/mnt/anaconda2/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/mnt/anaconda2/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/mnt/analyses/python_mozetl/mozetl/topline/topline_summary.py", line 298, in main
    save(rollup, bucket, prefix, version, mode, start_date)
  File "/mnt/analyses/python_mozetl/mozetl/topline/topline_summary.py", line 265, in save
    .parquet(location)
  File "/usr/lib/spark/python/lib/pyspark.zip/pyspark/sql/readwriter.py", line 641, in parquet
  File "/usr/lib/spark/python/lib/py4j-0.10.3-src.zip/py4j/java_gateway.py", line 1133, in __call__
  File "/usr/lib/spark/python/lib/pyspark.zip/pyspark/sql/utils.py", line 69, in deco
pyspark.sql.utils.AnalysisException: u'path s3://telemetry-parquet/topline_summary/v1/v1/mode=weekly/report_start=20170618 already exists.;'
```