### PR TITLE
Bug 1401655 - Prepare jobs to run via Airflow.

### DIFF
--- a/mozetl/cli.py
+++ b/mozetl/cli.py
@@ -22,4 +22,4 @@ entry_point.add_command(taar_locale.main, "taar_locale")
 entry_point.add_command(taar_similarity.main, "taar_similarity")
 
 if __name__ == '__main__':
-	entry_point()
+    entry_point()


### PR DESCRIPTION
In particular, change the `clientsdaily` job to accept an "end" date
instead of a "start" date to simplify the airflow side. Also accept
the LAG specification as an argument.