### PR TITLE
bug 1387236: extract and load study_state too

### DIFF
--- a/mozetl/shield/privacy_prefs.py
+++ b/mozetl/shield/privacy_prefs.py
@@ -5,40 +5,85 @@
 # with:
 # https://github.com/mozilla/python_mozetl/blob/689afa3d23229ca717422314c5a56abd83a85a0d/mozetl/testpilot/containers.py
 
+from datetime import date, timedelta
+
 from pyspark.sql.types import StringType
+from moztelemetry.dataset import Dataset
 
 from ..basic import convert_pings, DataFrameConfig
-from .utils import shield_etl_boilerplate
 
 
 SHIELD_ADDON_ID = '@shield-study-privacy'
 
 # Note that the JSON paths in this config are unusual for Shield pings.
-# See Bug 1387236 for more details and discussion
-DATAFRAME_COLUMN_CONFIGS = [
+# See https://bugzil.la/1387236 for more details and discussion
+
+COMMON_COLUMN_CONFIGS = [
     ("client_id", "clientId", None, StringType()),
     ("branch", "payload/branch", None, StringType()),
+    ("study_state", "payload/study_state", None, StringType()),
     ("event", "payload/event", None, StringType()),
     ("originDomain", "payload/originDomain", None, StringType()),
     ("breakage", "payload/breakage", None, StringType()),
     ("notes", "payload/notes", None, StringType()),
+]
+
+STUDY_STATE_DATAFRAME_COLUMN_CONFIGS = COMMON_COLUMN_CONFIGS + [
+    ("study", "payload/study_name", None, StringType()),
+]
+
+STUDY_EVENT_DATAFRAME_COLUMN_CONFIGS = COMMON_COLUMN_CONFIGS + [
     ("study", "payload/study", None, StringType()),
 ]
 
 
-def transform_shield_pings(sqlContext, pings):
+def transform_state_pings(sqlContext, pings):
     return convert_pings(
         sqlContext,
         pings,
-        DataFrameConfig(DATAFRAME_COLUMN_CONFIGS, include_shield_pings)
+        DataFrameConfig(STUDY_STATE_DATAFRAME_COLUMN_CONFIGS,
+                        include_state_pings)
     )
 
 
-def include_shield_pings(ping):
+def transform_event_pings(sqlContext, pings):
+    return convert_pings(
+        sqlContext,
+        pings,
+        DataFrameConfig(STUDY_EVENT_DATAFRAME_COLUMN_CONFIGS,
+                        include_event_pings)
+    )
+
+
+def include_event_pings(ping):
     return ping['payload/study'] == SHIELD_ADDON_ID
 
 
-etl_job = shield_etl_boilerplate(
-    transform_shield_pings,
-    's3n://telemetry-parquet/harter/privacy_prefs_shield/v1'
-)
+def include_state_pings(ping):
+    return ping['payload/study_name'] == SHIELD_ADDON_ID
+
+
+def etl_job(sc, sqlContext, submission_date=None, save=True):
+    s3_path = 's3n://telemetry-parquet/harter/privacy_prefs_shield/v1'
+    if submission_date is None:
+        submission_date = (date.today() - timedelta(1)).strftime("%Y%m%d")
+
+    pings = Dataset.from_source(
+        "telemetry"
+    ).where(
+        docType="shield-study",
+        submissionDate=submission_date,
+        appName="Firefox",
+    ).records(sc)
+
+    transformed_event_pings = transform_event_pings(sqlContext, pings)
+
+    transformed_state_pings = transform_state_pings(sqlContext, pings)
+
+    transformed_pings = transformed_event_pings.union(transformed_state_pings)
+
+    if save:
+        path = s3_path + '/submission_date={}'.format(submission_date)
+        transformed_pings.repartition(1).write.mode('overwrite').parquet(path)
+
+    return transformed_pings

--- a/tests/test_shield_privacy_prefs.py
+++ b/tests/test_shield_privacy_prefs.py
@@ -1,5 +1,6 @@
 from pyspark.sql import SQLContext
-from mozetl.shield.privacy_prefs import transform_shield_pings
+from mozetl.shield.privacy_prefs import (transform_state_pings,
+                                         transform_event_pings)
 
 
 def create_ping_rdd(sc, payload):
@@ -14,15 +15,40 @@ def create_ping_rdd(sc, payload):
 
 def create_row(overrides):
     keys = ["client_id", "branch", "event", "originDomain", "breakage",
-            "notes", "study"]
+            "notes", "study", "study_state"]
 
-    overrides['study'] = '@shield-study-privacy'
+    # simulate transforuming study_name into study field
+    if 'study_name' in overrides:
+        del overrides['study_name']
+        overrides['study'] = '@shield-study-privacy'
     overrides['client_id'] = 'aa'
 
     return {key: overrides.get(key, None) for key in keys}
 
 
-def test_report_problem(row_to_dict, spark_context):
+def test_study_state_value(row_to_dict, spark_context):
+    input_payload = {
+      "study_name": "@shield-study-privacy",
+      "branch": "firstPartyIsolationOpenerAccess",
+      "study_state": "running",
+      "study_version": "0.0.4",
+      "about": {
+        "_src": "shield",
+        "_v": 2
+      }
+    }
+
+    result_payload = input_payload
+
+    actual = transform_state_pings(
+        SQLContext(spark_context),
+        create_ping_rdd(spark_context, input_payload)
+    ).take(1)[0]
+
+    assert row_to_dict(actual) == create_row(result_payload)
+
+
+def test_event_value_problem(row_to_dict, spark_context):
     input_payload = {
         'study': '@shield-study-privacy',
         'branch': 'thirdPartyCookiesOnlyFromVisited',
@@ -39,32 +65,7 @@ def test_report_problem(row_to_dict, spark_context):
 
     result_payload = input_payload
 
-    actual = transform_shield_pings(
-        SQLContext(spark_context),
-        create_ping_rdd(spark_context, input_payload)
-    ).take(1)[0]
-
-    assert row_to_dict(actual) == create_row(result_payload)
-
-
-def test_page_works(row_to_dict, spark_context):
-    input_payload = {
-        'study': '@shield-study-privacy',
-        'branch': 'thirdPartyCookiesOnlyFromVisited',
-        'originDomain': 'www.mozilla.org',
-        'event': 'page-works',
-        'breakage': None,
-        'notes': None,
-        'study_version': '0.0.1',
-        'about': {
-            '_src': 'addon',
-            '_v': 2
-        }
-    }
-
-    result_payload = input_payload
-
-    actual = transform_shield_pings(
+    actual = transform_event_pings(
         SQLContext(spark_context),
         create_ping_rdd(spark_context, input_payload)
     ).take(1)[0]
@@ -89,7 +90,7 @@ def test_page_breakage(row_to_dict, spark_context):
 
     result_payload = input_payload
 
-    actual = transform_shield_pings(
+    actual = transform_event_pings(
         SQLContext(spark_context),
         create_ping_rdd(spark_context, input_payload)
     ).take(1)[0]
@@ -114,7 +115,7 @@ def test_notes(row_to_dict, spark_context):
 
     result_payload = input_payload
 
-    actual = transform_shield_pings(
+    actual = transform_event_pings(
         SQLContext(spark_context),
         create_ping_rdd(spark_context, input_payload)
     ).take(1)[0]
@@ -122,48 +123,43 @@ def test_notes(row_to_dict, spark_context):
     assert row_to_dict(actual) == create_row(result_payload)
 
 
-def test_disable(row_to_dict, spark_context):
-    input_payload = {
+def test_combine_state_and_event(row_to_dict, spark_context):
+    state_payload = {
+      "study_name": "@shield-study-privacy",
+      "branch": "firstPartyIsolationOpenerAccess",
+      "study_state": "running",
+      "study_version": "0.0.4",
+      "about": {
+        "_src": "shield",
+        "_v": 2
+      }
+    }
+    event_payload = {
         'study': '@shield-study-privacy',
         'branch': 'thirdPartyCookiesOnlyFromVisited',
         'originDomain': 'www.paypal.com',
         'event': 'disable',
         'breakage': None,
         'notes': None,
-        'study_version': '0.0.1',
+        'study_version': '0.0.4',
         'about': {
             '_src': 'addon',
             '_v': 2
         }
     }
-
-    result_payload = input_payload
-
-    actual = transform_shield_pings(
+    transformed_event_ping = transform_event_pings(
         SQLContext(spark_context),
-        create_ping_rdd(spark_context, input_payload)
-    ).take(1)[0]
-
-    assert row_to_dict(actual) == create_row(result_payload)
-
-
-def test_user_ended_study(row_to_dict, spark_context):
-    input_payload = {
-        'study': '@shield-study-privacy',
-        'branch': 'thirdPartyCookiesOnlyFromVisited',
-        'study_state': 'user-ended-study',
-        'study_version': '0.0.1',
-        'about': {
-            '_src': 'addon',
-            '_v': 2
-        }
-    }
-
-    result_payload = input_payload
-
-    actual = transform_shield_pings(
+        create_ping_rdd(spark_context, event_payload)
+    )
+    transformed_state_ping = transform_state_pings(
         SQLContext(spark_context),
-        create_ping_rdd(spark_context, input_payload)
-    ).take(1)[0]
+        create_ping_rdd(spark_context, state_payload)
+    )
 
-    assert row_to_dict(actual) == create_row(result_payload)
+    transformed_pings = transformed_event_ping.union(transformed_state_ping)
+
+    actual_rows = transformed_pings.take(2)
+
+    for actual_row in actual_rows:
+        assert (row_to_dict(actual_row) == create_row(state_payload) or
+                row_to_dict(actual_row) == create_row(event_payload))


### PR DESCRIPTION
I want to measure the % of users who submit 1+ "page-problem" pings. But we only have data for the 'page-problem|page-works|breakage|notes|disable' pings. So, we don't know how many users are running the study who have never sent a page problem/works report.

This PR adds `study_state` extraction and load into the table, so I can get the total # of clients running the study add-on - including the ones who have not sent any breakage reports at all.