### PR TITLE
Fix use of bare except in basic transforms

### DIFF
--- a/mozetl/basic/transform.py
+++ b/mozetl/basic/transform.py
@@ -1,7 +1,12 @@
+import logging
 from collections import namedtuple
 
 from moztelemetry import get_pings_properties
 from pyspark.sql.types import StructType, StructField
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 ColumnConfig = namedtuple('ColumnConfig',
@@ -40,7 +45,9 @@ def _build_cell(ping, column_config):
     if func is not None:
         try:
             return func(raw_value)
-        except Exception as e:  # TODO: should we make this more specific?
+        except Exception as e:
+            logger.warning("Unable to apply transform on data '%s': %s",
+                           raw_value, e)
             return None
     else:
         return raw_value

--- a/mozetl/basic/transform.py
+++ b/mozetl/basic/transform.py
@@ -40,7 +40,7 @@ def _build_cell(ping, column_config):
     if func is not None:
         try:
             return func(raw_value)
-        except:  # TODO: what exception could happen here, fill in?
+        except Exception as e:  # TODO: should we make this more specific?
             return None
     else:
         return raw_value


### PR DESCRIPTION
Bare except makes it harder to interrupt programs. Better to catch the Exception
class instead, which will at least let the SystemExit and KeyboardInterrupt
exceptions go through (https://stackoverflow.com/a/14797463).