### PR TITLE
Bug 1486435 - Fix search aggregates hll

### DIFF
--- a/mozetl/search/aggregates.py
+++ b/mozetl/search/aggregates.py
@@ -104,7 +104,7 @@ def search_aggregates(main_summary):
             'submission_date',
             'default_search_engine',
         ],
-        [expr("hll_cardinality(hll_merge(hll)) as client_count")]
+        [expr("hll_merge(hll) as client_count_hll")]
     ).where(col('engine').isNotNull())
 
 

--- a/tests/test_search_aggregates.py
+++ b/tests/test_search_aggregates.py
@@ -274,7 +274,6 @@ def expected_search_dashboard_data(define_dataframe_factory):
         ('sap', 4, LongType(), True),
         ('organic', None, LongType(), True),
         ('unknown', None, LongType(), True),
-        ('client_count', 1, LongType(), True),
     ]))
 
     return factory([
@@ -410,6 +409,11 @@ def test_basic_aggregation(main_summary,
                            expected_search_dashboard_data,
                            df_equals):
     actual = search_aggregates(main_summary)
+    # it is too complicated to test the contents of the client count hll
+    # (it's essentially an inscrutable binary blob), so just verify it's there
+    # and of the appropriate type, then drop it to do the actual comparison
+    assert ('client_count_hll', 'binary') in actual.dtypes
+    actual = actual.drop('client_count_hll')
     assert df_equals(actual, expected_search_dashboard_data)
 
 


### PR DESCRIPTION
We want the user of this column to get the cardinality, otherwise there is a risk
that people will accidentally get wrong results when combining across dimensions.