### PR TITLE
Fix for intermittent TAAR test case failures

### DIFF
--- a/mozetl/taar/taar_locale.py
+++ b/mozetl/taar/taar_locale.py
@@ -45,6 +45,7 @@ def get_addons(spark):
         SELECT locality, key AS addon_key FROM sample
         WHERE value['blocklisted'] = FALSE -- not blocklisted
           AND value['type'] = 'extension' -- nice webextensions only
+          AND value['foreign_install'] = FALSE  -- not sideloaded
           AND value['signed_state'] = 2 -- fully reviewed addons only
           AND value['user_disabled'] = FALSE -- active addons only get counted
           AND value['app_disabled'] = FALSE -- exclude compatibility disabled addons


### PR DESCRIPTION
Some TAAR test cases were failing due to odd behavior in PySpark after the upgrade from 2.2 to 2.3.1

Issue details are here: https://github.com/mozilla/taar/issues/114

This adds a `df.cache()` invocation which seems to force the dataframe to load properly when running under test.

Note that this issue has never manifested itself in production, just under test so I suspect that this is some kind of issue with `.createOrReplaceTempView` when the longitudinal table is being replaced. 