### PR TITLE
Fixes #151 - Fix expected value in `test_pulse.py`

### DIFF
--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -75,10 +75,10 @@ def test_simple_transform(row_to_dict, simple_rdd, spark_context):
         'version': u'1.0.2',
         'requests': requests,
         'disconnectRequests': 1,
-        'consoleErrors': None,
+        'consoleErrors': 0,
         'e10sStatus': 1,
         'e10sProcessCount': 4,
-        'trackingProtection': None
+        'trackingProtection': False,
     }
 
     assert row_to_dict(actual) == expected


### PR DESCRIPTION
Fixes issue #151. 

This test has been failing after an update to some mysterious dependency. It seems that the test expects the wrong value after further inspection. Both [`consoleErrors`](https://github.com/mozilla/python_mozetl/blob/master/tests/pulse_ping.json#L59) and [`trackingProtection`](https://github.com/mozilla/python_mozetl/blob/master/tests/pulse_ping.json#L74) have non-null values in the pre-transform stage, however the test expects null values for some reason. 