### PR TITLE
Refactor taar_locale to include weights.

### DIFF
--- a/mozetl/taar/taar_locale.py
+++ b/mozetl/taar/taar_locale.py
@@ -11,9 +11,11 @@ locale after filtering for good candidates (e.g. no unsigned, no disabled,
 import click
 import json
 import logging
+import pyspark.sql.functions as f
 
-from pyspark.sql import SparkSession
-from pyspark.sql.functions import col
+from pyspark.sql import SparkSession, Row
+from pyspark.sql.functions import col, rank
+from pyspark.sql.window import Window
 from taar_utils import store_json_to_s3
 from taar_utils import load_amo_curated_whitelist
 
@@ -95,48 +97,85 @@ def compute_threshold(addon_df):
     # small number of addons installations.
     locale_pop_threshold =\
         addon_install_counts.approxQuantile('sum(pair_cnts)', [0.25], 0.2)[0]
-
+    
     # Safety net in case the distribution gets really skewed, we should
     # require 2000 addon installation instances to make recommendations.
-    return 2000 if locale_pop_threshold < 2000 else locale_pop_threshold
+    if locale_pop_threshold < 2000:
+        locale_pop_threshold = 2000
+    
+    # Filter the list to only include locales including a sufficient
+    # number of addon installations. Include number of addons in locales
+    # that satisfy the threshold condition.
+    addon_locale_counts = (
+        addon_install_counts
+        .filter((f.col('sum(pair_cnts)')>=locale_pop_threshold))
+        )
+    
+    return addon_locale_counts
 
 
-def transform(addon_df, threshold, num_addons):
+def transform(addon_df, addon_locale_counts_df, num_addons):
     """ Converts the locale-specific addon data in to a dictionary.
 
     :param addon_df: the locale-specific addon dataframe;
-    :param threshold: the minimum number of addon-installs per locale;
+    :param addon_locale_counts_df: total addon-installs per locale;
     :param num_addons: requested number of recommendations.
     :return: a dictionary {<locale>: ['GUID1', 'GUID2', ...]}
     """
+    
+    # Helper function to normalize addon installations in a lambda.
+    def normalize_cnts(p):
+        loc_norm = float(p['pair_cnts'])/float(p['sum(pair_cnts)'])
+        return loc_norm
+    
+    # Instantiate an empty dict.
     top10_per = {}
+    
+    # Join addon pair counts with total addon installs per locale.
+    # need to clone the DFs to workaround for SPARK bug#14948
+    # https://issues.apache.org/jira/browse/SPARK-14948
+    df1 = addon_locale_counts_df.alias("df1")
+    df2 = addon_df.alias("df2")
 
-    # Decide that we can not make reasonable recommendations without
-    # a minimum number of addon installations.
-    grouped_addons = (
+    combined_df = (
         addon_df
-        .groupBy('locality')
-        .agg({'pair_cnts': 'sum'})
-        .collect()
+        .join(df1, df2.locality == df1.locality)
+        .drop(df1.locality)
     )
+    
+    # Normalize installation rate per locale.
+    normalized_installs = combined_df.rdd.map(
+        lambda p: Row(addon_key=p['addon_key'], 
+        locality=p['locality'], 
+        loc_norm = normalize_cnts(p))
+    ).toDF()
+
+    # Groupby locale and sort by normalized install rate
+    window = Window\
+        .partitionBy(normalized_installs['locality'])\
+        .orderBy(d['loc_norm']\
+        .desc())
+    
+    # Truncate reults exceeding required number of addons.
+    truncated_df = \
+        normalized_installs\
+        .select('*', rank()\
+        .over(window)\
+        .alias('rank'))\
+        .filter(col('rank') <= num_addons)\
+        .drop(col('rank'))
+
     list_of_locales =\
-        [i['locality'] for i in grouped_addons if i['sum(pair_cnts)'] > threshold]
-
+        [x[0] for x in truncated_df.select(truncated_df.locality).distinct().collect()]
+        
+    # There is probably a *much* smarter way fo doing this, but I am le tired.
     for specific_locale in list_of_locales:
-        # Most popular addons per locale sorted by number of installs
-        # are added to the list.
-        sorted_addon_guids = (
-            addon_df
-            .filter(addon_df.locality == specific_locale)
-            .sort(addon_df.pair_cnts.desc())
-            .collect()
+        # Most popular addons per locale sorted by normalized number of installs.
+        top10_per[specific_locale] = (
+            [[x['addon_key'], x['loc_norm']] for x in truncated_df
+            .filter(truncated_df.locality == specific_locale)
+            .collect()]
         )
-
-        # Creates a dictionary of locales (keys) and list of
-        # recommendation GUIDS (values).
-        top10_per[specific_locale] =\
-            [addon_stats.addon_key for addon_stats in sorted_addon_guids[0:num_addons]]
-
     return top10_per
 
 
@@ -154,7 +193,7 @@ def generate_dictionary(spark, num_addons):
     addon_df_filtered = addon_df.where(col("addon_key").isin(amo_whitelist))
 
     # Make sure not to include addons from very small locales.
-    locale_pop_threshold = compute_threshold(addon_df_filtered)
+    addon_locale_counts_df = compute_threshold(addon_df_filtered)
     return transform(addon_df_filtered, locale_pop_threshold, num_addons)
 
 


### PR DESCRIPTION
WebExtension installation frequencies per locale are now normalized by the total number of observed WebExtension in each locale.