### PR TITLE
Parse the date string into a proper date object in taar_dynamo.

### DIFF
--- a/mozetl/taar/taar_dynamo.py
+++ b/mozetl/taar/taar_dynamo.py
@@ -408,8 +408,9 @@ def main(date, region, table, prod_iam_role, sample_rate):
     APP_NAME = "HBaseAddonRecommenderView"
     conf = SparkConf().setAppName(APP_NAME)
     spark = SparkSession.builder.config(conf=conf).getOrCreate()
+    date_obj = datetime.strptime(date, "%Y%m%d")
     reduction_output = run_etljob(spark,
-                                  date,
+                                  date_obj,
                                   region,
                                   table,
                                   prod_iam_role,


### PR DESCRIPTION
This parses the date option passed into taar_dynamo into a proper python datetime object. 

I've tested this patch on atmo using `mozetl-submit.sh` patched to point at crankycoder/python_mozetl instead of mozilla/python_mozetl

r? @sunahsuh 
