### PR TITLE
Bug 1368089 - Filter incontent searches in search aggregation jobs

### DIFF
--- a/mozetl/constants.py
+++ b/mozetl/constants.py
@@ -1,0 +1,7 @@
+# Restrict to a whitelist of search_source's to avoid double counting while
+# we test our new search_count telemetry developed in:
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1367554
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1368089
+SEARCH_SOURCE_WHITELIST = [
+    'searchbar', 'urlbar', 'abouthome', 'newtab', 'contextmenu', 'system'
+]

--- a/mozetl/topline/topline_summary.py
+++ b/mozetl/topline/topline_summary.py
@@ -135,10 +135,16 @@ def search_aggregates(dataframe, attributes):
         .alias("count")
     )
 
+    source_whitelist = [
+        'searchbar', 'urlbar', 'abouthome', 'newtab', 'contextmenu', 'system'
+    ]
+
     # generate the search aggregates by exploding and pivoting
     search = (
         dataframe
         .withColumn("search_count", F.explode("search_counts"))
+        .where(F.col("search_count.source").isNull() |
+               F.col("search_count.source").isin(source_whitelist))
         .select("country", "channel", "os", s_engine, s_count)
         .groupBy(attributes)
         .pivot("engine", search_labels)

--- a/tests/test_search_rollup.py
+++ b/tests/test_search_rollup.py
@@ -86,6 +86,19 @@ def test_single_client_multiple_search_engines(generate_data):
     assert result.select(F.sum("search_count")).first()[0] == 7
 
 
+def test_filter_incontent_searches(generate_data):
+    snippets = [
+        {'search_counts': [search_row(source="in-content")]},   # no
+        {'search_counts': [search_row(source="contextmenu")]},  # yes
+        {'search_counts': [search_row(source="abouthome")]},    # yes
+    ]
+    df = generate_data(snippets)
+    result = search_rollups.transform(df, "daily")
+
+    # in-content search should be filtered
+    assert result.select(F.sum("search_count")).first()[0] == 2
+
+
 # 2 profiles have different search counts
 def test_multiple_clients_multiple_search_engines(generate_data):
     snippets = [

--- a/tests/test_topline_summary.py
+++ b/tests/test_topline_summary.py
@@ -231,6 +231,19 @@ def test_transform_searches(generate_data):
         .first()["sum(other)"]) == 1
 
 
+def test_transform_searches_filters_incontent(generate_data):
+    snippets = [
+        {'search_counts': [search_row("google", source="in-content")]},   # no
+        {'search_counts': [search_row("google", source="contextmenu")]},  # yes
+        {'search_counts': [search_row("google", source="abouthome")]},    # yes
+    ]
+
+    df = generate_data(snippets)
+    res = topline.transform(df, start_ds, "weekly")
+
+    assert res.groupBy().sum().first()["sum(google)"] == 2
+
+
 def test_transform_hours(generate_data):
     snippets = [
         {"country": "US", "subsession_length": topline.seconds_per_hour},


### PR DESCRIPTION
In-content searches were removed from the search rollup in a refactor, causing
search data to become skewed. This also affects the topline summary, inflating
the search results significantly.