### PR TITLE
Bug 1403745 - Validate churn schema via test suite

### DIFF
--- a/mozetl/churn/churn.py
+++ b/mozetl/churn/churn.py
@@ -229,7 +229,9 @@ def clean_columns(prepared_clients, effective_version, start_ds):
         'is_funnelcake': (
             F.when(is_funnelcake, F.lit("yes"))
             .otherwise(F.lit("no"))),
-        'acquisition_period': F.date_sub(F.next_day(pcd, 'Sun'), 7),
+        'acquisition_period': F.date_format(
+            F.date_sub(F.next_day(pcd, 'Sun'), 7),
+            "yyyy-MM-dd"),
         'sync_usage': (
             F.when(device_count > 1, F.lit("multiple"))
             .otherwise(

--- a/tests/churn/test_churn.py
+++ b/tests/churn/test_churn.py
@@ -8,7 +8,7 @@ from pyspark.sql.types import (
     LongType, IntegerType, BooleanType
 )
 
-from mozetl.churn import churn
+from mozetl.churn import churn, schema
 
 SPBE = "scalar_parent_browser_engagement_"
 
@@ -264,6 +264,18 @@ def test_transform(generate_data, effective_version):
             week_start
         )
     return _test_transform
+
+
+def test_transform_adheres_to_schema(test_transform):
+    df = test_transform(None)
+
+    def column_types(schema):
+        return {
+            col.name: col.dataType.typeName()
+            for col in schema.fields
+        }
+
+    assert column_types(df.schema) == column_types(schema.churn_schema)
 
 
 def test_nulled_stub_attribution(test_transform):


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1403745)

The schema types are validated through the test suite.   

This is the source of the failing `churn_to_csv` job today. The acquisition_date field was a `date` type instead of a `yyyy-MM-dd` `string` type.