### PR TITLE
Bug 1377730 - disable document_id deduplication in topline_summary

### DIFF
--- a/mozetl/topline/topline_summary.py
+++ b/mozetl/topline/topline_summary.py
@@ -107,7 +107,6 @@ def clean_input(dataframe, start, end):
     # clean the dataset
     clean = (
         dataframe
-        .drop_duplicates(["document_id"])
         .where(F.col("submission_date_s3") >= start)
         .where(F.col("submission_date_s3") < end)
         .select([expr.alias(name) for name, expr in columns.iteritems()])

--- a/tests/test_topline_summary.py
+++ b/tests/test_topline_summary.py
@@ -126,6 +126,7 @@ def test_column_like(cool_df):
     assert res.where("items='not cool'").count() == 3
 
 
+@pytest.mark.skip(reason="Bug 1377730 - Weekly Topline Summary aborts on save")
 def test_deduplicate_documents(dataframe_factory):
     snippets = [
         {"document_id": "1"},


### PR DESCRIPTION
Resolves [Bug 1377730 - Weekly Topline Summary aborts on save](https://bugzilla.mozilla.org/show_bug.cgi?id=1377730)

`document_id` deduplication causes a large data shuffle across a week of data (1+TB of main_summary), running the cluster 2 hours before failing. Disabling deduplication makes the job work again. 