### PR TITLE
Search bugfix: Use consistent variable names

### DIFF
--- a/mozetl/search/aggregates.py
+++ b/mozetl/search/aggregates.py
@@ -233,15 +233,15 @@ def generate_rollups(submission_date, output_bucket, output_prefix,
 
 
 # Generate ETL jobs - these are useful if you want to run a job from ATMO
-def search_aggregates_etl(submission_date, output_bucket, output_prefix,
+def search_aggregates_etl(submission_date, bucket, prefix,
                           **kwargs):
-    generate_rollups(submission_date, output_bucket, output_prefix,
+    generate_rollups(submission_date, bucket, prefix,
                      3, search_aggregates, **kwargs)
 
 
-def search_clients_daily_etl(submission_date, output_bucket, output_prefix,
+def search_clients_daily_etl(submission_date, bucket, prefix,
                              **kwargs):
-    generate_rollups(submission_date, output_bucket, output_prefix,
+    generate_rollups(submission_date, bucket, prefix,
                      1, search_clients_daily, **kwargs)
 
 


### PR DESCRIPTION
As is, line 265 throws an error because python expects to pass `bucket`
and `prefix` variables to `search_aggregates_etl` and
`search_clients_daily_etl`.

Unfortunately, we don't have test coverage for the cli command.
I had to run this manually to test.