### PR TITLE
Add legacy addons etl job to TAAR

### DIFF
--- a/mozetl/taar/taar_legacy.py
+++ b/mozetl/taar/taar_legacy.py
@@ -1,0 +1,59 @@
+"""
+TAAR legacy addon replacements
+This job pulls the latest curated substitute webestensions from the
+AMO data sources. This ensures that TAAR recommendations for legacy
+substitutions are consistent with AMO replacements.
+Prototype notebook is here [1]
+
+[1] https://gist.github.com/mlopatka/c6fe350dbcd8fe11ccf0929fc9f8c223
+"""
+
+import click
+import json
+import logging
+import requests
+
+from taar_utils import store_json_to_s3
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+AMO_LEGACY_RECS_URI =\
+    "https://addons.mozilla.org/api/v3/addons/replacement-addon/"
+EXPORT_FILE_NAME = 'legacy_substitutes.json'
+
+
+def fetch_legacy_replacement_masterlist():
+    # Set the initial URI to the REST API entry point.
+    request_uri = AMO_LEGACY_RECS_URI
+
+    # Put all the mappings in this dictionary, keyed on legacy guid.
+    legacy_replacement_dict = {}
+
+    while request_uri is not None:
+        print("Fetching {}\n".format(request_uri))
+        # Request the data and get it in JSON format.
+        r = requests.get(request_uri)
+        page_blob = r.json()
+        # Re map as {guid : [guid-1, guid-2,... guid-n]}
+        for addon in page_blob.get('results'):
+            legacy_replacement_dict[addon.get('guid')] =\
+                addon.get('replacement')
+
+        request_uri = page_blob.get('next')
+
+    return legacy_replacement_dict
+
+
+@click.command()
+@click.option('--date', required=True)
+@click.option('--bucket', default='telemetry-private-analysis-2')
+@click.option('--prefix', default='taar/legacy/')
+def main(date, bucket, prefix):
+    logger.info("Retreiving AMO legacy addon replacements list")
+    legacy_dict = fetch_legacy_replacement_masterlist()
+
+    if len(legacy_dict) > 0:
+        logger.info("Updating active legacy addon replacements list in s3")
+        store_json_to_s3(json.dumps(legacy_dict, indent=2), EXPORT_FILE_NAME,
+                         date, prefix, bucket)

--- a/tests/test_taar_legacy.py
+++ b/tests/test_taar_legacy.py
@@ -32,19 +32,26 @@ FAKE_MIXED_LEGACY_DATA = {
 }
 
 
+def swap_returned_dict(target_dict):
+    return target_dict
+
+
 @pytest.fixture
 def mock_amo_api_response(monkeypatch):
-    monkeypatch.setattr('requests.get', lambda x, y: FAKE_LEGACY_DATA)
+    monkeypatch.setattr('fetch_legacy_replacement_masterlist.parse_from_amo_api',
+                        swap_returned_dict(FAKE_LEGACY_DATA))
 
 
 @pytest.fixture
 def mock_amo_broke(monkeypatch):
-    monkeypatch.setattr('requests.get', lambda x, y: FAKE_BROKEN_LEGACY_DATA)
+    monkeypatch.setattr('fetch_legacy_replacement_masterlist.parse_from_amo_api',
+                        swap_returned_dict(FAKE_BROKEN_LEGACY_DATA))
 
 
 @pytest.fixture
 def mock_amo_mixed(monkeypatch):
-    monkeypatch.setattr('requests.get', lambda x, y: FAKE_MIXED_LEGACY_DATA)
+    monkeypatch.setattr('fetch_legacy_replacement_masterlist.parse_from_amo_api',
+                        swap_returned_dict(FAKE_MIXED_LEGACY_DATA))
 
 
 def test_fetch_legacy_replacement_masterlist(mock_amo_api_response):

--- a/tests/test_taar_legacy.py
+++ b/tests/test_taar_legacy.py
@@ -1,0 +1,18 @@
+"""Test suite for TAAR Legacy Job."""
+
+import pytest
+import requests
+
+AMO_LEGACY_RECS_URI =\
+    "https://addons-dev.allizom.org/api/v3/addons/replacement-addon/"
+
+
+@pytest.fixture
+def is_api_up():
+    request_uri = AMO_LEGACY_RECS_URI
+    while request_uri is not None:
+        # Request some data from the AMO API.
+        r = requests.get(request_uri)
+    return r.ok
+
+assert is_api_up()

--- a/tests/test_taar_legacy.py
+++ b/tests/test_taar_legacy.py
@@ -2,17 +2,83 @@
 
 import pytest
 import requests
+from mozetl.taar import taar_legacy
 
-AMO_LEGACY_RECS_URI =\
-    "https://addons-dev.allizom.org/api/v3/addons/replacement-addon/"
+FAKE_LEGACY_DATA = {
+    "guid-01":
+        ["guid-02"],
+    "guid-03":
+        ["guid-05"],
+    "guid-05":
+        ["guid-06"],
+    "guid-07": ["guid-08-1", "guid-09-2", "guid-10-3", "guid-11-4"],
+    "guid-12": ["guid-13-1", "guid-14-2", "guid-15-3", "guid-16-4",
+                "guid-17-5", "guid-18-6", "guid-19-7", "guid-20-8",
+                "guid-21-9", "guid-22-10"],
+    "next": None
+}
+
+FAKE_BROKEN_LEGACY_DATA = {
+    "guid-23": [],
+    "guid-24": {},
+    "guid-25": None
+}
+
+FAKE_MIXED_LEGACY_DATA = {
+    "guid-26": [],
+    "guid-27": {},
+    "guid-28": None,
+    "guid-29": ["guid-30"]
+}
 
 
 @pytest.fixture
-def is_api_up():
-    request_uri = AMO_LEGACY_RECS_URI
-    while request_uri is not None:
-        # Request some data from the AMO API.
-        r = requests.get(request_uri)
-    return r.ok
+def mock_amo_api_response(monkeypatch):
+    monkeypatch.setattr(requests, 'requests.get', lambda x, y: FAKE_LEGACY_DATA)
 
-assert is_api_up()
+
+@pytest.fixture
+def mock_amo_broke(monkeypatch):
+    monkeypatch.setattr(requests, 'requests.get', lambda x, y: FAKE_BROKEN_LEGACY_DATA)
+
+
+@pytest.fixture
+def mock_amo_mixed(monkeypatch):
+    monkeypatch.setattr(requests, 'requests.get', lambda x, y: FAKE_MIXED_LEGACY_DATA)
+
+
+def test_fetch_legacy_replacement_masterlist(mock_amo_api_response):
+    # Test with mocked properly-formed data.
+    test_data = taar_legacy.fetch_legacy_replacement_masterlist()
+
+    # Test for expected legacy addon guids as keys.
+    for i in ["guid-01", "guid-03", "guid-05", "guid-07", "guid-12"]:
+        assert i in test_data.keys()
+
+    # Test for removeal of pagination structure in output.
+    assert "next" not in test_data.keys()
+
+    # Test for values in specific legacy replacement.
+    expected = ["guid-13-1", "guid-14-2", "guid-15-3", "guid-16-4",
+                "guid-17-5", "guid-18-6", "guid-19-7", "guid-20-8",
+                "guid-21-9", "guid-22-10"]
+
+    assert test_data["guid-12"] == expected
+
+
+def test_fetch_broken_legacy(mock_amo_broke):
+    # Test with mocked malformed data.
+    test_data = taar_legacy.fetch_legacy_replacement_masterlist()
+
+    # This should be empty as no valid entries exist in mocked data.
+    assert not test_data
+
+
+def test_fetch_mixed_legacy(mock_amo_mixed):
+    # Test with mocked malformed data.
+    test_data = taar_legacy.fetch_legacy_replacement_masterlist()
+
+    # This contain only the single valid entry in the mocked data.
+    assert "guid-29" in test_data.keys()
+    assert test_data["guid-29"] == ["guid-30"]
+    assert len(test_data) == 1

--- a/tests/test_taar_legacy.py
+++ b/tests/test_taar_legacy.py
@@ -34,17 +34,17 @@ FAKE_MIXED_LEGACY_DATA = {
 
 @pytest.fixture
 def mock_amo_api_response(monkeypatch):
-    monkeypatch.setattr(requests, 'requests.get', lambda x, y: FAKE_LEGACY_DATA)
+    monkeypatch.setattr('requests.get', lambda x, y: FAKE_LEGACY_DATA)
 
 
 @pytest.fixture
 def mock_amo_broke(monkeypatch):
-    monkeypatch.setattr(requests, 'requests.get', lambda x, y: FAKE_BROKEN_LEGACY_DATA)
+    monkeypatch.setattr('requests.get', lambda x, y: FAKE_BROKEN_LEGACY_DATA)
 
 
 @pytest.fixture
 def mock_amo_mixed(monkeypatch):
-    monkeypatch.setattr(requests, 'requests.get', lambda x, y: FAKE_MIXED_LEGACY_DATA)
+    monkeypatch.setattr('requests.get', lambda x, y: FAKE_MIXED_LEGACY_DATA)
 
 
 def test_fetch_legacy_replacement_masterlist(mock_amo_api_response):


### PR DESCRIPTION
Just a small job that uses a new AMO API to get appropriate replacement addons for legacy addons. This will populate a data source for one of TAAR's modules.