### PR TITLE
Remove taar_legacy from the cli

### DIFF
--- a/mozetl/cli.py
+++ b/mozetl/cli.py
@@ -14,7 +14,7 @@ from mozetl.search.aggregates import (
 )
 from mozetl.sync import bookmark_validation
 from mozetl.taar import (
-    taar_locale, taar_similarity, taar_legacy,
+    taar_locale, taar_similarity,
     taar_dynamo, taar_amodump, taar_amowhitelist,
     taar_lite_guidguid, taar_lite_guidranking
 )
@@ -36,7 +36,6 @@ entry_point.add_command(search_rollups.main, "search_rollup")
 entry_point.add_command(bookmark_validation.main, "sync_bookmark_validation")
 entry_point.add_command(taar_locale.main, "taar_locale")
 entry_point.add_command(taar_similarity.main, "taar_similarity")
-entry_point.add_command(taar_legacy.main, "taar_legacy")
 entry_point.add_command(taar_lite_guidguid.main, "taar_lite")
 entry_point.add_command(taar_dynamo.main, "taar_dynamo")
 entry_point.add_command(taar_amodump.main, "taar_amodump")


### PR DESCRIPTION
I'm merging this to fix an import issue that was inadvertently introduced in #267.