### PR TITLE
Make the similarity job work around SPARK-20803

### DIFF
--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -199,7 +199,11 @@ def similarity_function(x, y):
 
     # Take the product of similarities to attain a univariate similarity score.
     # Add a minimal constant to prevent zero values from categorical features.
-    return abs((j_c + 0.001) * j_d)
+    # Note: since both the distance function return a Numpy type, we need to
+    # call the |item| function to get the underlying Python type. If we don't
+    # do that this job will fail when performing KDE due to SPARK-20803 on
+    # Spark 2.2.0.
+    return abs((j_c + 0.001) * j_d).item()
 
 
 def generate_non_cartesian_pairs(first_rdd, second_rdd):

--- a/tests/test_taar_similarity.py
+++ b/tests/test_taar_similarity.py
@@ -226,10 +226,11 @@ def test_similarity():
     # (categorical feature). The latter should never be possible, but let's be cautious.
     test_user_5 = UserDataRow("release", None, 10, "swodniW", "SU-ne", [], 1, None, 3, 4)
 
-    taar_similarity.similarity_function(test_user_1, test_user_4)
-
-    # Identical users should be very close (0 distance).
-    assert np.isclose(taar_similarity.similarity_function(test_user_1, test_user_1), 0.0)
+    # Identical users should be very close (0 distance) and the result must not
+    # be a Numpy number.
+    similarity_result = taar_similarity.similarity_function(test_user_1, test_user_1)
+    assert not isinstance(similarity_result, np.generic)
+    assert np.isclose(similarity_result, 0.0)
     # Users with completely different categorical features but identical
     # continuous features should be slightly different.
     assert np.isclose(taar_similarity.similarity_function(test_user_1, test_user_2), 0.001)


### PR DESCRIPTION
Without this fix, the job will fail on Spark 2.2.0 due to [a bug](https://issues.apache.org/jira/browse/SPARK-20803) in the Kernel Density Estimation not correctly handling Numpy types. Moreover, the job will go OOM on previous Spark versions due to other bugs, so we can't really use anything less than Spark 2.2.0.

This fix was tested on EMR 5.8.0 and the results are accessible in the test telemetry bucket under the TAAR directory