### PR TITLE
Final changes to taar_lite_guid_guid PR

### DIFF
--- a/mozetl/taar/taar_lite_guidguid.py
+++ b/mozetl/taar/taar_lite_guidguid.py
@@ -112,10 +112,10 @@ def load_training_from_telemetry(spark):
         # user to a list of add-on GUIDs. Also filter undesired add-ons.
         return (
             users_df.rdd
-                .map(lambda p: (p["client_id"],
-                                [guid for guid, data in p["active_addons"].items() if is_valid_addon(guid, data)]))
-                .filter(lambda p: len(p[1]) > 1)
-                .toDF(["client_id", "addon_ids"])
+                    .map(lambda p: (p["client_id"],
+                                    [guid for guid, data in p["active_addons"].items() if is_valid_addon(guid, data)]))
+                    .filter(lambda p: len(p[1]) > 1)
+                    .toDF(["client_id", "addon_ids"])
         )
 
     logging.info("Init loading client features")

--- a/mozetl/taar/taar_lite_guidguid.py
+++ b/mozetl/taar/taar_lite_guidguid.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError   # noqa
 from pyspark.sql import Row, SparkSession     # noqa
 from pyspark.sql.functions import col, collect_list, explode, udf, sum as sum_, max as max_, first  # noqa
 from pyspark.sql.types import StructType, StructField, StringType, LongType, IntegerType  # noqa
+from taar_utils import store_json_to_s3
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
@@ -25,48 +26,6 @@ AMO_DUMP_BUCKET = 'telemetry-parquet'
 AMO_DUMP_KEY = 'telemetry-ml/addon_recommender/addons_database.json'
 MAIN_SUMMARY_PATH = 's3://telemetry-parquet/main_summary/v4/'
 ONE_WEEK_AGO = (dt.datetime.now() - dt.timedelta(days=7)).strftime('%Y%m%d')
-
-
-def write_to_s3(source_file_name, s3_dest_file_name, s3_prefix, bucket):
-    """Store the new json file containing current top addons per locale to S3.
-
-    :param source_file_name: The name of the local source file.
-    :param s3_dest_file_name: The name of the destination file on S3.
-    :param s3_prefix: The S3 prefix in the bucket.
-    :param bucket: The S3 bucket.
-    """
-    client = boto3.client('s3', 'us-west-2')
-    transfer = boto3.s3.transfer.S3Transfer(client)
-
-    # Update the state in the analysis bucket.
-    key_path = s3_prefix + s3_dest_file_name
-    transfer.upload_file(source_file_name, bucket, key_path)
-
-
-def store_json_to_s3(json_data, base_filename, date, prefix, bucket):
-    """Saves the JSON data to a local file and then uploads it to S3.
-
-    Two copies of the file will get uploaded: one with as "<base_filename>.json"
-    and the other as "<base_filename><YYYYMMDD>.json" for backup purposes.
-
-    :param json_data: A string with the JSON content to write.
-    :param base_filename: A string with the base name of the file to use for saving
-        locally and uploading to S3.
-    :param date: A date string in the "YYYYMMDD" format.
-    :param prefix: The S3 prefix.
-    :param bucket: The S3 bucket name.
-    """
-    FULL_FILENAME = "{}.json".format(base_filename)
-
-    with open(FULL_FILENAME, "w+") as json_file:
-        json_file.write(json_data)
-
-    archived_file_copy =\
-        "{}{}.json".format(base_filename, date)
-
-    # Store a copy of the current JSON with datestamp.
-    write_to_s3(FULL_FILENAME, archived_file_copy, prefix, bucket)
-    write_to_s3(FULL_FILENAME, FULL_FILENAME, prefix, bucket)
 
 
 # TODO: eventually replace this with the whitelist that Victor is writing ETL for.

--- a/tests/test_taar_lite_guidguid.py
+++ b/tests/test_taar_lite_guidguid.py
@@ -8,10 +8,10 @@ from pyspark.sql import Row  # noqa
 
 """
 Expected schema of co-installation counts dict.
-| -- key_addon: string(nullable=true) 
-| -- coinstallation_counts: array(nullable=true) 
-| | -- element: struct(containsNull=true) 
-| | | -- id: string(nullable=true) 
+| -- key_addon: string(nullable=true)
+| -- coinstallation_counts: array(nullable=true)
+| | -- element: struct(containsNull=true)
+| | | -- id: string(nullable=true)
 | | | -- n: long(nullable=true)
 """
 

--- a/tests/test_taar_lite_guidguid.py
+++ b/tests/test_taar_lite_guidguid.py
@@ -61,12 +61,12 @@ MOCK_KEYED_ADDONS = [
     ]
 
 
-@mock.patch('mozetl.taar.taar_lite_guidguid.load_training_from_telemetry',
+@mock.patch('mozetl.taar.taar_lite_guidguid.extract_telemetry',
             return_value=MOCK_TELEMETRY_SAMPLE)
 @mock_s3
-def test_load_training_from_telemetry(spark):
+def test_extract_telemetry(spark):
     # Sanity check that mocking is happening correctly.
-    assert taar_lite_guidguid.load_training_from_telemetry(spark) == MOCK_TELEMETRY_SAMPLE
+    assert taar_lite_guidguid.extract_telemetry(spark) == MOCK_TELEMETRY_SAMPLE
 
 # Exercise the only part of the ETL job happening outside of spark.
 def test_addon_keying():

--- a/tests/test_taar_lite_guidguid.py
+++ b/tests/test_taar_lite_guidguid.py
@@ -23,17 +23,31 @@ MOCK_TELEMETRY_SAMPLE = [
     Row(installed_addons=["test-guid-1", "test-guid-1"])
 ]
 
-MOCK_ADDON_INSTALLATIONS = {
-    "test-guid-1":
-        {"test-guid-2": 1,
-         "test-guid-3": 2,
-         "test-guid-4": 2
-         },
-    "test-guid-2":
-        {"test-guid-1": 2,
-         "test-guid-5": 1,
-         "test-guid-6": 1
-         }}
+MOCK_ADDON_INSTALLATIONS = [
+        (
+            Row(key_addon='test-guid-1', coinstalled_addons=['test-guid-2', 'test-guid-3', 'test-guid-4']),
+            [Row(key_addon='test-guid-1', coinstalled_addons=['test-guid-3', 'test-guid-4']),
+             Row(key_addon='test-guid-2', coinstalled_addons=['test-guid-1', 'test-guid-5', 'test-guid-6']),
+             Row(key_addon='test-guid-2', coinstalled_addons=['test-guid-1'])]
+        ),
+        (
+            Row(key_addon='test-guid-1', coinstalled_addons=['test-guid-3', 'test-guid-4']),
+            [Row(key_addon='test-guid-1', coinstalled_addons=['test-guid-2', 'test-guid-3', 'test-guid-4']),
+             Row(key_addon='test-guid-2', coinstalled_addons=['test-guid-1', 'test-guid-5', 'test-guid-6']),
+             Row(key_addon='test-guid-2', coinstalled_addons=['test-guid-1'])]
+        ),
+        (
+            Row(key_addon='test-guid-2', coinstalled_addons=['test-guid-1', 'test-guid-5', 'test-guid-6']),
+            [Row(key_addon='test-guid-1', coinstalled_addons=['test-guid-2', 'test-guid-3', 'test-guid-4']),
+             Row(key_addon='test-guid-1', coinstalled_addons=['test-guid-3', 'test-guid-4']),
+             Row(key_addon='test-guid-2', coinstalled_addons=['test-guid-1'])]
+        ),
+        (
+            Row(key_addon='test-guid-2', coinstalled_addons=['test-guid-1']),
+            [Row(key_addon='test-guid-1', coinstalled_addons=['test-guid-2', 'test-guid-3', 'test-guid-4']),
+             Row(key_addon='test-guid-1', coinstalled_addons=['test-guid-3', 'test-guid-4']),
+             Row(key_addon='test-guid-2', coinstalled_addons=['test-guid-1', 'test-guid-5', 'test-guid-6'])]
+        )]
 
 MOCK_KEYED_ADDONS = [
     Row(key_addon='test-guid-1',


### PR DESCRIPTION
This corrects the format of the expected output of .key_all() function.

* The ETL job has also been explicitly split into extract, transform and load functions.
* taar_utils.store_json_to_s3 is now being reused as that was just duplicate code
