### PR TITLE
Fix tests for shield privacy ETL

### DIFF
--- a/mozetl/shield/privacy_prefs.py
+++ b/mozetl/shield/privacy_prefs.py
@@ -17,7 +17,8 @@ DATAFRAME_COLUMN_CONFIGS = [
     ("event", "payload/payload/event", None, StringType()),
     ("originDomain", "payload/payload/originDomain", None, StringType()),
     ("breakage", "payload/payload/breakage", None, StringType()),
-    ("notes", "payload/payload/notes", None, StringType())
+    ("notes", "payload/payload/notes", None, StringType()),
+    ("study", "payload/payload/study", None, StringType()),
 ]
 
 

--- a/tests/test_shield_privacy_prefs.py
+++ b/tests/test_shield_privacy_prefs.py
@@ -13,7 +13,7 @@ def create_ping_rdd(sc, payload):
 
 
 def create_row(overrides):
-    keys = ["branch", "event", "originDomain", "breakage", "notes"]
+    keys = ["branch", "event", "originDomain", "breakage", "notes", "study"]
 
     overrides['study'] = '@shield-study-privacy'
 


### PR DESCRIPTION
`included_shield_pings` was throwing an error because payload/payload/study wasn't included in the filtered ping. This PR fixes this error by adding the field to the dataframe config.