### PR TITLE
Bug 1389231 - Add new-profile ping to churn

### DIFF
--- a/mozetl/churn/churn.py
+++ b/mozetl/churn/churn.py
@@ -145,12 +145,10 @@ def extract(main_summary, new_profile, start_ds, period, slack, is_sampled):
         main_summary
         .where(reduce(operator.__and__, predicates))
         .select(SOURCE_COLUMNS)
-        .withColumn("is_new_profile", F.lit(False))
         .union(
             clean_new_profile(new_profile)
             .where(reduce(operator.__and__, predicates))
             .select(SOURCE_COLUMNS)
-            .withColumn("is_new_profile", F.lit(True))
         )
     )
 
@@ -258,7 +256,6 @@ def clean_columns(prepared_clients, effective_version, start_ds):
     is_funnelcake = F.col('distribution_id').rlike("^mozilla[0-9]+.*$")
 
     attr_mapping = {
-        'is_new_profile': None,
         'distribution_id': None,
         'default_search_engine': None,
         'locale': None,

--- a/mozetl/churn/churn.py
+++ b/mozetl/churn/churn.py
@@ -88,11 +88,6 @@ def clean_new_profile(new_profile):
 
     iso8601_tz_format = "yyyy-MM-dd'T'HH:mm:ss.S'+00:00'"
 
-    subsession_length = (
-        F.col("metadata.timestamp") -
-        F.col("metadata.creation_timestamp")
-    ) / 10**9
-
     select_expr = {
         "app_version": "environment.build.version",
         "attribution": "environment.settings.attribution",
@@ -103,11 +98,7 @@ def clean_new_profile(new_profile):
         "locale": "environment.settings.locale",
         "normalized_channel": "metadata.normalized_channel",
         "profile_creation_date": "environment.profile.creation_date",
-        "subsession_length": (
-            F.when(subsession_length < 0, 0)
-            .otherwise(subsession_length)
-            .cast('long')
-        ),
+        "subsession_length": F.lit(None).cast('long'),
         # The subsession_start_date is the profile_creation_date
         "subsession_start_date": F.from_unixtime(
             F.col("metadata.creation_timestamp") / 10 ** 9, iso8601_tz_format),

--- a/mozetl/churn/churn.py
+++ b/mozetl/churn/churn.py
@@ -109,7 +109,7 @@ def clean_new_profile(new_profile):
         "timestamp": F.col("metadata.timestamp"),
         "scalar_parent_browser_engagement_total_uri_count": F.lit(None).cast("int"),
         "scalar_parent_browser_engagement_unique_domains_count": F.lit(None).cast("int"),
-        "sample_id": F.expr("crc32(encode(client_id, 'UTF-8')) % 100"),
+        "sample_id": F.expr("crc32(encode(client_id, 'UTF-8')) % 100").cast("string"),
         "submission_date_s3": "submission",
     }
 
@@ -150,7 +150,7 @@ def extract(main_summary, new_profile, start_ds, period, slack, is_sampled):
             clean_new_profile(new_profile)
             .where(reduce(operator.__and__, predicates))
             .select(SOURCE_COLUMNS)
-            .withColumn("is_new_profile", F.lit(False))
+            .withColumn("is_new_profile", F.lit(True))
         )
     )
 

--- a/mozetl/churn/schema.py
+++ b/mozetl/churn/schema.py
@@ -1,5 +1,5 @@
 from pyspark.sql.types import (DoubleType, LongType, StringType, StructField,
-                               StructType, BooleanType)
+                               StructType)
 
 churn_schema = StructType([
     StructField('channel', StringType(), True, metadata={
@@ -67,10 +67,6 @@ churn_schema = StructType([
         'description':
             'Used to determine if the profile seen during processing is active'
             'during the particular week of churn.'
-    }),
-    StructField('is_new_profile', BooleanType(), True, metadata={
-        'description':
-            'Distinguishes whether the client appeared as a new profile ping.'
     }),
     StructField('n_profiles', LongType(), True, metadata={
         'description':

--- a/mozetl/churn/schema.py
+++ b/mozetl/churn/schema.py
@@ -1,5 +1,5 @@
 from pyspark.sql.types import (DoubleType, LongType, StringType, StructField,
-                               StructType)
+                               StructType, BooleanType)
 
 churn_schema = StructType([
     StructField('channel', StringType(), True, metadata={
@@ -67,6 +67,10 @@ churn_schema = StructType([
         'description':
             'Used to determine if the profile seen during processing is active'
             'during the particular week of churn.'
+    }),
+    StructField('is_new_profile', BooleanType(), True, metadata={
+        'description':
+            'Distinguishes whether the client appeared as a new profile ping.'
     }),
     StructField('n_profiles', LongType(), True, metadata={
         'description':

--- a/tests/churn/test_churn.py
+++ b/tests/churn/test_churn.py
@@ -204,10 +204,7 @@ def single_profile_df(generate_main_summary_data):
     old_ping = generate_dates(subsession_start)
 
     snippets = [recent_ping, old_ping]
-    return (
-        generate_main_summary_data(snippets)
-        .withColumn("is_new_profile", F.lit(False))
-    )
+    return generate_main_summary_data(snippets)
 
 
 @pytest.fixture
@@ -249,10 +246,7 @@ def multi_profile_df(generate_main_summary_data):
     })
 
     snippets = [user_0, user_1, user_2]
-    return (
-        generate_main_summary_data(snippets)
-        .withColumn("is_new_profile", F.lit(False))
-    )
+    return generate_main_summary_data(snippets)
 
 
 def test_extract_main_summary(spark, generate_main_summary_data):
@@ -319,13 +313,9 @@ def test_multiple_sources_transform(effective_version,
         {"client_id": "2"},
     ])
     sources = churn.extract(main_summary, new_profile, week_start_ds, 1, 0, False)
-
-    assert sources.where("is_new_profile").count() == 3
-    assert sources.where("NOT is_new_profile").count() == 2
-
     df = churn.transform(sources, effective_version, week_start_ds)
 
-    # There are now two rows, representing the source of these clients
+    # There are two different channels
     assert df.count() == 2
 
     assert (
@@ -393,10 +383,7 @@ def test_cohort_by_channel_aggregates(multi_profile_df, effective_version):
 def test_transform(generate_main_summary_data, effective_version):
     def _test_transform(snippets, week_start=week_start_ds):
         return churn.transform(
-            (
-                generate_main_summary_data(snippets)
-                .withColumn("is_new_profile", F.lit(False))
-            ),
+            generate_main_summary_data(snippets),
             effective_version,
             week_start
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ def spark():
         .appName("python_mozetl_test")
         .getOrCreate()
     )
+    # Set server timezone at UTC+0
+    spark.conf.set("spark.sql.session.timeZone", "UTC")
     yield spark
     spark.stop()
 


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1389231)

This adds the `new-profile` ping as a data source for churn. A new
column `is_new_profile` differentiates the source for the clients.

This is also a version bump to `v3`.

Additionally, `spark.sql.session.timeZone` is set to UTC, which require
Spark 2.2.0 to work (see SPARK-18936 for details). The spark session
assumes the timezone of the local machine, which can cause failing
tests.