### PR TITLE
Add convenience columns to search tables

### DIFF
--- a/mozetl/search/aggregates.py
+++ b/mozetl/search/aggregates.py
@@ -138,6 +138,10 @@ def agg_search_data(main_summary, grouping_cols, agg_functions):
             ['tagged-sap', 'tagged-follow-on', 'sap']
         )
         .sum('count')
+        # Add convenience columns with underscores instead of hyphens.
+        # This makes the table easier to query from Presto.
+        .withColumn('tagged_sap', 'tagged-sap')
+        .withColumn('tagged_follow_on', 'tagged-follow-on')
     )
 
     return pivoted

--- a/mozetl/search/aggregates.py
+++ b/mozetl/search/aggregates.py
@@ -132,7 +132,8 @@ def agg_search_data(main_summary, grouping_cols, agg_functions):
     # Pivot on search type
     pivoted = (
         aggregated
-        .groupBy([col for col in aggregated.columns if col not in ['type', 'count']])
+        .groupBy([column for column in aggregated.columns
+                  if column not in ['type', 'count']])
         .pivot(
             'type',
             ['tagged-sap', 'tagged-follow-on', 'sap']
@@ -140,8 +141,8 @@ def agg_search_data(main_summary, grouping_cols, agg_functions):
         .sum('count')
         # Add convenience columns with underscores instead of hyphens.
         # This makes the table easier to query from Presto.
-        .withColumn('tagged_sap', 'tagged-sap')
-        .withColumn('tagged_follow_on', 'tagged-follow-on')
+        .withColumn('tagged_sap', col('tagged-sap'))
+        .withColumn('tagged_follow_on', col('tagged-follow-on'))
     )
 
     return pivoted

--- a/mozetl/search/aggregates.py
+++ b/mozetl/search/aggregates.py
@@ -261,7 +261,7 @@ def search_aggregates_etl(submission_date, output_bucket, output_prefix,
 def search_clients_daily_etl(submission_date, output_bucket, output_prefix,
                              **kwargs):
     generate_rollups(submission_date, output_bucket, output_prefix,
-                     1, search_clients_daily, orderBy='sample_id', **kwargs)
+                     2, search_clients_daily, orderBy='sample_id', **kwargs)
 
 
 # Generate click commands - wrap ETL jobs to accept click arguements

--- a/tests/test_search_aggregates.py
+++ b/tests/test_search_aggregates.py
@@ -256,6 +256,8 @@ def expected_search_dashboard_data(define_dataframe_factory):
         ('source', 'urlbar', StringType(), False),
         ('tagged-sap', None, LongType(), True),
         ('tagged-follow-on', None, LongType(), True),
+        ('tagged_sap', None, LongType(), True),
+        ('tagged_follow_on', None, LongType(), True),
         ('sap', 4, LongType(), True),
     ]))
 
@@ -288,6 +290,8 @@ def expected_search_clients_daily_data(define_dataframe_factory):
         ('source', 'urlbar', StringType(), True),
         ('tagged-sap', None, LongType(), True),
         ('tagged-follow-on', None, LongType(), True),
+        ('tagged_sap', None, LongType(), True),
+        ('tagged_follow_on', None, LongType(), True),
         ('sap', 4, LongType(), True),
         # Roughly 2016-01-01
         ('profile_creation_date', 16801, LongType(), False),
@@ -336,6 +340,8 @@ def expected_search_clients_daily_data(define_dataframe_factory):
             'sap': 0,
             'tagged-sap': None,
             'tagged-follow-on': None,
+            'tagged_sap': None,
+            'tagged_follow_on': None,
             'source': None,
             'engine': None,
         }


### PR DESCRIPTION
`tagged-sap` and `tagged-follow-on` both contain hyphens, which makes them difficult to work with in Presto. Adding convenience columns which replace the hyphens with underscores.

This will close out the changes to scd_v2