### PR TITLE
add several dimensions and write more efficiently

### DIFF
--- a/mozetl/clientsdaily/fields.py
+++ b/mozetl/clientsdaily/fields.py
@@ -97,9 +97,15 @@ MAIN_SUMMARY_FIELD_AGGREGATORS = [
         'plugins_notification_shown_sum'),
     # plugins_notification_user_action
     # popup_notification_stats
-    F.first('profile_creation_date').alias('profile_creation_date'),
-    F.sum('push_api_notification_received').alias(
-        'push_api_notification_received_sum'),
+    F.first(
+        F.expr(
+            "datediff(subsession_start_date, " \
+            "from_unixtime(profile_creation_date*24*60*60))"
+        )
+    ).alias("profile_age_in_days"),
+    F.first(
+        F.expr("from_unixtime(profile_creation_date*24*60*60)")
+    ).alias('profile_creation_date'),
     F.sum('push_api_notify').alias('push_api_notify_sum'),
     F.first('sample_id').alias('sample_id'),
     F.first('scalar_parent_aushelper_websense_reg_version').alias(
@@ -157,6 +163,8 @@ MAIN_SUMMARY_FIELD_AGGREGATORS = [
     F.first('search_cohort').alias('search_cohort'),
     F.sum('search_count').alias('search_count_sum'),
     F.mean('session_restored').alias('session_restored_mean'),
+    F.sum(F.expr("IF(subsession_counter = 1, 1, 0)")).alias(
+        "sessions_started_on_this_day"),
     # shutdown_kill
     F.sum(F.expr('subsession_length/3600.0')).alias('subsession_hours_sum'),
     # ssl_handshake_result

--- a/tests/test_clientsdaily.py
+++ b/tests/test_clientsdaily.py
@@ -64,3 +64,63 @@ def test_to_profile_day_aggregates(spark):
     for k, expected in EXPECTED_INTEGER_VALUES.items():
         actual = int(result['sum({})'.format(k)])
         assert actual == expected
+
+
+def test_profile_creation_date_fields(spark):
+    from mozetl.clientsdaily import rollup
+
+    frame = make_frame_with_extracts(spark)
+    clients_daily = rollup.to_profile_day_aggregates(frame)
+
+    # Spark's from_unixtime() is apparently sensitive to environment TZ
+    # See https://issues.apache.org/jira/browse/SPARK-17971
+    # There are therefore three possible expected results, depending on
+    # the TZ setting of the system on which the tests run.
+    expected_back = set([
+        u'2014-12-16', u'2016-09-07',
+        u'2016-05-12', u'2017-02-16',
+        u'2012-11-17', u'2013-09-08',
+        u'2017-02-12', u'2016-04-04',
+        u'2017-04-25', u'2015-06-17'
+    ])
+    expected_utc = set([
+        u'2014-12-17', u'2016-09-08',
+        u'2016-05-13', u'2017-02-17',
+        u'2012-11-18', u'2013-09-09',
+        u'2017-02-13', u'2016-04-05',
+        u'2017-04-26', u'2015-06-18'
+    ])
+    expected_forward = set([
+        u'2014-12-18', u'2016-09-09',
+        u'2016-05-14', u'2017-02-18',
+        u'2012-11-19', u'2013-09-10',
+        u'2017-02-14', u'2016-04-06',
+        u'2017-04-27', u'2015-06-19'
+    ])
+    ten_pcds = clients_daily.select("profile_creation_date").take(10)
+    actual1 = set([r.asDict().values()[0][:10] for r in ten_pcds])
+    assert actual1 in (expected_back, expected_utc, expected_forward)
+
+    expected2_back = [
+        378, 894, 261, 1361, 101, 1656, 415, 29, 703, 102
+    ]
+    expected2_utc = [
+        377, 893, 260, 1360, 100, 1655, 414, 28, 702, 101
+    ]
+    expected2_forward = [
+        376, 892, 259, 1359, 99, 1654, 413, 27, 701, 100
+    ]
+    ten_pdas = clients_daily.select("profile_age_in_days").take(10)
+    actual2 = [r.asDict().values()[0] for r in ten_pdas]
+    assert actual2 in (expected2_back, expected2_utc, expected2_forward)
+
+
+def test_sessions_started_on_this_day(spark):
+    from mozetl.clientsdaily import rollup
+
+    frame = make_frame_with_extracts(spark)
+    clients_daily = rollup.to_profile_day_aggregates(frame)
+    expected = [2, 0, 3, 2, 1, 0, 1, 0, 0, 3]
+    ten_ssotds = clients_daily.select("sessions_started_on_this_day").take(10)
+    actual = [r.asDict().values()[0] for r in ten_ssotds]
+    assert actual == expected


### PR DESCRIPTION
Work for bug 1381896:

1) Repartitions before writing Parquet files and skips _SUCCESS flag for redash compatibility.
2) Adds dimensions: profile_age_in_days, sessions_started_on_this_day.
3) Casts profile_creation_date to a date object.