### PR TITLE
Reworked the AMO Dump to run completely in memory

### DIFF
--- a/mozetl/taar/taar_amodump.py
+++ b/mozetl/taar/taar_amodump.py
@@ -1,14 +1,9 @@
 #!/bin/env python
 
-from contextlib import contextmanager
 import click
 import json
 import logging
 import logging.config
-import os
-import shutil
-import sys
-import tempfile
 import typing
 import urllib
 import Queue as queue
@@ -26,27 +21,6 @@ DEFAULT_AMO_REQUEST_URI = "https://addons.mozilla.org/api/v3/addons/search/"
 QUERY_PARAMS = "?app=firefox&sort=created&type=extension"
 
 logger = logging.getLogger('amo_database')
-
-
-@contextmanager
-def guid_cache(fpath):
-    """
-    This contextmanager cache uses the filesystem to store
-    JSON blobs that contain a 'guid' key.  Each file is stored simply
-    with the GUID as the filename and '.json' as the extension.
-    """
-    class Cache:
-        def __init__(self, fpath):
-            self._fpath = fpath
-            shutil.rmtree(self._fpath, ignore_errors=True)
-            os.makedirs(self._fpath)
-
-        def put(self, data):
-            guid = data['guid']
-            fname = os.path.join(self._fpath, "%s.json" % guid)
-            with open(fname, 'w') as fout:
-                fout.write(json.dumps(data))
-    yield Cache(fpath)
 
 
 """
@@ -79,23 +53,18 @@ class JSONSchema:
 
 
 class AMOAddonFile(JSONSchema):
-    meta = {
-            'id': int,
+    meta = {'id': int,
             'platform': str,
             'status': str,
-            'is_webextension': bool
-    }
+            'is_webextension': bool}
 
 
 class AMOAddonVersion(JSONSchema):
-    meta = {
-            'files': typing.List[AMOAddonFile]
-    }
+    meta = {'files': typing.List[AMOAddonFile]}
 
 
 class AMOAddonInfo(JSONSchema):
-    meta = {
-            'guid': str,
+    meta = {'guid': str,
             'categories': typing.Dict[str, typing.List[str]],
             'default_locale': str,
             'description': typing.Dict[str, str],
@@ -104,38 +73,15 @@ class AMOAddonInfo(JSONSchema):
             'ratings': typing.Dict[str, float],
             'summary': typing.Dict[str, str],
             'tags': typing.List[str],
-            'weekly_downloads': int
-    }
-
-
-class URLIteratorFactory(object):
-    BATCH_SIZE = 500
-
-    def __init__(self, cache_dir):
-        self._fnames = os.listdir(cache_dir)
-        logger.info("Processing %d GUIDs" % len(self._fnames))
-
-    def generatorFactory(self):
-        data_slice, self._fnames = self._fnames[:self.BATCH_SIZE], self._fnames[self.BATCH_SIZE:]
-        logger.info("%d in current batch. %d remaining URLs" % (len(data_slice), len(self._fnames)))
-        for i, fname in enumerate(data_slice):
-            guid = fname.split(".json")[0]
-            url = "https://addons.mozilla.org/api/v3/addons/addon/%s/versions/" % guid
-            yield url
+            'weekly_downloads': int}
 
 
 class AMODatabase:
-    def __init__(self, root_path, worker_count):
+    def __init__(self, worker_count):
         """
         Just setup the page_count
         """
-
-        self._root_path = root_path
-        logger.info("Writing temp files to : %s" % self._root_path)
         self._max_processes = worker_count
-
-        self._amo_cache_dir = os.path.join(self._root_path, "amo_cache")
-        self._amo_date_cache_dir = os.path.join(self._root_path, "amo_cache_dates")
 
         uri = DEFAULT_AMO_REQUEST_URI + QUERY_PARAMS
         response = requests.get(uri)
@@ -143,91 +89,97 @@ class AMODatabase:
 
         self._page_count = jdata['page_count']
 
-    def fetch_pages(self):
-        with guid_cache(self._amo_cache_dir) as db:
-            urls = []
-            for i in range(1, self._page_count+1):
-                url = "%s%s%s" % (DEFAULT_AMO_REQUEST_URI, QUERY_PARAMS, ("&page=%d" % i))
-                urls.append(url)
-            logger.info("Processing AMO urls")
-            p = pool.Pool.from_urls(urls, num_processes=self._max_processes)
+    def fetch_addons(self):
+        addon_map = self._fetch_pages()
+        self._fetch_versions(addon_map)
+        final_result = {}
+        for k, v in addon_map.items():
+            if 'first_create_date' in v:
+                final_result[k] = v
+        logger.info("Final addon set includes %d addons." % len(final_result))
+        return final_result
+
+    def _fetch_pages(self):
+        addon_map = {}
+
+        urls = []
+        for i in range(1, self._page_count+1):
+            url = "%s%s%s" % (DEFAULT_AMO_REQUEST_URI, QUERY_PARAMS, ("&page=%d" % i))
+            urls.append(url)
+        logger.info("Processing AMO urls")
+        p = pool.Pool.from_urls(urls, num_processes=self._max_processes)
+        p.join_all()
+
+        self._handle_responses(p, addon_map)
+
+        # Try failed requests
+        exceptions = p.exceptions()
+        p = pool.Pool.from_exceptions(exceptions, num_processes=self._max_processes)
+        p.join_all()
+        self._handle_responses(p, addon_map)
+        return addon_map
+
+    def _fetch_versions(self, addon_map):
+
+        logger.info("Processing Version urls")
+
+        q = queue.Queue()
+        logger.info("Filling initial verson page queue")
+
+        def iterFactory(guid_map):
+            for guid in guid_map.keys():
+                yield "https://addons.mozilla.org/api/v3/addons/addon/%s/versions/" % guid
+
+        def chunker(seq, size):
+            collector = []
+            for term in seq:
+                collector.append(term)
+                if len(collector) == size:
+                    yield collector
+                    collector = []
+
+            # Yield any dangling records we collected
+            if len(collector) > 0:
+                yield collector
+
+        total_processed_addons = 0
+        for chunk in chunker(iterFactory(addon_map), 500):
+            for i, url in enumerate(chunk):
+                q.put({'method': 'GET',
+                       'url': url,
+                       'timeout': 2.0})
+            logger.info("Queue setup - processing initial version page requests")
+            logger.info("%d requests to process" % q.qsize())
+
+            p = pool.Pool(q, num_processes=self._max_processes)
+            p.join_all()
+            logger.info("Pool completed - processing responses")
+            last_page_urls = self._handle_version_responses(p)
+            logger.info("Captured %d last page urls" % len(last_page_urls))
+            total_processed_addons += len(last_page_urls)
+
+            # Try processing the exceptions once
+            p = pool.Pool.from_exceptions(p.exceptions(), num_processes=self._max_processes)
+            p.join_all()
+            last_page_urls.extend(self._handle_version_responses(p))
+
+            # Now fetch the last version of each addon
+            logger.info("Processing last page urls: %d" % len(last_page_urls))
+            p = pool.Pool.from_urls(last_page_urls,
+                                    num_processes=self._max_processes)
             p.join_all()
 
-            self._handle_responses(p, db)
+            self._handle_last_version_responses(p, addon_map)
 
-            # Try failed requests
-            exceptions = p.exceptions()
-            p = pool.Pool.from_exceptions(exceptions, num_processes=self._max_processes)
+            # Try processing exceptions once
+            p = pool.Pool.from_exceptions(p.exceptions(), num_processes=self._max_processes)
             p.join_all()
-            self._handle_responses(p, db)
+            self._handle_last_version_responses(p, addon_map)
 
-    def parse_file(self, guid):
-        try:
-            tmpl = os.path.join(self._amo_cache_dir, '%s.json')
-            jbdata = open(tmpl % guid, 'rb').read()
-            data = json.loads(jbdata.decode('utf8'))
-            result = marshal(data, None, AMOAddonInfo)
-        except Exception as exc:
-            logger.error("Error parsing addon json. GUID: %s, %s" % (guid, str(exc)))
-            return None
+            logger.info("Processed %d addons with version info" %
+                        total_processed_addons)
 
-        try:
-            tmpl = os.path.join(self._amo_date_cache_dir, '%s.json')
-            jbdata = open(tmpl % guid, 'rb').read()
-            data = json.loads(jbdata.decode('utf8'))
-            result['first_create_date'] = data['create_date']
-            return result
-        except ValueError:
-            logger.warn("Error parsing version json. GUID: %s" % guid)
-            return None
-
-    def fetch_versions(self):
-
-        with guid_cache(self._amo_date_cache_dir) as date_db:
-            logger.info("Processing Version urls")
-
-            q = queue.Queue()
-            logger.info("Filling initial verson page queue")
-
-            iterFactory = URLIteratorFactory(self._amo_cache_dir)
-            while True:
-                url_gen = iterFactory.generatorFactory()
-                for i, url in enumerate(url_gen):
-                    q.put({'method': 'GET',
-                           'url': url,
-                           'timeout': 2.0})
-                logger.info("Queue setup - processing initial version page requests")
-                logger.info("%d requests to process" % q.qsize())
-                if q.qsize() == 0:
-                    logger.info("Finished processing version URLs")
-                    break
-                p = pool.Pool(q, num_processes=self._max_processes)
-                p.join_all()
-                logger.info("Pool completed - processing responses")
-                last_page_urls = self._handle_version_responses(p)
-                logger.info("Captured %d last page urls" % len(last_page_urls))
-
-                # Try processing the exceptions once
-                p = pool.Pool.from_exceptions(p.exceptions(), num_processes=self._max_processes)
-                p.join_all()
-                last_page_urls.extend(self._handle_version_responses(p))
-
-                # Now fetch the last version of each addon
-                logger.info("Processing Last page urls: %d" % len(last_page_urls))
-                p = pool.Pool.from_urls(last_page_urls,
-                                        num_processes=self._max_processes)
-                p.join_all()
-
-                logger.info("Writing create dates")
-                last_versions = self._handle_last_version_responses(p, date_db)
-
-                # Try processing exceptions once
-                p = pool.Pool.from_exceptions(p.exceptions(), num_processes=self._max_processes)
-                p.join_all()
-                last_versions.extend(self._handle_last_version_responses(p, date_db))
-
-    def _handle_last_version_responses(self, p, db):
-        guids = []
+    def _handle_last_version_responses(self, p, addon_map):
         for i, resp in enumerate(p.responses()):
             try:
                 if resp.status_code == 200:
@@ -238,29 +190,30 @@ class AMODatabase:
                     guid = urllib.unquote(raw_guid)
                     create_date = results[-1]['files'][0]['created']
 
-                    record = {'guid': guid, 'create_date': create_date}
-                    db.put(record)
-                    guids.append(guid)
+                    record = addon_map.get(guid, None)
+                    if record is not None:
+                        record['first_create_date'] = create_date
             except Exception as e:
                 # Skip this record
                 logger.error(e)
-        return guids
+        return addon_map
 
-    def _handle_responses(self, p, db):
-        guids = []
+    def _handle_responses(self, p, addon_map):
+        i = 0
         for resp in p.responses():
             try:
                 if resp.status_code == 200:
                     jdata = json.loads(resp.content.decode('utf8'))
                     results = jdata['results']
                     for record in results:
+                        if i % 500 == 0:
+                            logger.info("Still parsing  addons...")
                         guid = record['guid']
-                        guids.append(guid)
-                        db.put(record)
+                        addon_map[guid] = record
+                    i += 1
             except Exception as e:
                 # Skip this record
                 logger.error(e)
-        return guids
 
     def _handle_version_responses(self, p):
         page_urls = []
@@ -324,49 +277,24 @@ def marshal(value, name, type_def):
 
 
 @click.command()
-@click.option("--path", default=tempfile.mkdtemp())
 @click.option("--date", required=True)
 @click.option("--workers", default=100)
 @click.option("--s3-prefix", default=AMO_DUMP_PREFIX)
 @click.option("--s3-bucket", default=AMO_DUMP_BUCKET)
-def main(path, date, workers, s3_prefix, s3_bucket):
-    amodb = AMODatabase(path, int(workers))
-    amodb.fetch_pages()
-    amodb.fetch_versions()
+def main(date, workers, s3_prefix, s3_bucket):
+    amodb = AMODatabase(int(workers))
+
+    addon_map = amodb.fetch_addons()
+
     try:
-        large_blob = {}
-
-        successful = 0
-        for i, fname in enumerate(os.listdir(amodb._amo_cache_dir)):
-            guid = fname.split(".json")[0]
-            client_blob = amodb.parse_file(guid)
-
-            if client_blob is None:
-                continue
-
-            large_blob[guid] = client_blob
-            successful += 1
-
-            if i > 0 and i % 200 == 0:
-                sys.stdout.write('.')
-                sys.stdout.flush()
-
-        fail_rate = 1.0 - (successful * 1.0 / len(os.listdir(amodb._amo_cache_dir)))
-        if fail_rate >= 0.01:
-            msg = "Unexpectedly high failure rate for merging versions with addon JSON.  %0.4f"
-            logger.error(msg % (fail_rate))
-            sys.exit(1)
-        else:
-            logger.info("Version merging failure rate: %0.4f" % fail_rate)
-
-        store_json_to_s3(json.dumps(large_blob),
+        store_json_to_s3(json.dumps(addon_map),
                          AMO_DUMP_FILENAME,
                          date,
                          s3_prefix,
                          s3_bucket)
-    finally:
-        logger.info("Cleaning up and removing : %s" % path)
-        shutil.rmtree(path, ignore_errors=True)
+        logger.info("Completed uploading s3://%s/%s%s.json" % (s3_bucket, s3_prefix, AMO_DUMP_FILENAME))
+    except Exception as e:
+        logger.error("Error uploading data to S3", e)
 
 
 if __name__ == '__main__':

--- a/mozetl/taar/taar_amodump.py
+++ b/mozetl/taar/taar_amodump.py
@@ -104,7 +104,7 @@ class AMODatabase:
 
         urls = []
         for i in range(1, self._page_count+1):
-            url = "%s%s%s" % (DEFAULT_AMO_REQUEST_URI, QUERY_PARAMS, ("&page=%d" % i))
+            url = "{0}{1}&page={2}".format(DEFAULT_AMO_REQUEST_URI, QUERY_PARAMS, i)
             urls.append(url)
         logger.info("Processing AMO urls")
         p = pool.Pool.from_urls(urls, num_processes=self._max_processes)
@@ -292,7 +292,9 @@ def main(date, workers, s3_prefix, s3_bucket):
                          date,
                          s3_prefix,
                          s3_bucket)
-        logger.info("Completed uploading s3://%s/%s%s.json" % (s3_bucket, s3_prefix, AMO_DUMP_FILENAME))
+        logger.info("Completed uploading s3://%s/%s%s.json" % (s3_bucket,
+                                                               s3_prefix,
+                                                               AMO_DUMP_FILENAME))
     except Exception as e:
         logger.error("Error uploading data to S3", e)
 


### PR DESCRIPTION
This reworks the taar_amodump job to run completely in memory and not write any temporary files to disk.

cc/ @acmiyaguchi 