### PR TITLE
Bug 1378989 - remove catching of exceptions in churn job

### DIFF
--- a/mozetl/churn/churn.py
+++ b/mozetl/churn/churn.py
@@ -690,8 +690,6 @@ def main(start_date, bucket, prefix,
                 lambda d: process_week(main_df, d, bucket, prefix))
         else:
             process_week(main_df, week_start_date, bucket, prefix)
-    except Exception:
-        logger.exception("Exception for {}".format(week_start_date))
     finally:
         spark.stop()
 


### PR DESCRIPTION
[Bug 1378989 - Churn job from mozetl should retry on exceptions](https://bugzilla.mozilla.org/show_bug.cgi?id=1378989)

This should prevent the exception handler from suppressing the error. This behavior caused the churn job to miss data for several weeks. 