### PR TITLE
Bug 1419080 - Use attribution from new-profile pings in churn 

### DIFF
--- a/mozetl/engagement/churn/job.py
+++ b/mozetl/engagement/churn/job.py
@@ -508,6 +508,12 @@ def main(start_date, bucket, prefix, input_bucket, input_prefix,
     )
     spark.conf.set("spark.sql.session.timeZone", "UTC")
 
+    shuffle_partitions = max(
+        spark.sparkContext.defaultParallelism * 4,
+        int(spark.conf.get("spark.sql.shuffle.partitions"))
+    )
+    spark.conf.set("spark.sql.shuffle.partitions", shuffle_partitions)
+
     # If this job is scheduled, we need the input date to lag a total of
     # 10 days of slack for incoming data. Airflow subtracts 7 days to
     # account for the weekly nature of this report.

--- a/mozetl/engagement/churn/job.py
+++ b/mozetl/engagement/churn/job.py
@@ -114,6 +114,33 @@ def clean_new_profile(new_profile):
     return new_profile.select(utils.build_col_expr(select_expr))
 
 
+def join_and_coalesce(lhs, rhs, on, col):
+    """ Join two dataframes on a common column, coalescing the value of a
+    target column to the right hand side over the left hand side.
+
+    :param lhs: dataframe as the frame of reference, left hand side
+    :param rhs: dataframe to coalesce values from, right hand side
+    :param on:  column name to join on
+    :param col: name of the column in the rhs to coalesce with lhs
+    :return:    a dataframe with the same schema as the lhs
+    """
+
+    assert len({on, col} & set(lhs.columns) & set(rhs.columns)) == 2, \
+        "both dataframes should contain join key and coalesce column"
+
+    rhs_name = "_rhs_column_name"
+    rhs = rhs.select(on, F.col(col).alias(rhs_name))
+
+    coalesced = (
+        lhs
+        .join(rhs, on, "left")
+        .withColumn(col, F.coalesce(rhs_name, col))
+        .select(lhs.columns)
+    )
+
+    return coalesced
+
+
 def extract(main_summary, new_profile, start_ds, period, slack, is_sampled):
     """
     Extract data from the main summary table taking into account the
@@ -139,15 +166,23 @@ def extract(main_summary, new_profile, start_ds, period, slack, is_sampled):
     if is_sampled:
         predicates.append((F.col("sample_id") == "57"))
 
-    return (
+    extract_ms = (
         main_summary
         .where(reduce(operator.__and__, predicates))
         .select(SOURCE_COLUMNS)
-        .union(
-            clean_new_profile(new_profile)
-            .where(reduce(operator.__and__, predicates))
-            .select(SOURCE_COLUMNS)
-        )
+    )
+
+    np = clean_new_profile(new_profile)
+    extract_np = (
+        np
+        .where(reduce(operator.__and__, predicates))
+        .select(SOURCE_COLUMNS)
+    )
+
+    return (
+        # bug 1416364: use attribution from new profiles
+        join_and_coalesce(extract_ms, np, "client_id", "attribution")
+        .union(extract_np)
     )
 
 

--- a/mozetl/engagement/churn/job.py
+++ b/mozetl/engagement/churn/job.py
@@ -388,7 +388,15 @@ def clean_columns(prepared_clients, effective_version, start_ds):
             (F.col("profile_creation") > DEFAULT_DATE) &
             (pcd <= client_date)
         ))
-        .select("profile_creation", *select_expr)
+        .select(
+            # avoid acquisition dates in the future
+            (
+                F.when(F.col(is_valid), F.col("profile_creation"))
+                .otherwise(F.lit(None))
+                .alias("profile_creation")
+            ),
+            *select_expr
+        )
         # Set default values for the rows
         .fillna({
             'acquisition_period': DEFAULT_DATE,

--- a/mozetl/engagement/churn/job.py
+++ b/mozetl/engagement/churn/job.py
@@ -179,9 +179,16 @@ def extract(main_summary, new_profile, start_ds, period, slack, is_sampled):
         .select(SOURCE_COLUMNS)
     )
 
+    np_attribution = (
+        np
+        .where("attribution is not null")
+        .groupBy("client_id")
+        .agg(F.first("attribution").alias("attribution"))
+    )
+
     return (
         # bug 1416364: use attribution from new profiles
-        join_and_coalesce(extract_ms, np, "client_id", "attribution")
+        join_and_coalesce(extract_ms, np_attribution, "client_id", "attribution")
         .union(extract_np)
     )
 


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1419080)

Attribution is [often] missing from main-pings. This uses the attribution value from the new-profile ping over the main-ping value when generating churn and retention.

The left join will most likely increase the processing time on this dataset. 