### PR TITLE
 Bug 1485049 - Upgrade pyspark used in python_mozetl's test environment to 2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,15 +24,12 @@ install_dependencies: &install_dependencies
     pip install tox coverage
 
 save_cache_settings: &save_cache_settings
-  key: python_mozetl-{{ .Branch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+  key: v1-python_mozetl-{{ checksum "setup.py" }}
   paths:
     - ~/python_mozetl/.tox
 
 restore_cache_settings: &restore_cache_settings
-  keys:
-    - python_mozetl-{{ .Branch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
-    - python_mozetl-{{ .Branch }}
-    - python_mozetl-
+  key: v1-python_mozetl-{{ checksum "setup.py" }}
 
 early_return_for_skip_tests: &early_return_for_skip_tests
   name: Early return if the latest non-merge commit message contains "[skip-tests]"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'click==6.7',
         'click_datetime==0.2',
         'numpy==1.13.3',
-        'pyspark==2.2.0.post0',
+        'pyspark==2.3.1',
         'pyspark_hyperloglog==2.1.1',
         'python_moztelemetry==0.8.9',
         'requests-toolbelt==0.8.0',


### PR DESCRIPTION
The `.tox` cache is not updated to reflect new dependencies in the setup and subsequently breaks tests. This removes the per-branch, per-workflow, and fallback cache and replaces it with the checksum of `setup.py`. Locally, I would run `tox -r` to rebuild the dependencies on issues. It only adds a a minute or two to download all the dependencies from pypi. 