### PR TITLE
Use underscore instead of hyphen in dataset names.

### DIFF
--- a/mozetl/clientsdaily/rollup.py
+++ b/mozetl/clientsdaily/rollup.py
@@ -170,7 +170,7 @@ def get_partition_count_for_writing(is_sampled):
               default='net-mozaws-prod-us-west-2-pipeline-analysis',
               help='Bucket of the output dataset')
 @click.option('--output-prefix',
-              default='/clients-daily',
+              default='/clients_daily',
               help='Prefix of the output dataset')
 @click.option('--output-version',
               default=5,

--- a/mozetl/experimentsdaily/rollup.py
+++ b/mozetl/experimentsdaily/rollup.py
@@ -41,7 +41,7 @@ def to_experiment_profile_day_aggregates(frame_with_extracts):
               default='net-mozaws-prod-us-west-2-pipeline-analysis',
               help='Bucket of the output dataset')
 @click.option('--output-prefix',
-              default='/experiments-daily',
+              default='/experiments_daily',
               help='Prefix of the output dataset')
 @click.option('--output-version',
               default=2,


### PR DESCRIPTION
In keeping with all the other datasets.