### PR TITLE
mozetl/shield/privacy_prefs.py

### DIFF
--- a/mozetl/shield/privacy_prefs.py
+++ b/mozetl/shield/privacy_prefs.py
@@ -17,7 +17,8 @@ DATAFRAME_COLUMN_CONFIGS = [
     ("event", "payload/payload/event", None, StringType()),
     ("originDomain", "payload/payload/originDomain", None, StringType()),
     ("breakage", "payload/payload/breakage", None, StringType()),
-    ("notes", "payload/payload/notes", None, StringType())
+    ("notes", "payload/payload/notes", None, StringType()),
+    ("study", "payload/payload/study", None, StringType()),
 ]
 
 

--- a/mozetl/shield/privacy_prefs.py
+++ b/mozetl/shield/privacy_prefs.py
@@ -8,7 +8,7 @@
 from pyspark.sql.types import StringType
 
 from ..basic import convert_pings, DataFrameConfig
-from .utils import testpilot_etl_boilerplate
+from ..testpilot.utils import testpilot_etl_boilerplate
 
 
 SHIELD_ADDON_ID = '@shield-study-privacy'
@@ -30,7 +30,7 @@ def transform_shield_pings(sqlContext, pings):
 
 
 def include_shield_pings(ping):
-    return ping['payload/test'] == SHIELD_ADDON_ID
+    return ping['payload/payload/study'] == SHIELD_ADDON_ID
 
 
 def etl_job(sc, sqlContext, **kwargs):

--- a/mozetl/shield/privacy_prefs.py
+++ b/mozetl/shield/privacy_prefs.py
@@ -1,0 +1,40 @@
+# coding: utf-8
+
+# Started from mashing up:
+#  https://gist.githubusercontent.com/ilanasegall/b3ce1aa0d3cc8c117a35b4a4fb9d4681/raw/c8a96e823cd56072e896e4c2d94c496306b59c8c/blok_df.py
+# with:
+# https://github.com/mozilla/python_mozetl/blob/689afa3d23229ca717422314c5a56abd83a85a0d/mozetl/testpilot/containers.py
+
+from pyspark.sql.types import StringType
+
+from ..basic import convert_pings, DataFrameConfig
+from .utils import testpilot_etl_boilerplate
+
+
+SHIELD_ADDON_ID = '@shield-study-privacy'
+DATAFRAME_COLUMN_CONFIGS = [
+    ("branch", "payload/payload/branch", None, StringType()),
+    ("event", "payload/payload/event", None, StringType()),
+    ("originDomain", "payload/payload/originDomain", None, StringType()),
+    ("breakage", "payload/payload/breakage", None, StringType()),
+    ("notes", "payload/payload/notes", None, StringType())
+]
+
+
+def transform_shield_pings(sqlContext, pings):
+    return convert_pings(
+        sqlContext,
+        pings,
+        DataFrameConfig(DATAFRAME_COLUMN_CONFIGS, include_shield_pings)
+    )
+
+
+def include_shield_pings(ping):
+    return ping['payload/test'] == SHIELD_ADDON_ID
+
+
+def etl_job(sc, sqlContext, **kwargs):
+    return testpilot_etl_boilerplate(
+        transform_shield_pings,
+        's3n://telemetry-parquet/harter/privacy_prefs_shield/v1'
+    )

--- a/tests/test_shield_privacy_prefs.py
+++ b/tests/test_shield_privacy_prefs.py
@@ -1,0 +1,167 @@
+from pyspark.sql import SQLContext
+from mozetl.shield.privacy_prefs import transform_shield_pings
+
+
+def create_ping_rdd(sc, payload):
+    return sc.parallelize([
+        {'payload': {
+            'study': '@shield-study-privacy',
+            'other-ignored-field': 'who cares',
+            'payload': payload
+        }}
+    ])
+
+
+def create_row(overrides):
+    keys = ["branch", "event", "originDomain", "breakage", "notes"]
+
+    overrides['study'] = '@shield-study-privacy'
+
+    return {key: overrides.get(key, None) for key in keys}
+
+
+def test_report_problem(row_to_dict, spark_context):
+    input_payload = {
+        'study': '@shield-study-privacy',
+        'branch': 'thirdPartyCookiesOnlyFromVisited',
+        'originDomain': 'www.paypal.com',
+        'event': 'page-problem',
+        'breakage': '',
+        'notes': '',
+        'study_version': '0.0.1',
+        'about': {
+            '_src': 'addon',
+            '_v': 2
+        }
+    }
+
+    result_payload = input_payload
+
+    actual = transform_shield_pings(
+        SQLContext(spark_context),
+        create_ping_rdd(spark_context, input_payload)
+    ).take(1)[0]
+
+    assert row_to_dict(actual) == create_row(result_payload)
+
+
+def test_page_works(row_to_dict, spark_context):
+    input_payload = {
+        'study': '@shield-study-privacy',
+        'branch': 'thirdPartyCookiesOnlyFromVisited',
+        'originDomain': 'www.mozilla.org',
+        'event': 'page-works',
+        'breakage': '',
+        'notes': '',
+        'study_version': '0.0.1',
+        'about': {
+            '_src': 'addon',
+            '_v': 2
+        }
+    }
+
+    result_payload = input_payload
+
+    actual = transform_shield_pings(
+        SQLContext(spark_context),
+        create_ping_rdd(spark_context, input_payload)
+    ).take(1)[0]
+
+    assert row_to_dict(actual) == create_row(result_payload)
+
+
+def test_page_breakage(row_to_dict, spark_context):
+    input_payload = {
+        'study': '@shield-study-privacy',
+        'branch': 'thirdPartyCookiesOnlyFromVisited',
+        'originDomain': 'www.paypal.com',
+        'event': 'breakage',
+        'breakage': 'other',
+        'notes': '',
+        'study_version': '0.0.1',
+        'about': {
+            '_src': 'addon',
+            '_v': 2
+        }
+    }
+
+    result_payload = input_payload
+
+    actual = transform_shield_pings(
+        SQLContext(spark_context),
+        create_ping_rdd(spark_context, input_payload)
+    ).take(1)[0]
+
+    assert row_to_dict(actual) == create_row(result_payload)
+
+
+def test_notes(row_to_dict, spark_context):
+    input_payload = {
+        'study': '@shield-study-privacy',
+        'branch': 'thirdPartyCookiesOnlyFromVisited',
+        'originDomain': 'www.paypal.com',
+        'event': 'notes',
+        'breakage': 'other',
+        'notes': 'Paypal prompted me for Reader Mode. WTF?',
+        'study_version': '0.0.1',
+        'about': {
+            '_src': 'addon',
+            '_v': 2
+        }
+    }
+
+    result_payload = input_payload
+
+    actual = transform_shield_pings(
+        SQLContext(spark_context),
+        create_ping_rdd(spark_context, input_payload)
+    ).take(1)[0]
+
+    assert row_to_dict(actual) == create_row(result_payload)
+
+
+def test_disable(row_to_dict, spark_context):
+    input_payload = {
+        'study': '@shield-study-privacy',
+        'branch': 'thirdPartyCookiesOnlyFromVisited',
+        'originDomain': 'www.paypal.com',
+        'event': 'disable',
+        'breakage': '',
+        'notes': '',
+        'study_version': '0.0.1',
+        'about': {
+            '_src': 'addon',
+            '_v': 2
+        }
+    }
+
+    result_payload = input_payload
+
+    actual = transform_shield_pings(
+        SQLContext(spark_context),
+        create_ping_rdd(spark_context, input_payload)
+    ).take(1)[0]
+
+    assert row_to_dict(actual) == create_row(result_payload)
+
+
+def test_user_ended_study(row_to_dict, spark_context):
+    input_payload = {
+        'study': '@shield-study-privacy',
+        'branch': 'thirdPartyCookiesOnlyFromVisited',
+        'study_state': 'user-ended-study',
+        'study_version': '0.0.1',
+        'about': {
+            '_src': 'addon',
+            '_v': 2
+        }
+    }
+
+    result_payload = input_payload
+
+    actual = transform_shield_pings(
+        SQLContext(spark_context),
+        create_ping_rdd(spark_context, input_payload)
+    ).take(1)[0]
+
+    assert row_to_dict(actual) == create_row(result_payload)

--- a/tests/test_shield_privacy_prefs.py
+++ b/tests/test_shield_privacy_prefs.py
@@ -26,8 +26,8 @@ def test_report_problem(row_to_dict, spark_context):
         'branch': 'thirdPartyCookiesOnlyFromVisited',
         'originDomain': 'www.paypal.com',
         'event': 'page-problem',
-        'breakage': '',
-        'notes': '',
+        'breakage': None,
+        'notes': None,
         'study_version': '0.0.1',
         'about': {
             '_src': 'addon',
@@ -51,8 +51,8 @@ def test_page_works(row_to_dict, spark_context):
         'branch': 'thirdPartyCookiesOnlyFromVisited',
         'originDomain': 'www.mozilla.org',
         'event': 'page-works',
-        'breakage': '',
-        'notes': '',
+        'breakage': None,
+        'notes': None,
         'study_version': '0.0.1',
         'about': {
             '_src': 'addon',
@@ -77,7 +77,7 @@ def test_page_breakage(row_to_dict, spark_context):
         'originDomain': 'www.paypal.com',
         'event': 'breakage',
         'breakage': 'other',
-        'notes': '',
+        'notes': None,
         'study_version': '0.0.1',
         'about': {
             '_src': 'addon',
@@ -126,8 +126,8 @@ def test_disable(row_to_dict, spark_context):
         'branch': 'thirdPartyCookiesOnlyFromVisited',
         'originDomain': 'www.paypal.com',
         'event': 'disable',
-        'breakage': '',
-        'notes': '',
+        'breakage': None,
+        'notes': None,
         'study_version': '0.0.1',
         'about': {
             '_src': 'addon',

--- a/tests/test_shield_privacy_prefs.py
+++ b/tests/test_shield_privacy_prefs.py
@@ -13,7 +13,7 @@ def create_ping_rdd(sc, payload):
 
 
 def create_row(overrides):
-    keys = ["branch", "event", "originDomain", "breakage", "notes"]
+    keys = ["branch", "event", "originDomain", "breakage", "notes", "study"]
 
     overrides['study'] = '@shield-study-privacy'
 


### PR DESCRIPTION
This reverts commit 4083764b4c62be941c8dec9df0e6c7af03eed416 to restore the `privacy_prefs.py` job; only now it can get an actual review instead of just pushed straight to `master`! 😢 

@harterrt - any way you can run this to check for errors and see if it catches the few `@shield-study-privacy` pings I've been sending while testing?