### PR TITLE
Bug 1381460 - Whitelist activity stream event source

### DIFF
--- a/mozetl/constants.py
+++ b/mozetl/constants.py
@@ -3,5 +3,6 @@
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1367554
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1368089
 SEARCH_SOURCE_WHITELIST = [
-    'searchbar', 'urlbar', 'abouthome', 'newtab', 'contextmenu', 'system'
+    'searchbar', 'urlbar', 'abouthome', 'newtab', 'contextmenu', 'system',
+    'activitystream'
 ]


### PR DESCRIPTION
Should this be enough to track the new search event?

This pull request should not land until [a matching patch](https://bugzilla.mozilla.org/show_bug.cgi?id=1381460) on the Firefox side to add the event in telemetry gets r+. In order to make sure the event name won't change.