### PR TITLE
Pioneer filtering was invalid causing the RDD to have no rows.

### DIFF
--- a/mozetl/taar/taar_lite_guidguid.py
+++ b/mozetl/taar/taar_lite_guidguid.py
@@ -72,7 +72,7 @@ def extract_telemetry(spark):
 
                 # Make sure that the Pioneer addon is explicitly
                 # excluded
-                guid != "pioneer-opt-in@mozilla.org"
+                guid == "pioneer-opt-in@mozilla.org"
             )
 
         # TODO: may need additional whitelisting to remove shield addons


### PR DESCRIPTION
I didn't notice that the `is_valid_addon` method was negated at the start.  The filter for the pioneer GUID caused `is_valid_addon` to always return False breaking the generation of the add-on coinstallation data.

cc/ @mlopatka 