### PR TITLE
Explicitly exclude 'Firefox Pioneer' addon from TAARlite

### DIFF
--- a/mozetl/taar/taar_amowhitelist.py
+++ b/mozetl/taar/taar_amowhitelist.py
@@ -53,6 +53,7 @@ class AMOTransformer:
         * At least 3.0 average rating or higher
         * At least 60 days old as computed using the
           'first_create_date' field in the addon JSON
+        * Not the Firefox Pioneer addon
 
         Criteria are discussed over at :
           https://github.com/mozilla/taar-lite/issues/1
@@ -62,12 +63,15 @@ class AMOTransformer:
         latest_create_date = latest_create_date.replace(tzinfo=None)
 
         new_data = {}
-        for k in json_data.keys():
-            rating = json_data[k]['ratings']['average']
-            create_date = parse(json_data[k]['first_create_date']).replace(tzinfo=None)
+        for guid in json_data.keys():
+            rating = json_data[guid]['ratings']['average']
+            create_date = parse(json_data[guid]['first_create_date']).replace(tzinfo=None)
+            if guid == 'pioneer-opt-in@mozilla.org':
+                # Firefox Pioneer is explicitly excluded
+                continue
 
             if rating >= self._min_rating and create_date <= latest_create_date:
-                new_data[k] = json_data[k]
+                new_data[guid] = json_data[guid]
 
         return new_data
 

--- a/mozetl/taar/taar_lite_guidguid.py
+++ b/mozetl/taar/taar_lite_guidguid.py
@@ -68,7 +68,11 @@ def extract_telemetry(spark):
                 addon.user_disabled or
                 addon.foreign_install or
                 # make sure the amo_whitelist has been broadcast to worker nodes.
-                guid not in broadcast_amo_whitelist.value
+                guid not in broadcast_amo_whitelist.value or
+
+                # Make sure that the Pioneer addon is explicitly
+                # excluded
+                guid != "pioneer-opt-in@mozilla.org"
             )
 
         # TODO: may need additional whitelisting to remove shield addons


### PR DESCRIPTION
This addresses https://github.com/mozilla/taar-lite/issues/9

TAARlite should not whitelist the Firefox Pioneer addon, and it should not consider the Firefox Pioneer add-on when querying for add-on suggestions.

cc/ @mlopatka 