### PR TITLE
Added a loader for the curated amo whitelist

### DIFF
--- a/mozetl/taar/taar_locale.py
+++ b/mozetl/taar/taar_locale.py
@@ -13,7 +13,8 @@ import logging
 
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col
-from taar_utils import store_json_to_s3, load_amo_external_whitelist
+from taar_utils import store_json_to_s3
+from taar_utils import load_amo_curated_whitelist
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -131,7 +132,7 @@ def generate_dictionary(spark, num_addons):
     addon_df = get_addons(spark)
 
     # Load external whitelist based on AMO data.
-    amo_whitelist = load_amo_external_whitelist()
+    amo_whitelist = load_amo_curated_whitelist()
 
     # Filter to include only addons present in AMO whitelist.
     addon_df_filtered = addon_df.where(col("addon_key").isin(amo_whitelist))

--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -20,7 +20,9 @@ from pyspark.ml.clustering import BisectingKMeans
 from pyspark.ml import Pipeline
 from pyspark.mllib.stat import KernelDensity
 from scipy.spatial import distance
-from taar_utils import store_json_to_s3, load_amo_external_whitelist
+from taar_utils import store_json_to_s3
+from taar_utils import load_amo_curated_whitelist
+from taar_utils import read_from_s3
 
 # Define the set of feature names to be used in the donor computations.
 CATEGORICAL_FEATURES = ["geo_city", "locale", "os"]
@@ -61,6 +63,7 @@ def get_addons_per_client(users_df, addon_whitelist, minimum_addons_count):
     """ Extracts a DataFrame that contains one row
     for each client along with the list of active add-on GUIDs.
     """
+
     def is_valid_addon(guid, addon):
         return not (
             addon.is_system or
@@ -316,7 +319,7 @@ def main(date, bucket, prefix, num_clusters, num_donors, kernel_bandwidth, num_p
         num_donors = 100
 
     logger.info("Loading the AMO whitelist...")
-    whitelist = load_amo_external_whitelist()
+    whitelist = load_amo_curated_whitelist()
 
     logger.info("Computing the list of donors...")
 

--- a/mozetl/taar/taar_utils.py
+++ b/mozetl/taar/taar_utils.py
@@ -119,3 +119,13 @@ def load_amo_external_whitelist():
         raise RuntimeError("Empty AMO whitelist detected")
 
     return final_whitelist
+
+
+def load_amo_curated_whitelist():
+    """
+    Return the curated whitelist of addon GUIDs
+    """
+    whitelist = read_from_s3('only_guids_top_200.json',
+                             'telemetry-ml/addon_recommender/', 
+                             'telemetry-parquet')
+    return list(whitelist)


### PR DESCRIPTION
This adds an extra loader function to fetch the curated list of ~200 approved AMO addon GUIDs.

We also update :
 * taar_similarity to use the curated whitelist of 200 addons
 *  taar_locale to use amo curated whitelist

cc/ @mlopatka 