### PR TITLE
Updated taar locale and taar similarity jobs to work around longitudinal dataset

### DIFF
--- a/mozetl/taar/taar_locale.py
+++ b/mozetl/taar/taar_locale.py
@@ -142,7 +142,7 @@ def generate_dictionary(spark, num_addons, longitudinal_override):
     amo_whitelist = load_amo_curated_whitelist()
 
     # Filter to include only addons present in AMO whitelist.
-    addon_df_filtered = addon_df.where(col("addon_key").isin(amo_whitelist))
+    addon_df_filtered = addon_df.where(col("addon_key").isin(amo_whitelist)).persist()
 
     # Make sure not to include addons from very small locales.
     locale_pop_threshold = compute_threshold(addon_df_filtered)

--- a/mozetl/taar/taar_locale.py
+++ b/mozetl/taar/taar_locale.py
@@ -32,17 +32,17 @@ def get_addons(spark, longitudinal_override):
     """
     if longitudinal_override:
         df = spark.read.parquet(longitudinal_override)
-        df.registerDataFrameAsTable(df, "taar_longitudinal")
-    else:
-        df = spark.sql("SELECT * FROM longitudinal")
-        df.registerDataFrameAsTable(df, "taar_longitudinal")
+        df.createOrReplaceTempView("longitudinal")
+
+    count = spark.sql("SELECT client_id from longitudinal").count()
+    print("Longitudinal dataset has {} rows".format(count))
 
     return spark.sql("""
         WITH sample AS (
         SELECT client_id,
         settings[0].locale AS locality,
         EXPLODE(active_addons[0])
-        FROM taar_longitudinal
+        FROM longitudinal
         WHERE normalized_channel='release'
           AND build IS NOT NULL
           AND build[0].application_name='Firefox'

--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -153,9 +153,9 @@ def get_donors(spark, num_clusters, num_donors, addon_whitelist, longitudinal_ov
     users_sample = get_samples(spark, longitudinal_override).persist()
     # Get add-ons from selected users and make sure they are
     # useful for making a recommendation.
-    addons_df = get_addons_per_client(users_sample, addon_whitelist, 2)
+    addons_df = get_addons_per_client(users_sample, addon_whitelist, 2).persist()
     # Perform clustering by using the add-on info.
-    clusters = compute_clusters(addons_df, num_clusters, random_seed)
+    clusters = compute_clusters(addons_df, num_clusters, random_seed).persist()
     # Sample representative ("donors") users from each cluster.
     cluster_ids, donors_df =\
         get_donor_pools(users_sample, clusters, num_donors, random_seed)

--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -39,13 +39,10 @@ def get_samples(spark, longitudinal_override):
 
     if longitudinal_override:
         df = spark.read.parquet(longitudinal_override)
-        df.registerDataFrameAsTable(df, "taar_longitudinal")
-    else:
-        df = spark.sql("SELECT * FROM longitudinal")
-        df.registerDataFrameAsTable(df, "taar_longitudinal")
+        df.createOrReplaceTempView("longitudinal")
 
     return (
-        spark.sql("SELECT * FROM taar_longitudinal")
+        spark.sql("SELECT * FROM longitudinal")
         .where("active_addons IS NOT null")
         .where("size(active_addons[0]) > 2")
         .where("size(active_addons[0]) < 100")
@@ -153,7 +150,7 @@ def get_donor_pools(users_df, clusters_df, num_donors, random_seed=None):
 
 def get_donors(spark, num_clusters, num_donors, addon_whitelist, longitudinal_override, random_seed=None):
     # Get the data for the potential add-on donors.
-    users_sample = get_samples(spark, longitudinal_override)
+    users_sample = get_samples(spark, longitudinal_override).persist()
     # Get add-ons from selected users and make sure they are
     # useful for making a recommendation.
     addons_df = get_addons_per_client(users_sample, addon_whitelist, 2)

--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -32,12 +32,20 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def get_samples(spark):
+def get_samples(spark, longitudinal_override):
     """ Get a DataFrame with a valid set of sample to base the next
     processing on.
     """
+
+    if longitudinal_override:
+        df = spark.read.parquet(longitudinal_override)
+        df.registerDataFrameAsTable(df, "taar_longitudinal")
+    else:
+        df = spark.sql("SELECT * FROM longitudinal")
+        df.registerDataFrameAsTable(df, "taar_longitudinal")
+
     return (
-        spark.sql("SELECT * FROM longitudinal")
+        spark.sql("SELECT * FROM taar_longitudinal")
         .where("active_addons IS NOT null")
         .where("size(active_addons[0]) > 2")
         .where("size(active_addons[0]) < 100")
@@ -143,9 +151,9 @@ def get_donor_pools(users_df, clusters_df, num_donors, random_seed=None):
     return clusters, donor_pool_df
 
 
-def get_donors(spark, num_clusters, num_donors, addon_whitelist, random_seed=None):
+def get_donors(spark, num_clusters, num_donors, addon_whitelist, longitudinal_override, random_seed=None):
     # Get the data for the potential add-on donors.
-    users_sample = get_samples(spark)
+    users_sample = get_samples(spark, longitudinal_override)
     # Get add-ons from selected users and make sure they are
     # useful for making a recommendation.
     addons_df = get_addons_per_client(users_sample, addon_whitelist, 2)
@@ -306,7 +314,8 @@ def get_lr_curves(spark, features_df, cluster_ids, kernel_bandwidth,
 @click.option('--num_donors', default=1000)
 @click.option('--kernel_bandwidth', default=0.35)
 @click.option('--num_pdf_points', default=1000)
-def main(date, bucket, prefix, num_clusters, num_donors, kernel_bandwidth, num_pdf_points):
+@click.option('--longitudinal_override', default=None)
+def main(date, bucket, prefix, num_clusters, num_donors, kernel_bandwidth, num_pdf_points, longitudinal_override):
     spark = (SparkSession
              .builder
              .appName("taar_similarity")
@@ -323,7 +332,7 @@ def main(date, bucket, prefix, num_clusters, num_donors, kernel_bandwidth, num_p
     logger.info("Computing the list of donors...")
 
     # Compute the donors clusters and the LR curves.
-    cluster_ids, donors_df = get_donors(spark, num_clusters, num_donors, whitelist)
+    cluster_ids, donors_df = get_donors(spark, num_clusters, num_donors, whitelist, longitudinal_override)
     lr_curves = get_lr_curves(spark, donors_df, cluster_ids, kernel_bandwidth,
                               num_pdf_points)
 

--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -181,6 +181,10 @@ def get_donors(spark,
     cluster_ids, donors_df =\
         get_donor_pools(users_sample, clusters, num_donors, random_seed)
 
+    logger.info("donors_df count: %d" % donors_df.count())
+    for obj in donors_df.take(5):
+        logger.debug(str(obj))
+
     # Finally, get the feature vectors for users that represent
     # each cluster. Since the "active_addons" in "users_sample"
     # are in a |MapType| and contain system add-ons as well, just


### PR DESCRIPTION
The longitudinal dataset is currently broken, so the taar locale and similarity jobs were rewritten to use an alternate datasource.

More logging has also been added to aid in setting the parameters for the similarity job.