### PR TITLE
Partition search_clients_daily by sample_id

### DIFF
--- a/mozetl/search/aggregates.py
+++ b/mozetl/search/aggregates.py
@@ -56,6 +56,7 @@ def search_clients_daily(main_summary):
             'default_search_engine',
             'default_search_engine_data_load_path',
             'default_search_engine_data_submission_url',
+            'sample_id',
         ]) + [
             # Count of 'first' subsessions seen for this client_day
             (
@@ -203,7 +204,7 @@ def generate_rollups(submission_date, output_bucket, output_prefix,
                      output_version, transform_func,
                      input_bucket=DEFAULT_INPUT_BUCKET,
                      input_prefix=DEFAULT_INPUT_PREFIX,
-                     save_mode=DEFAULT_SAVE_MODE):
+                     save_mode=DEFAULT_SAVE_MODE, orderBy=[]):
     """Load main_summary, apply transform_func, and write to S3"""
     logger.info('Running the {0} ETL job...'.format(transform_func.__name__))
     start = datetime.datetime.now()
@@ -235,7 +236,7 @@ def generate_rollups(submission_date, output_bucket, output_prefix,
     logger.info('Saving rollups to: {}'.format(output_path))
     (
         search_dashboard_data
-        .repartition(10)
+        .orderBy(*orderBy)
         .write
         .mode(save_mode)
         .save(output_path)
@@ -255,7 +256,7 @@ def search_aggregates_etl(submission_date, output_bucket, output_prefix,
 def search_clients_daily_etl(submission_date, output_bucket, output_prefix,
                              **kwargs):
     generate_rollups(submission_date, output_bucket, output_prefix,
-                     1, search_clients_daily, **kwargs)
+                     1, search_clients_daily, orderBy='sample_id', **kwargs)
 
 
 # Generate click commands - wrap ETL jobs to accept click arguements

--- a/tests/test_search_aggregates.py
+++ b/tests/test_search_aggregates.py
@@ -107,6 +107,7 @@ search_type = ArrayType(StructType([
 
 main_summary_schema = [
     ('client_id', 'a', StringType(), False),
+    ('sample_id', '42', StringType(), False),
     ('submission_date', '20170101', StringType(), False),
     ('os', 'windows', StringType(), True),
     ('channel', 'release', StringType(), True),
@@ -273,6 +274,7 @@ def expected_search_clients_daily_data(define_dataframe_factory):
     # template for the expected results
     factory = define_dataframe_factory(map(to_field, [
         ('client_id', 'a', StringType(), False),
+        ('sample_id', '42', StringType(), False),
         ('submission_date', '20170101', StringType(), False),
         ('os', 'windows', StringType(), True),
         ('channel', 'release', StringType(), True),


### PR DESCRIPTION
SCD is proving to be uncomfortably big for re:dash. Filtering by sample_id will make quick calculations easier.