### PR TITLE
Include new bookmarks engine results in Sync validation views

### DIFF
--- a/mozetl/sync/bookmark_validation.py
+++ b/mozetl/sync/bookmark_validation.py
@@ -60,7 +60,7 @@ def transform(spark):
 
     bookmark_validations = (
         engine_validations
-        .where(F.col("engine_name") == "bookmarks")
+        .where(F.col("engine_name").isin("bookmarks", "bookmarks-buffered"))
     )
 
     bookmark_validation_problems = (

--- a/tests/test_sync_bookmark.py
+++ b/tests/test_sync_bookmark.py
@@ -246,14 +246,47 @@ def test_validation_problems(test_transform):
                 }
             ]
         },
+        # new bookmarks engine with problems
+        {
+            'failure_reason': None,
+            'engines': [{
+                'name': 'bookmarks-buffered',
+                'validation': {
+                    'problems': [{
+                        'name': 'new problem',
+                        'count': 50,
+                    }, {
+                        'name': 'another problem',
+                        'count': 4,
+                    }],
+                },
+            }],
+        },
+        # new bookmarks engine without problems
+        {
+            'failure_reason': None,
+            'engines': [{
+                'name': 'bookmarks-buffered',
+                'validation': {'problems': None},
+            }],
+        },
     ])
 
-    assert df.count() == 4
-
-    # one hot encode the cases
+    assert df.count() == 6
     assert df.select(
         F.sum('engine_validation_problem_count').alias('pcount')
+    ).first().pcount == 1165
+
+    assert df.where(
+        F.col('engine_name') == 'bookmarks'
+    ).select(
+        F.sum('engine_validation_problem_count').alias('pcount')
     ).first().pcount == 1111
+    assert df.where(
+        F.col('engine_name') == 'bookmarks-buffered'
+    ).select(
+        F.sum('engine_validation_problem_count').alias('pcount')
+    ).first().pcount == 54
 
 
 def test_total_bookmarks_checked(test_transform):


### PR DESCRIPTION
Hi! We're currently [testing](https://bugzilla.mozilla.org/show_bug.cgi?id=1456221) a new bookmarks engine in Nightly. It reports the same validation results as the current `bookmarks` engine, and we'd like to include them in the `bmk_validation_problems` and `bmk_total_per_day` views, so that we can compare corruption rates for the two.

@acmiyaguchi r?