### PR TITLE
Fix min install date

### DIFF
--- a/mozetl/addon_aggregates/addon_aggregates.py
+++ b/mozetl/addon_aggregates/addon_aggregates.py
@@ -155,9 +155,9 @@ def aggregate_addons(df):
              fun.sum("is_foreign_install").alias("n_foreign_installed_addons"),
              fun.sum("is_system").alias("n_system_addons"),
              fun.sum("is_web_extension").alias("n_web_extensions"),
-             fun.date_format(
-                fun.from_unixtime(
-                    fun.min("install_day")*60*60*24), "yyyyMMdd")
+             fun.min(fun.when(df.is_self_install == 1,
+                              fun.date_format(fun.from_unixtime(fun.col("install_day")*60*60*24),
+                                              "yyyyMMdd")).otherwise(None))
              .alias("first_addon_install_date"),
              fun.date_format(
                 fun.from_unixtime(

--- a/mozetl/cli.py
+++ b/mozetl/cli.py
@@ -10,6 +10,7 @@ from mozetl.sync import bookmark_validation
 from mozetl.taar import taar_locale, taar_similarity, taar_legacy
 from mozetl.addon_aggregates import addon_aggregates
 
+
 @click.group()
 def entry_point():
     pass

--- a/tests/test_addon_aggregates.py
+++ b/tests/test_addon_aggregates.py
@@ -138,9 +138,9 @@ def test_unix_dates(aggregate_data):
     # min install_day - pcd
     true_client_days_to_install = {
         1: {'min_install_day': 16890 - 15000},
-        2: {'min_install_day': 17000 - 15001},
+        2: {'min_install_day': None},
         3: {'min_install_day': 16800 - 15002},
-        4: {'min_install_day': 16900 - 15003}
+        4: {'min_install_day': None}
 
     }
 
@@ -152,7 +152,7 @@ def test_unix_dates(aggregate_data):
         fmt = '%Y%m%d'
         days_to_install = (
             dt.datetime.strptime(first_install, fmt) - dt.datetime.strptime(pcd, fmt)
-        ).days
+        ).days if first_install is not None else None
 
         assert true_client_days_to_install[client_id]['min_install_day'] == days_to_install
 


### PR DESCRIPTION
Added logic to only record `first_addon_install_date` for self-installed add-ons, otherwise it should be `null`. This was an oversight from the initial script, and I'd like to backfill through 2017-10-01.

r? @acmiyaguchi 