### PR TITLE
Bug 1416225 - skip nulls with "first" aggregation in clients_daily

### DIFF
--- a/mozetl/clientsdaily/fields.py
+++ b/mozetl/clientsdaily/fields.py
@@ -24,7 +24,7 @@ def agg_mean(field_name, alias=None):
 
 
 def agg_first(field_name):
-    return F.first(field_name).alias(field_name)
+    return F.first(field_name, ignorenulls=True).alias(field_name)
 
 
 def agg_max(field_name, alias=None):

--- a/tests/test_clientsdaily.py
+++ b/tests/test_clientsdaily.py
@@ -117,3 +117,19 @@ def test_sessions_started_on_this_day_sorted(clients_daily):
     ten_ssotds = one_day.select("sessions_started_on_this_day").take(10)
     actual = [r.asDict().values()[0] for r in ten_ssotds]
     assert actual == expected
+
+
+# Ensure that "first" aggregations skip null values
+def test_first_skips_nulls(clients_daily):
+    filter_template = "client_id = '{}' and activity_date = '{}'"
+    client = '0c495fce-5fbf-4f4a-ac03-2dedcef0a8d0'
+    day = '2017-05-25'
+    filter_clause = filter_template.format(client, day)
+    null_to_false = clients_daily.where(filter_clause).select("sync_configured").first()
+    expected = False
+    actual = null_to_false.sync_configured
+    assert actual == expected
+
+    expected = 230
+    actual = clients_daily.where("sync_configured is null").count()
+    assert actual == expected

--- a/tests/test_taar_legacy.py
+++ b/tests/test_taar_legacy.py
@@ -1,7 +1,6 @@
 """Test suite for TAAR Legacy Job."""
 
 import pytest
-import requests
 from mozetl.taar import taar_legacy
 
 FAKE_LEGACY_DATA = {
@@ -92,4 +91,3 @@ def test_parse_from_amo_api():
     expected = {'test-key': 'test-val'}
     new_dict = taar_legacy.parse_from_amo_api(None, expected)
     assert expected == new_dict
-


### PR DESCRIPTION
I can't imagine a case where a null would be preferred over the first non-null value, particularly given that the data is not sorted first, as far as I can tell.