### PR TITLE
Features/236 generic whitelist

### DIFF
--- a/mozetl/taar/taar_amowhitelist.py
+++ b/mozetl/taar/taar_amowhitelist.py
@@ -125,6 +125,9 @@ class AMOTransformer:
 
         return self.get_whitelist()
 
+    def get_featuredlist(self):
+        return self._accumulators['featured'].get_results()
+
     def get_whitelist(self):
         return self._accumulators['whitelist'].get_results()
 

--- a/mozetl/taar/taar_lite_guidguid.py
+++ b/mozetl/taar/taar_lite_guidguid.py
@@ -67,6 +67,7 @@ def extract_telemetry(spark):
                 addon.foreign_install or
                 # make sure the amo_whitelist has been broadcast to worker nodes.
                 guid not in broadcast_amo_whitelist.value or
+                guid not in broadcast_amo_taarlite_whitelist.value or
 
                 # Make sure that the Pioneer addon is explicitly
                 # excluded
@@ -93,8 +94,14 @@ def extract_telemetry(spark):
     amo_white_list = taar_utils.load_amo_external_whitelist()
     logging.info("AMO White list loaded")
 
+    amo_taarlite_white_list = taar_utils.load_amo_taarlite_whitelist()
+    logging.info("AMO TAARlite White list loaded")
+
     broadcast_amo_whitelist = sc.broadcast(amo_white_list)
     logging.info("Broadcast AMO whitelist success")
+
+    broadcast_amo_taarlite_whitelist = sc.broadcast(amo_taarlite_white_list)
+    logging.info("Broadcast AMO TAARlite whitelist success")
 
     addons_info_frame = get_addons_per_client(client_features_frame)
     logging.info("Filtered for valid addons only.")


### PR DESCRIPTION
WIP: Do not merge

This is based on #235 and adds an extra whitelist to check against for the TAARlite guid-guid model generation and addresses #236.

The final criteria for whitelisting addons that may participate in TAAR is uncertain, so I've added a optional JSON file that can be used to further constrain the addon GUIDs that are valid for model generation. 