### PR TITLE
ETL for a featured addon JSON file

### DIFF
--- a/mozetl/taar/taar_amowhitelist.py
+++ b/mozetl/taar/taar_amowhitelist.py
@@ -125,6 +125,9 @@ class AMOTransformer:
 
         return self.get_whitelist()
 
+    def get_featuredlist(self):
+        return self._accumulators['featured'].get_results()
+
     def get_whitelist(self):
         return self._accumulators['whitelist'].get_results()
 

--- a/mozetl/taar/taar_amowhitelist.py
+++ b/mozetl/taar/taar_amowhitelist.py
@@ -68,7 +68,8 @@ class WhitelistAccumulator(AbstractAccumulator):
         self._min_age = min_age
         self._min_rating = min_rating
 
-        self._latest_create_date = datetime.datetime.today() - datetime.timedelta(days=self._min_age)
+        self._latest_create_date = datetime.datetime.today() - \
+                                   datetime.timedelta(days=self._min_age)  # noqa
         self._latest_create_date = self._latest_create_date.replace(tzinfo=None)
 
     def process_record(self, guid, addon_data):


### PR DESCRIPTION
This refactors the existing taar_amowhitelist job to upload two separate JSON files - one with the existing whitelist file, and the other is a list of all featured addons on AMO.

Test cases have been updated accordingly.

This should close off #233 and #234