### PR TITLE
Bug 1401655 - Add cli entry point for clients/experiments daily

### DIFF
--- a/mozetl/cli.py
+++ b/mozetl/cli.py
@@ -3,6 +3,8 @@ from mozetl.churn import churn
 from mozetl.search import dashboard, search_rollups
 from mozetl.taar import taar_locale, taar_similarity
 from mozetl.sync import bookmark_validation
+from mozetl.clientsdaily import rollup as clientsdaily
+from mozetl.experimentsdaily import rollup as experimentsdaily
 
 
 @click.group()
@@ -11,8 +13,13 @@ def entry_point():
 
 
 entry_point.add_command(churn.main, "churn")
+entry_point.add_command(clientsdaily.main, "clients_daily")
+entry_point.add_command(experimentsdaily.main, "experiments_daily")
 entry_point.add_command(dashboard.main, "search_dashboard")
 entry_point.add_command(search_rollups.main, "search_rollup")
+entry_point.add_command(bookmark_validation.main, "sync_bookmark_validation")
 entry_point.add_command(taar_locale.main, "taar_locale")
 entry_point.add_command(taar_similarity.main, "taar_similarity")
-entry_point.add_command(bookmark_validation.main, "sync_bookmark_validation")
+
+if __name__ == '__main__':
+	entry_point()


### PR DESCRIPTION
Add two more entrypoints so we can easily run `clientsdaily` and `experimentsdaily` via Airflow.

I also updated `cli.py` so that it would call its entrypoint if invoked directly. This allows one to test out the cli via:
` $ python mozetl/cli.py --help`

And get useful output.