### PR TITLE
Bug 1381896 - add daywise rollups and search counts per access point

### DIFF
--- a/mozetl/clientsdaily/fields.py
+++ b/mozetl/clientsdaily/fields.py
@@ -161,7 +161,13 @@ MAIN_SUMMARY_FIELD_AGGREGATORS = [
     F.sum('scalar_parent_webrtc_nicer_turn_438s').alias(
         'scalar_parent_webrtc_nicer_turn_438s_sum'),
     F.first('search_cohort').alias('search_cohort'),
-    F.sum('search_count').alias('search_count_sum'),
+    F.sum('search_count_all').alias('search_count_all_sum'),
+    F.sum('search_count_abouthome').alias('search_count_abouthome_sum'),
+    F.sum('search_count_contextmenu').alias('search_count_contextmenu_sum'),
+    F.sum('search_count_newtab').alias('search_count_newtab_sum'),
+    F.sum('search_count_searchbar').alias('search_count_searchbar_sum'),
+    F.sum('search_count_system').alias('search_count_system_sum'),
+    F.sum('search_count_urlbar').alias('search_count_urlbar_sum'),
     F.mean('session_restored').alias('session_restored_mean'),
     F.sum(F.expr("IF(subsession_counter = 1, 1, 0)")).alias(
         "sessions_started_on_this_day"),

--- a/tests/test_clientsdaily.py
+++ b/tests/test_clientsdaily.py
@@ -1,4 +1,3 @@
-import datetime as DT
 import pytest
 import os
 from mozetl.schemas import MAIN_SUMMARY_SCHEMA
@@ -9,7 +8,7 @@ EXPECTED_INTEGER_VALUES = {
     'crashes_detected_content_sum': 9,
     'first_paint_mean': 12802105,
     'pings_aggregated_by_this_row': 1122,
-    'search_count_sum': 1043
+    'search_count_all_sum': 1043
 }
 
 
@@ -34,21 +33,9 @@ def test_extract_search_counts(spark):
 
     frame = make_frame(spark)
     extracted = rollup.extract_search_counts(frame)
-    row = extracted.agg({'search_count': 'sum'}).collect()[0]
+    row = extracted.agg({'search_count_all': 'sum'}).collect()[0]
     total = row.asDict().values()[0]
-    assert total == EXPECTED_INTEGER_VALUES['search_count_sum']
-
-
-def test_extract_month(spark):
-    from mozetl.clientsdaily import rollup
-
-    frame = make_frame(spark)
-    month_frame0 = rollup.extract_month(DT.date(2000, 1, 1), frame)
-    count0 = month_frame0.count()
-    assert count0 == 0
-    month_frame1 = rollup.extract_month(DT.date(2017, 6, 1), frame)
-    count1 = month_frame1.count()
-    assert count1 == 68
+    assert total == EXPECTED_INTEGER_VALUES['search_count_all_sum']
 
 
 def test_to_profile_day_aggregates(spark):


### PR DESCRIPTION
Per bug 1381896, convert main to run daywise rather than monthwise. Also add columns that tally searches for each chrome access point.