### PR TITLE
Exclude legacy extensions in the AMO whitelist

### DIFF
--- a/mozetl/taar/taar_amowhitelist.py
+++ b/mozetl/taar/taar_amowhitelist.py
@@ -63,9 +63,7 @@ class AMOTransformer:
         latest_create_date = latest_create_date.replace(tzinfo=None)
 
         new_data = {}
-        for guid in json_data.keys():
-            addon_data = json_data[guid]
-
+        for guid, addon_data in json_data.items():
             if guid == 'pioneer-opt-in@mozilla.org':
                 # Firefox Pioneer is explicitly excluded
                 continue
@@ -74,13 +72,13 @@ class AMOTransformer:
             if len(current_version_files) == 0:
                 # Only allow webextensions
                 continue
-            else:
-                if current_version_files[0].get('is_webextension', False) is False:
-                    # Only allow webextensions
-                    continue
 
-            rating = addon_data['ratings']['average']
-            create_date = parse(addon_data['first_create_date']).replace(tzinfo=None)
+            if current_version_files[0].get('is_webextension', False) is False:
+                # Only allow webextensions
+                continue
+
+            rating = addon_data.get('ratings', {}).get('average', 0)
+            create_date = parse(addon_data.get('first_create_date', None)).replace(tzinfo=None)
 
             if rating >= self._min_rating and create_date <= latest_create_date:
                 new_data[guid] = json_data[guid]

--- a/mozetl/taar/taar_amowhitelist.py
+++ b/mozetl/taar/taar_amowhitelist.py
@@ -75,7 +75,7 @@ class AMOTransformer:
                 # Only allow webextensions
                 continue
             else:
-                if False == current_version_files[0].get('is_webextension', False):
+                if current_version_files[0].get('is_webextension', False) is False:
                     # Only allow webextensions
                     continue
 

--- a/mozetl/taar/taar_amowhitelist.py
+++ b/mozetl/taar/taar_amowhitelist.py
@@ -64,11 +64,23 @@ class AMOTransformer:
 
         new_data = {}
         for guid in json_data.keys():
-            rating = json_data[guid]['ratings']['average']
-            create_date = parse(json_data[guid]['first_create_date']).replace(tzinfo=None)
+            addon_data = json_data[guid]
+
             if guid == 'pioneer-opt-in@mozilla.org':
                 # Firefox Pioneer is explicitly excluded
                 continue
+
+            current_version_files = addon_data.get('current_version', {}).get('files', [])
+            if len(current_version_files) == 0:
+                # Only allow webextensions
+                continue
+            else:
+                if False == current_version_files[0].get('is_webextension', False):
+                    # Only allow webextensions
+                    continue
+
+            rating = addon_data['ratings']['average']
+            create_date = parse(addon_data['first_create_date']).replace(tzinfo=None)
 
             if rating >= self._min_rating and create_date <= latest_create_date:
                 new_data[guid] = json_data[guid]

--- a/mozetl/taar/taar_lite_guidguid.py
+++ b/mozetl/taar/taar_lite_guidguid.py
@@ -33,15 +33,13 @@ def extract_telemetry(spark):
 
     # Define the set of feature names to be used in the donor computations.
 
-    def get_initial_sample(pct_sample=10):
+    def get_initial_sample():
         """ Takes an initial sample from the longitudinal dataset
         (randomly sampled from main summary). Coarse filtering on:
         - number of installed addons (greater than 1)
         - corrupt and generally wierd telemetry entries
         - isolating release channel
         - column selection
-        -
-        - pct_sample is an integer [1, 100] indicating sample size
         """
         # Could scale this up to grab more than what is in
         # longitudinal and see how long it takes to run.

--- a/tests/test_taar_amowhitelist.py
+++ b/tests/test_taar_amowhitelist.py
@@ -317,10 +317,11 @@ def test_transform(s3_fixture):
                                            taar_amowhitelist.MIN_RATING,
                                            taar_amowhitelist.MIN_AGE)
     final_jdata = etl.transform(data)
-    assert len(final_jdata) == 2
+    assert len(final_jdata) == 1
 
     today = datetime.datetime.today().replace(tzinfo=None)
     for client_data in final_jdata.values():
+        assert client_data['current_version']['files'][0]['is_webextension']
         assert client_data['ratings']['average'] >= taar_amowhitelist.MIN_RATING
         create_datetime = parse(client_data['first_create_date']).replace(tzinfo=None)
         assert create_datetime + datetime.timedelta(days=taar_amowhitelist.MIN_AGE) < today

--- a/tests/test_taar_amowhitelist.py
+++ b/tests/test_taar_amowhitelist.py
@@ -7,6 +7,8 @@ from moto import mock_s3
 from dateutil.parser import parse
 import datetime
 
+# This SAMPLE_DATA blob is a copy of some sample data that was
+# extracted from the AMO JSON API.
 SAMPLE_DATA = {
     "gnome-download-notify@ion201": {
         "categories": {


### PR DESCRIPTION
The TAAR addon whitelist was including legacy addons by mistake.  This filters the list further ensuring that an `is_webextension` flag exists and is true for each addon in the whitelist.