### PR TITLE
Taar similarity job

### DIFF
--- a/mozetl/cli.py
+++ b/mozetl/cli.py
@@ -1,7 +1,7 @@
 import click
 from mozetl.churn import churn
 from mozetl.search import dashboard, search_rollups
-from mozetl.taar import taar_locale
+from mozetl.taar import taar_locale, taar_similarity
 from mozetl.sync import bookmark_validation
 
 
@@ -14,4 +14,5 @@ entry_point.add_command(churn.main, "churn")
 entry_point.add_command(dashboard.main, "search_dashboard")
 entry_point.add_command(search_rollups.main, "search_rollup")
 entry_point.add_command(taar_locale.main, "taar_locale")
+entry_point.add_command(taar_similarity.main, "taar_similarity")
 entry_point.add_command(bookmark_validation.main, "sync_bookmark_validation")

--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -1,0 +1,330 @@
+"""
+Bug 1386274 - TAAR similarity-based add-on donor list
+
+This job clusters users into different groups based on their
+active add-ons. A representative users sample is selected from
+each cluster ("donors") and is saved to a model file along
+with a feature vector that will be used, by the TAAR library
+module, to perform recommendations.
+"""
+
+import click
+import json
+import logging
+import numpy as np
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col
+from pyspark.ml.feature import HashingTF, IDF
+from pyspark.ml.clustering import BisectingKMeans
+from pyspark.ml import Pipeline
+from pyspark.mllib.stat import KernelDensity
+from scipy.spatial import distance
+from taar_utils import store_json_to_s3, load_amo_external_whitelist
+
+# Define the set of feature names to be used in the donor computations.
+CATEGORICAL_FEATURES = ["geo_city", "locale", "os"]
+CONTINUOUS_FEATURES = \
+    ["subsession_length", "bookmark_count", "tab_open_count", "total_uri", "unique_tlds"]
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def get_samples(spark):
+    """ Get a DataFrame with a valid set of sample to base the next
+    processing on.
+    """
+    return (
+        spark.sql("SELECT * FROM longitudinal")
+        .where("active_addons IS NOT null")
+        .where("size(active_addons[0]) > 2")
+        .where("size(active_addons[0]) < 100")
+        .where("normalized_channel = 'release'")
+        .where("build IS NOT NULL AND build[0].application_name = 'Firefox'")
+        .selectExpr(
+            "client_id as client_id",
+            "active_addons[0] as active_addons",
+            "geo_city[0] as geo_city",
+            "subsession_length[0] as subsession_length",
+            "settings[0].locale as locale",
+            "os as os",
+            "places_bookmarks_count[0].sum AS bookmark_count",
+            "scalar_parent_browser_engagement_tab_open_event_count[0].value AS tab_open_count",
+            "scalar_parent_browser_engagement_total_uri_count[0].value AS total_uri",
+            "scalar_parent_browser_engagement_unique_domains_count[0].value AS unique_tlds"
+        )
+    )
+
+
+def get_addons_per_client(users_df, addon_whitelist, minimum_addons_count):
+    """ Extracts a DataFrame that contains one row
+    for each client along with the list of active add-on GUIDs.
+    """
+    def is_valid_addon(guid, addon):
+        return not (
+            addon.is_system or
+            addon.app_disabled or
+            addon.type != "extension" or
+            addon.user_disabled or
+            addon.foreign_install or
+            guid not in addon_whitelist
+        )
+
+    # Create an add-ons dataset un-nesting the add-on map from each
+    # user to a list of add-on GUIDs. Also filter undesired add-ons.
+    return (
+        users_df.rdd
+        .map(lambda p: (p["client_id"],
+             [guid for guid, data in p["active_addons"].items() if is_valid_addon(guid, data)]))
+        .filter(lambda p: len(p[1]) > minimum_addons_count)
+        .toDF(["client_id", "addon_ids"])
+    )
+
+
+def compute_clusters(addons_df, num_clusters, random_seed):
+    """ Performs user clustering by using add-on ids as features.
+    """
+
+    # Build the stages of the pipeline. We need hashing to make the next
+    # steps work.
+    hashing_stage = HashingTF(inputCol="addon_ids", outputCol="hashed_features")
+    idf_stage = IDF(inputCol="hashed_features", outputCol="features", minDocFreq=1)
+    # As a future improvement, we may add a sane value for the minimum cluster size
+    # to BisectingKMeans (e.g. minDivisibleClusterSize). For now, just make sure
+    # to pass along the random seed if needed for tests.
+    kmeans_kwargs = {"seed": random_seed} if random_seed else {}
+    bkmeans_stage = BisectingKMeans(k=num_clusters, **kmeans_kwargs)
+    pipeline = Pipeline(stages=[hashing_stage, idf_stage, bkmeans_stage])
+
+    # Run the pipeline and compute the results.
+    model = pipeline.fit(addons_df)
+    return (
+        model
+        .transform(addons_df)
+        .select(["client_id", "prediction"])
+    )
+
+
+def get_donor_pools(users_df, clusters_df, num_donors, random_seed=None):
+    """ Samples users from each cluster.
+    """
+    cluster_population = clusters_df.groupBy("prediction").count().collect()
+    clusters_histogram =\
+        [(x["prediction"], x["count"]) for x in cluster_population]
+
+    # Sort in-place from highest to lowest populated cluster.
+    clusters_histogram.sort(key=lambda x: x[0], reverse=False)
+
+    # Save the cluster ids and their respective scores separately.
+    clusters = [cluster_id for cluster_id, _ in clusters_histogram]
+    counts = [donor_count for _, donor_count in clusters_histogram]
+
+    # Compute the proportion of user in each cluster.
+    total_donors_in_clusters = sum(counts)
+    clust_sample = [float(t) / total_donors_in_clusters for t in counts]
+    sampling_proportions = dict(zip(clusters, clust_sample))
+
+    # Sample the users in each cluster according to the proportions
+    # and pass along the random seed if needed for tests.
+    sampling_kwargs = {"seed": random_seed} if random_seed else {}
+    donor_df = clusters_df.sampleBy("prediction",
+                                    fractions=sampling_proportions,
+                                    **sampling_kwargs)
+    # Get the specific number of donors for each cluster and drop the
+    # predicted cluster number information.
+    current_sample_size = donor_df.count()
+    donor_pool_df = (
+        donor_df
+        .sample(False, float(num_donors) / current_sample_size, **sampling_kwargs)
+    )
+    return clusters, donor_pool_df
+
+
+def get_donors(spark, num_clusters, num_donors, addon_whitelist, random_seed=None):
+    # Get the data for the potential add-on donors.
+    users_sample = get_samples(spark)
+    # Get add-ons from selected users and make sure they are
+    # useful for making a recommendation.
+    addons_df = get_addons_per_client(users_sample, addon_whitelist, 2)
+    # Perform clustering by using the add-on info.
+    clusters = compute_clusters(addons_df, num_clusters, random_seed)
+    # Sample representative ("donors") users from each cluster.
+    cluster_ids, donors_df =\
+        get_donor_pools(users_sample, clusters, num_donors, random_seed)
+
+    # Finally, get the feature vectors for users that represent
+    # each cluster. Since the "active_addons" in "users_sample"
+    # are in a |MapType| and contain system add-ons as well, just
+    # use the cleaned up list from "addons_df".
+    return cluster_ids, (
+        users_sample
+        .join(donors_df, 'client_id')
+        .drop('active_addons')
+        .join(addons_df, 'client_id', 'left')
+        .drop('client_id')
+        .withColumnRenamed('addon_ids', 'active_addons')
+    )
+
+
+def format_donors_dictionary(donors_df):
+    cleaned_records = donors_df.drop('prediction').collect()
+    # Convert each row to a dictionary.
+    return [row.asDict() for row in cleaned_records]
+
+
+def similarity_function(x, y):
+    """ Similarity function for comparing user features.
+
+    This actually really should be implemented in taar.similarity_recommender
+    and then imported here for consistency.
+    """
+
+    def safe_get(field, row, default_value):
+        # Safely get a value from the Row. If the value is None, get the
+        # default value.
+        return row[field] if row[field] is not None else default_value
+
+    # Extract the values for the categorical and continuous features for both
+    # the x and y samples. Use an empty string as the default value for missing
+    # categorical fields and 0 for the continuous ones.
+    x_categorical_features = [safe_get(k, x, "") for k in CATEGORICAL_FEATURES]
+    x_continuous_features = [safe_get(k, x, 0) for k in CONTINUOUS_FEATURES]
+    y_categorical_features = [safe_get(k, y, "") for k in CATEGORICAL_FEATURES]
+    y_continuous_features = [safe_get(k, y, 0) for k in CONTINUOUS_FEATURES]
+
+    # Here a larger distance indicates a poorer match between categorical variables.
+    j_d = (distance.hamming(x_categorical_features, y_categorical_features))
+    j_c = (distance.canberra(x_continuous_features, y_continuous_features))
+
+    # Take the product of similarities to attain a univariate similarity score.
+    # Add a minimal constant to prevent zero values from categorical features.
+    return abs((j_c + 0.001) * j_d)
+
+
+def generate_non_cartesian_pairs(first_rdd, second_rdd):
+    # Add an index to all the elements in each RDD.
+    rdd1_with_indices = first_rdd.zipWithIndex().map(lambda p: (p[1], p[0]))
+    rdd2_with_indices = second_rdd.zipWithIndex().map(lambda p: (p[1], p[0]))
+    # Join the RDDs using the indices as keys, then strip
+    # them off before returning an RDD like [<v1, v2>, ...]
+    return rdd1_with_indices.join(rdd2_with_indices).map(lambda p: p[1])
+
+
+def get_lr_curves(spark, features_df, cluster_ids, kernel_bandwidth,
+                  num_pdf_points, random_seed=None):
+    """ Compute the likelihood ratio curves for clustered clients.
+
+    Work-flow followed in this function is as follows:
+
+     * Access the DataFrame including cluster numbers and features.
+     * Load same similarity function that will be used in TAAR module.
+     * Iterate through each cluster and compute in-cluster similarity.
+     * Iterate through each cluster and compute out-cluster similarity.
+     * Compute the kernel density estimate (KDE) per similarity score.
+     * Linearly down-sample both PDFs to 1000 points.
+
+    :param spark: the SparkSession object.
+    :param features_df: the DataFrame containing the user features (e.g. the
+                        ones coming from |get_donors|).
+    :param cluster_ids: the list of cluster ids (e.g. the one coming from |get_donors|).
+    :param kernel_bandwidth: the kernel bandwidth used to estimate the kernel densities.
+    :param num_pdf_points: the number of points to sample for the LR-curves.
+    :param random_seed: the provided random seed (fixed in tests).
+    :return: A list in the following format
+        [(idx, (lr-numerator-for-idx, lr-denominator-for-idx)), (...), ...]
+    """
+
+    # Instantiate holder lists for inter- and intra-cluster scores.
+    same_cluster_scores_rdd = spark.sparkContext.emptyRDD()
+    different_clusters_scores_rdd = spark.sparkContext.emptyRDD()
+
+    random_split_kwargs = {"seed": random_seed} if random_seed else {}
+
+    for cluster_number in cluster_ids:
+        # Pick the features for users belonging to the current cluster.
+        current_cluster_df = (
+            features_df
+            .where(col("prediction") == cluster_number)
+        )
+        # Pick the features for users belonging to all the other clusters.
+        other_clusters_df = (
+            features_df
+            .where(col("prediction") != cluster_number)
+        )
+
+        logger.debug("Computing scores for cluster", extra={"cluster_id": cluster_number})
+
+        # Compares the similarity score between pairs of clients in the same cluster.
+        cluster_half_1, cluster_half_2 =\
+            current_cluster_df.rdd.randomSplit([0.5, 0.5], **random_split_kwargs)
+        pair_rdd = generate_non_cartesian_pairs(cluster_half_1, cluster_half_2)
+        intra_scores_rdd = pair_rdd.map(lambda r: similarity_function(*r))
+        same_cluster_scores_rdd = same_cluster_scores_rdd.union(intra_scores_rdd)
+
+        # Compares the similarity score between pairs of clients in different clusters.
+        pair_rdd =\
+            generate_non_cartesian_pairs(current_cluster_df.rdd, other_clusters_df.rdd)
+        inter_scores_rdd = pair_rdd.map(lambda r: similarity_function(*r))
+        different_clusters_scores_rdd =\
+            different_clusters_scores_rdd.union(inter_scores_rdd)
+
+    # Determine a range of observed similarity values linearly spaced.
+    all_scores_rdd = same_cluster_scores_rdd.union(different_clusters_scores_rdd)
+    min_similarity = all_scores_rdd.min()
+    max_similarity = all_scores_rdd.max()
+    lr_index = np.arange(min_similarity, max_similarity,
+                         float(abs(min_similarity - max_similarity)) / num_pdf_points)
+
+    # Kernel density estimate for the inter-cluster comparison scores.
+    kd_dc = KernelDensity()
+    kd_dc.setSample(different_clusters_scores_rdd)
+    kd_dc.setBandwidth(kernel_bandwidth)
+    denominator_density = kd_dc.estimate(lr_index)
+
+    # Kernel density estimate for the intra-cluster comparison scores.
+    kd_sc = KernelDensity()
+    kd_sc.setSample(same_cluster_scores_rdd)
+    kd_sc.setBandwidth(kernel_bandwidth)
+    numerator_density = kd_sc.estimate(lr_index)
+
+    # Structure this in the correct output format.
+    return zip(lr_index, zip(numerator_density, denominator_density))
+
+
+@click.command()
+@click.option('--date', required=True)
+@click.option('--bucket', default='telemetry-private-analysis-2')
+@click.option('--prefix', default='taar/similarity/')
+@click.option('--num_clusters', default=20)
+@click.option('--num_donors', default=1000)
+@click.option('--kernel_bandwidth', default=0.35)
+@click.option('--num_pdf_points', default=1000)
+def main(date, bucket, prefix, num_clusters, num_donors, kernel_bandwidth, num_pdf_points):
+    spark = (SparkSession
+             .builder
+             .appName("taar_similarity")
+             .enableHiveSupport()
+             .getOrCreate())
+
+    if num_donors < 100:
+        logger.warn("Less than 100 donors were requested.", extra={"donors": num_donors})
+        num_donors = 100
+
+    logger.info("Loading the AMO whitelist...")
+    whitelist = load_amo_external_whitelist()
+
+    logger.info("Computing the list of donors...")
+
+    # Compute the donors clusters and the LR curves.
+    cluster_ids, donors_df = get_donors(spark, num_clusters, num_donors, whitelist)
+    lr_curves = get_lr_curves(spark, donors_df, cluster_ids, kernel_bandwidth,
+                              num_pdf_points)
+
+    # Store them.
+    donors = format_donors_dictionary(donors_df)
+    store_json_to_s3(json.dumps(donors, indent=2), 'donors',
+                     date, prefix, bucket)
+    store_json_to_s3(json.dumps(lr_curves, indent=2), 'lr_curves',
+                     date, prefix, bucket)
+    spark.stop()

--- a/mozetl/taar/taar_utils.py
+++ b/mozetl/taar/taar_utils.py
@@ -1,4 +1,14 @@
 import boto3
+import json
+import logging
+
+from botocore.exceptions import ClientError
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+AMO_DUMP_BUCKET = 'telemetry-parquet'
+AMO_DUMP_KEY = 'telemetry-ml/addon_recommender/addons_database.json'
 
 
 def write_to_s3(source_file_name, s3_dest_file_name, s3_prefix, bucket):
@@ -41,3 +51,34 @@ def store_json_to_s3(json_data, base_filename, date, prefix, bucket):
     # Store a copy of the current JSON with datestamp.
     write_to_s3(FULL_FILENAME, archived_file_copy, prefix, bucket)
     write_to_s3(FULL_FILENAME, FULL_FILENAME, prefix, bucket)
+
+
+def load_amo_external_whitelist():
+    """ Download and parse the AMO add-on whitelist.
+
+    :raises RuntimeError: the AMO whitelist file cannot be downloaded or contains
+                          no valid add-ons.
+    """
+    final_whitelist = []
+    amo_dump = {}
+    try:
+        # Load the most current AMO dump JSON resource.
+        s3 = boto3.client('s3')
+        s3_contents = s3.get_object(Bucket=AMO_DUMP_BUCKET, Key=AMO_DUMP_KEY)
+        amo_dump = json.loads(s3_contents['Body'].read())
+    except ClientError:
+        logger.exception("Failed to download from S3", extra={
+            "bucket": AMO_DUMP_BUCKET,
+            "key": AMO_DUMP_KEY})
+
+    # If the load fails, we will have an empty whitelist, this may be problematic.
+    for key, value in amo_dump.items():
+        addon_files = value.get('current_version', {}).get('files', {})
+        # If any of the addon files are web_extensions compatible, it can be recommended.
+        if any([f.get("is_webextension", False) for f in addon_files]):
+            final_whitelist.append(value['guid'])
+
+    if len(final_whitelist) == 0:
+        raise RuntimeError("Empty AMO whitelist detected")
+
+    return final_whitelist

--- a/mozetl/taar/taar_utils.py
+++ b/mozetl/taar/taar_utils.py
@@ -1,0 +1,43 @@
+import boto3
+
+
+def write_to_s3(source_file_name, s3_dest_file_name, s3_prefix, bucket):
+    """Store the new json file containing current top addons per locale to S3.
+
+    :param source_file_name: The name of the local source file.
+    :param s3_dest_file_name: The name of the destination file on S3.
+    :param s3_prefix: The S3 prefix in the bucket.
+    :param bucket: The S3 bucket.
+    """
+    client = boto3.client('s3', 'us-west-2')
+    transfer = boto3.s3.transfer.S3Transfer(client)
+
+    # Update the state in the analysis bucket.
+    key_path = s3_prefix + s3_dest_file_name
+    transfer.upload_file(source_file_name, bucket, key_path)
+
+
+def store_json_to_s3(json_data, base_filename, date, prefix, bucket):
+    """Saves the JSON data to a local file and then uploads it to S3.
+
+    Two copies of the file will get uploaded: one with as "<base_filename>.json"
+    and the other as "<base_filename><YYYYMMDD>.json" for backup purposes.
+
+    :param json_data: A string with the JSON content to write.
+    :param base_filename: A string with the base name of the file to use for saving
+        locally and uploading to S3.
+    :param date: A date string in the "YYYYMMDD" format.
+    :param prefix: The S3 prefix.
+    :param bucket: The S3 bucket name.
+    """
+    FULL_FILENAME = "{}.json".format(base_filename)
+
+    with open(FULL_FILENAME, "w+") as json_file:
+        json_file.write(json_data)
+
+    archived_file_copy =\
+        "{}{}.json".format(base_filename, date)
+
+    # Store a copy of the current JSON with datestamp.
+    write_to_s3(FULL_FILENAME, archived_file_copy, prefix, bucket)
+    write_to_s3(FULL_FILENAME, FULL_FILENAME, prefix, bucket)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(
         'requests',
         'click_datetime',
         'arrow',
+        'scipy',
+        'numpy'
     ],
     tests_require=test_deps,
     extras_require=extras,

--- a/tests/test_taar_locale.py
+++ b/tests/test_taar_locale.py
@@ -5,7 +5,7 @@ import json
 import functools
 import pytest
 from moto import mock_s3
-from mozetl.taar import taar_locale
+from mozetl.taar import taar_locale, taar_utils
 from pyspark.sql.types import (
     StructField, StructType, StringType,
     LongType, BooleanType, ArrayType, MapType
@@ -137,48 +137,12 @@ def multi_locales_df(generate_data):
 
 
 @mock_s3
-def test_load_amo_external_whitelist():
-    conn = boto3.resource('s3', region_name='us-west-2')
-    conn.create_bucket(Bucket=taar_locale.AMO_DUMP_BUCKET)
-
-    # Make sure that whitelist loading fails before mocking the S3 file.
-    EXCEPTION_MSG = 'Empty AMO whitelist detected'
-    with pytest.raises(RuntimeError) as excinfo:
-        taar_locale.load_amo_external_whitelist()
-
-    assert EXCEPTION_MSG in str(excinfo.value)
-
-    # Store an empty file and verify that an exception is raised.
-    conn.Object(taar_locale.AMO_DUMP_BUCKET, key=taar_locale.AMO_DUMP_KEY)\
-        .put(Body=json.dumps({}))
-
-    with pytest.raises(RuntimeError) as excinfo:
-        taar_locale.load_amo_external_whitelist()
-
-    assert EXCEPTION_MSG in str(excinfo.value)
-
-    # Store the data in the mocked bucket.
-    conn.Object(taar_locale.AMO_DUMP_BUCKET, key=taar_locale.AMO_DUMP_KEY)\
-        .put(Body=json.dumps(FAKE_AMO_DUMP))
-
-    # Check that the web_extension item is still present
-    # and the legacy addon is absent.
-    whitelist = taar_locale.load_amo_external_whitelist()
-    assert 'this_guid_can_not_be_in_amo' not in whitelist
-
-    # Verify that the legacy addon was removed while the
-    # web_extension compatible addon is still present.
-    assert 'test-guid-0001' in whitelist
-    assert 'test-guid-0002' not in whitelist
-
-
-@mock_s3
 def test_generate_dictionary(spark, multi_locales_df):
     conn = boto3.resource('s3', region_name='us-west-2')
-    conn.create_bucket(Bucket=taar_locale.AMO_DUMP_BUCKET)
+    conn.create_bucket(Bucket=taar_utils.AMO_DUMP_BUCKET)
 
     # Store the data in the mocked bucket.
-    conn.Object(taar_locale.AMO_DUMP_BUCKET, key=taar_locale.AMO_DUMP_KEY)\
+    conn.Object(taar_utils.AMO_DUMP_BUCKET, key=taar_utils.AMO_DUMP_KEY)\
         .put(Body=json.dumps(FAKE_AMO_DUMP))
 
     multi_locales_df.createOrReplaceTempView("longitudinal")

--- a/tests/test_taar_locale.py
+++ b/tests/test_taar_locale.py
@@ -190,30 +190,3 @@ def test_generate_dictionary(spark, multi_locales_df):
     }
 
     assert taar_locale.generate_dictionary(spark, 5) == expected
-
-
-@mock_s3
-def test_write_output():
-    bucket = 'test-bucket'
-    prefix = 'test-prefix/'
-
-    content = {
-        "it-IT": ["test-guid-0001"]
-    }
-
-    conn = boto3.resource('s3', region_name='us-west-2')
-    bucket_obj = conn.create_bucket(Bucket=bucket)
-
-    # Store the data in the mocked bucket.
-    taar_locale.store(content, '20171106', prefix, bucket)
-
-    # Get the content of the bucket.
-    available_objects = list(bucket_obj.objects.filter(Prefix=prefix))
-    assert len(available_objects) == 2
-
-    # Get the list of keys.
-    keys = [o.key for o in available_objects]
-    assert "{}{}.json".format(prefix, taar_locale.LOCALE_FILE_NAME) in keys
-    date_filename =\
-        "{}{}20171106.json".format(prefix, taar_locale.LOCALE_FILE_NAME)
-    assert date_filename in keys

--- a/tests/test_taar_similarity.py
+++ b/tests/test_taar_similarity.py
@@ -1,0 +1,294 @@
+"""Test suite for TAAR Locale Job."""
+
+import copy
+import functools
+import numpy as np
+import pytest
+
+from mozetl.taar import taar_similarity
+from pyspark.sql.types import (
+    StructField, StructType, StringType,
+    LongType, BooleanType, ArrayType, MapType, Row
+)
+
+longitudinal_schema = StructType([
+    StructField("client_id",             StringType(),  True),
+    StructField("normalized_channel",    StringType(),  True),
+    StructField("geo_city",              ArrayType(StringType(),  True)),
+    StructField("subsession_length",     ArrayType(LongType(),  True)),
+    StructField("os",                    StringType(),  True),
+    StructField(
+        "build",
+        ArrayType(
+            StructType(
+                [StructField("application_name",  StringType(),  True)]),
+            True),
+        True),
+    StructField("settings",              ArrayType(
+        StructType(
+            [StructField("locale",        StringType(),  True)]), True),
+        True),
+    StructField("active_addons",         ArrayType(
+        MapType(StringType(), StructType([
+            StructField("blocklisted",      BooleanType(), True),
+            StructField("type",             StringType(), True),
+            StructField("signed_state",     LongType(), True),
+            StructField("user_disabled",    BooleanType(), True),
+            StructField("app_disabled",     BooleanType(), True),
+            StructField("is_system",        BooleanType(), True),
+            StructField("foreign_install",  BooleanType(), True)
+        ]), True), True)),
+    StructField(
+        "places_bookmarks_count",
+        ArrayType(
+            StructType(
+                [StructField("sum",  LongType(),  True)]),
+            True),
+        True),
+    StructField(
+        "scalar_parent_browser_engagement_tab_open_event_count",
+        ArrayType(
+            StructType(
+                [StructField("value",  LongType(),  True)]),
+            True),
+        True),
+    StructField(
+        "scalar_parent_browser_engagement_total_uri_count",
+        ArrayType(
+            StructType(
+                [StructField("value",  LongType(),  True)]),
+            True),
+        True),
+    StructField(
+        "scalar_parent_browser_engagement_unique_domains_count",
+        ArrayType(
+            StructType(
+                [StructField("value",  LongType(),  True)]),
+            True),
+        True)
+    ])
+
+default_sample = {
+    "client_id":             "client-id",
+    "normalized_channel":    "release",
+    "geo_city": ["Boston"],
+    "subsession_length": [10],
+    "os": "Windows",
+    "build": [{
+        "application_name":  "Firefox"
+    }],
+    "settings": [{
+        "locale":            "en-US"
+    }],
+    "active_addons": [],
+    "places_bookmarks_count": [{"sum": 1}],
+    "scalar_parent_browser_engagement_tab_open_event_count": [{"value": 2}],
+    "scalar_parent_browser_engagement_total_uri_count": [{"value": 3}],
+    "scalar_parent_browser_engagement_unique_domains_count": [{"value": 4}]
+}
+
+
+@pytest.fixture()
+def generate_data(dataframe_factory):
+    return functools.partial(
+        dataframe_factory.create_dataframe,
+        base=default_sample,
+        schema=longitudinal_schema
+    )
+
+
+@pytest.fixture
+def multi_clusters_df(generate_data):
+    # Stub a different set of addons for each variation
+    # so that we get 3 clusters out.
+    CLUSTER_VARIATIONS = [
+        {
+            "count": 50,
+            "variation": {
+                "geo_city": ["Rome"],
+                "subsession_length": [3785],
+                "os": "Linux",
+                "settings": [{
+                    "locale": "it-IT"
+                }],
+            }
+        },
+        {
+            "count": 50,
+            "variation": {
+                "geo_city": ["London"],
+                "subsession_length": [1107],
+                "os": "MacOS",
+                "settings": [{
+                    "locale": "en-UK"
+                }],
+            }
+        },
+        {
+            "count": 50,
+            "variation": {
+                "geo_city": ["Boston"],
+                "subsession_length": [201507],
+                "os": "Windows",
+                "settings": [{
+                    "locale": "en-US"
+                }],
+            }
+        }
+    ]
+
+    sample_snippets = []
+    counter = 0
+    for variation_id, cluster in enumerate(CLUSTER_VARIATIONS):
+        for i in range(0, cluster["count"]):
+            variation = copy.deepcopy(cluster["variation"])
+            variation["client_id"] = "client-{}".format(counter)
+
+            # Generate some valid addons for each client. Each stub
+            # addon as a specific GUID that contains both the variation
+            # id and the addon id for simplified debugging.
+            variation["active_addons"] = [{}]
+            for addon_id in range(0, 3):
+                addon_name = "var-{}-guid-{}".format(variation_id, addon_id)
+                variation["active_addons"][0][addon_name] = {
+                    "blocklisted":     False,
+                    "user_disabled":   False,
+                    "app_disabled":    False,
+                    "signed_state":    2,
+                    "type":            "extension",
+                    "foreign_install": False,
+                    "is_system":       False
+                }
+
+            # Additionally add a system addon.
+            variation["active_addons"][0]["system-addon-guid"] = {
+                "blocklisted":     False,
+                "user_disabled":   False,
+                "app_disabled":    False,
+                "signed_state":    2,
+                "type":            "extension",
+                "foreign_install": False,
+                "is_system":       True
+            }
+
+            # Additionally add an AMO unlisted addon.
+            variation["active_addons"][0]["unlisted-addon-guid"] = {
+                "blocklisted":     False,
+                "user_disabled":   False,
+                "app_disabled":    False,
+                "signed_state":    2,
+                "type":            "extension",
+                "foreign_install": False,
+                "is_system":       False
+            }
+
+            sample_snippets.append(variation)
+            counter = counter + 1
+
+    return generate_data(sample_snippets)
+
+
+@pytest.fixture
+def addon_whitelist():
+    addon_whitelist = ["system-addon-guid"]
+    for cluster_id in range(0, 3):
+        for addon_id in range(0, 3):
+            addon_whitelist.append("var-{}-guid-{}".format(cluster_id, addon_id))
+    return addon_whitelist
+
+
+def test_non_cartesian_pairs(spark):
+    TEST_DATA_1 = [1, 2, 3, 4]
+    TEST_DATA_2 = ['a', 'b', 'c', 'd']
+
+    rdd1 = spark.sparkContext.parallelize(TEST_DATA_1)
+    rdd2 = spark.sparkContext.parallelize(TEST_DATA_2)
+
+    # Make sure we get the first element from rdd1 and the second
+    # from rdd2.
+    pairs = taar_similarity.generate_non_cartesian_pairs(rdd1, rdd2)
+    for p in pairs.collect():
+        assert p[0] in TEST_DATA_1
+        assert p[1] in TEST_DATA_2
+
+
+def test_similarity():
+    UserDataRow = Row(
+        "normalized_channel", "geo_city", "subsession_length", "os", "locale",
+        "active_addons", "bookmark_count", "tab_open_count", "total_uri", "unique_tlds"
+    )
+
+    test_user_1 = UserDataRow("release", "Boston", 10, "Windows", "en-US", [], 1, 2, 3, 4)
+    test_user_2 = UserDataRow("release", "notsoB", 10, "swodniW", "SU-ne", [], 1, 2, 3, 4)
+    test_user_3 = UserDataRow("release", "Boston", 0, "Windows", "en-US", [], 0, 0, 0, 0)
+    test_user_4 = UserDataRow("release", "notsoB", 0, "swodniW", "SU-ne", [], 0, 0, 0, 0)
+    # The following user contains a None value for "total_uri" and geo_city
+    # (categorical feature). The latter should never be possible, but let's be cautious.
+    test_user_5 = UserDataRow("release", None, 10, "swodniW", "SU-ne", [], 1, None, 3, 4)
+
+    taar_similarity.similarity_function(test_user_1, test_user_4)
+
+    # Identical users should be very close (0 distance).
+    assert np.isclose(taar_similarity.similarity_function(test_user_1, test_user_1), 0.0)
+    # Users with completely different categorical features but identical
+    # continuous features should be slightly different.
+    assert np.isclose(taar_similarity.similarity_function(test_user_1, test_user_2), 0.001)
+    # Users with completely different continuous features but identical
+    # categorical features should be very close.
+    assert np.isclose(taar_similarity.similarity_function(test_user_1, test_user_3), 0.0)
+    # Completely different users should be far away.
+    assert taar_similarity.similarity_function(test_user_1, test_user_4) >= 1.0
+    # Partial user information should not break the similarity function.
+    assert taar_similarity.similarity_function(test_user_1, test_user_5)
+
+
+def test_get_addons(spark, addon_whitelist, multi_clusters_df):
+    multi_clusters_df.createOrReplaceTempView("longitudinal")
+
+    samples_df = taar_similarity.get_samples(spark)
+    addons_df = taar_similarity.get_addons_per_client(samples_df, addon_whitelist, 2)
+
+    # We should have one row per client and that row should contain
+    # addons as an array.
+    assert samples_df.count() == addons_df.count()
+    assert isinstance(addons_df.schema.fields[1].dataType, ArrayType)
+
+
+def test_compute_donors(spark, addon_whitelist, multi_clusters_df):
+    multi_clusters_df.createOrReplaceTempView("longitudinal")
+
+    # Perform the clustering on our test data. We expect
+    # 3 clusters out of this and 10 donors.
+    _, donors_df = taar_similarity.get_donors(spark, 3, 10, addon_whitelist, random_seed=42)
+    donors = taar_similarity.format_donors_dictionary(donors_df)
+
+    # Even if we requested 10 donors, it doesn't mean we will receive
+    # precisely that number. All we can do is check that the number of
+    # donors should always be >= 2 * num_clusters. Since we're fixing
+    # the seed for this test, we can just assert that we receive 14 donors.
+    assert len(donors) == 14
+
+    # Our artificial clusters should report different cities.
+    for cluster_id, city in enumerate(["Rome", "London", "Boston"]):
+        # We should see at least one item for the "Rome" cluster.
+        cluster_donors = [d for d in donors if d["geo_city"] == city]
+        assert len(cluster_donors) >= 1
+
+        # The generated data must have all the required fields.
+        REQUIRED_FIELDS = [
+            "geo_city", "subsession_length", "locale", "os", "bookmark_count",
+            "tab_open_count", "total_uri", "unique_tlds", "active_addons"
+        ]
+        donor = cluster_donors[0]
+        for f in REQUIRED_FIELDS:
+            assert f in donor.keys()
+
+        # Verify that no system addon or unlisted addons are reported.
+        assert "system-addon-guid" not in donor["active_addons"]
+        assert "unlisted-addon-guid" not in donor["active_addons"]
+
+        # Verify that all the donor addons come from the relative
+        # cluster.
+        expected_initial = "var-{}-guid".format(cluster_id)
+        for addon_id in donor["active_addons"]:
+            assert addon_id.startswith(expected_initial)

--- a/tests/test_taar_utils.py
+++ b/tests/test_taar_utils.py
@@ -1,0 +1,72 @@
+import boto3
+import json
+
+from tempfile import NamedTemporaryFile
+from moto import mock_s3
+from mozetl.taar import taar_utils
+
+SAMPLE_DATA = {"test": "data"}
+
+
+@mock_s3
+def test_write_to_s3():
+    bucket = 'test-bucket'
+    prefix = 'test-prefix/'
+    dest_filename = 'test.json'
+
+    conn = boto3.resource('s3', region_name='us-west-2')
+    bucket_obj = conn.create_bucket(Bucket=bucket)
+
+    with NamedTemporaryFile() as json_file:
+        json_file.write(json.dumps(SAMPLE_DATA))
+        # Seek to the beginning of the file to allow the tested
+        # function to find the file content.
+        json_file.seek(0)
+        # Upload the temp file to S3.
+        taar_utils.write_to_s3(json_file.name, dest_filename, prefix, bucket)
+
+    available_objects = list(bucket_obj.objects.filter(Prefix=prefix))
+    assert len(available_objects) == 1
+
+    # Check that our file is there.
+    full_s3_name = '{}{}'.format(prefix, dest_filename)
+    keys = [o.key for o in available_objects]
+    assert full_s3_name in keys
+
+    stored_data = json.loads(
+        conn
+        .Object(bucket, full_s3_name)
+        .get()['Body']
+        .read()
+        .decode('utf-8')
+    )
+
+    assert SAMPLE_DATA == stored_data
+
+
+@mock_s3
+def test_write_json_s3():
+    bucket = 'test-bucket'
+    prefix = 'test-prefix/'
+    base_filename = 'test'
+
+    content = {
+        "it-IT": ["firefox@getpocket.com"]
+    }
+
+    conn = boto3.resource('s3', region_name='us-west-2')
+    bucket_obj = conn.create_bucket(Bucket=bucket)
+
+    # Store the data in the mocked bucket.
+    taar_utils.store_json_to_s3(json.dumps(content), base_filename,
+                                '20171106', prefix, bucket)
+
+    # Get the content of the bucket.
+    available_objects = list(bucket_obj.objects.filter(Prefix=prefix))
+    assert len(available_objects) == 2
+
+    # Get the list of keys.
+    keys = [o.key for o in available_objects]
+    assert "{}{}.json".format(prefix, base_filename) in keys
+    date_filename = "{}{}20171106.json".format(prefix, base_filename)
+    assert date_filename in keys

--- a/tests/test_taar_utils.py
+++ b/tests/test_taar_utils.py
@@ -1,11 +1,45 @@
 import boto3
 import json
+import pytest
 
 from tempfile import NamedTemporaryFile
 from moto import mock_s3
 from mozetl.taar import taar_utils
 
 SAMPLE_DATA = {"test": "data"}
+
+FAKE_AMO_DUMP = {
+    "test-guid-0001": {
+        "name": {
+            "en-US": "test-amo-entry-1"
+        },
+        "default_locale": "en-US",
+        "current_version": {
+            "files": [{
+                "status": "public",
+                "platform": "all",
+                "id": 1,
+                "is_webextension": True
+            }]
+        },
+        "guid": "test-guid-0001"
+    },
+    "test-guid-0002": {
+        "name": {
+            "en-US": "test-amo-entry-2"
+        },
+        "default_locale": "en-US",
+        "current_version": {
+            "files": [{
+                "status": "public",
+                "platform": "all",
+                "id": 2,
+                "is_webextension": False
+            }]
+        },
+        "guid": "test-guid-0002"
+    }
+}
 
 
 @mock_s3
@@ -70,3 +104,39 @@ def test_write_json_s3():
     assert "{}{}.json".format(prefix, base_filename) in keys
     date_filename = "{}{}20171106.json".format(prefix, base_filename)
     assert date_filename in keys
+
+
+@mock_s3
+def test_load_amo_external_whitelist():
+    conn = boto3.resource('s3', region_name='us-west-2')
+    conn.create_bucket(Bucket=taar_utils.AMO_DUMP_BUCKET)
+
+    # Make sure that whitelist loading fails before mocking the S3 file.
+    EXCEPTION_MSG = 'Empty AMO whitelist detected'
+    with pytest.raises(RuntimeError) as excinfo:
+        taar_utils.load_amo_external_whitelist()
+
+    assert EXCEPTION_MSG in str(excinfo.value)
+
+    # Store an empty file and verify that an exception is raised.
+    conn.Object(taar_utils.AMO_DUMP_BUCKET, key=taar_utils.AMO_DUMP_KEY)\
+        .put(Body=json.dumps({}))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        taar_utils.load_amo_external_whitelist()
+
+    assert EXCEPTION_MSG in str(excinfo.value)
+
+    # Store the data in the mocked bucket.
+    conn.Object(taar_utils.AMO_DUMP_BUCKET, key=taar_utils.AMO_DUMP_KEY)\
+        .put(Body=json.dumps(FAKE_AMO_DUMP))
+
+    # Check that the web_extension item is still present
+    # and the legacy addon is absent.
+    whitelist = taar_utils.load_amo_external_whitelist()
+    assert 'this_guid_can_not_be_in_amo' not in whitelist
+
+    # Verify that the legacy addon was removed while the
+    # web_extension compatible addon is still present.
+    assert 'test-guid-0001' in whitelist
+    assert 'test-guid-0002' not in whitelist


### PR DESCRIPTION
This job is used to compute TAAR similarity-based addon donor list.

This job clusters users into different groups based on their active addons. A representative users sample is selected from each cluster ("donors") and is saved to a model file along with a feature vector that will be used, by the TAAR library module, to perform recommendations.

*Please do not review yet*