### PR TITLE
[part 2] Run 2to3 and fix issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ workflows:
   build:
     jobs:
       - py27
+      - py36
       - lint
       - docs
       - docs-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,11 +71,11 @@ jobs:
     parallelism: 4
     docker:
       - image: python:2.7
-  py36:
+  py35:
     <<: *test_settings
     parallelism: 4
     docker:
-      - image: python:3.6
+      - image: python:3.5
 
   lint:
     docker:
@@ -138,7 +138,7 @@ workflows:
   build:
     jobs:
       - py27
-      - py36
+      - py35
       - lint
       - docs
       - docs-deploy:

--- a/mozetl/addon_aggregates/addon_aggregates.py
+++ b/mozetl/addon_aggregates/addon_aggregates.py
@@ -28,7 +28,7 @@ def get_test_pilot_addons():
     '''
     url = "https://testpilot.firefox.com/api/experiments.json"
     response = urllib.request.urlopen(url)
-    data = json.loads(response.read())
+    data = json.loads(response.read().decode("utf-8"))
     all_tp_addons = (
         ["@testpilot-addon"] + [i.get("addon_id") for i in data['results'] if i.get("addon_id")]
         )

--- a/mozetl/addon_aggregates/addon_aggregates.py
+++ b/mozetl/addon_aggregates/addon_aggregates.py
@@ -3,7 +3,7 @@
 from pyspark.sql import SparkSession
 import pyspark.sql.functions as fun
 import json
-import urllib.request, urllib.parse, urllib.error
+from six.moves import urllib
 import click
 
 MS_FIELDS = ['client_id',

--- a/mozetl/addon_aggregates/addon_aggregates.py
+++ b/mozetl/addon_aggregates/addon_aggregates.py
@@ -3,7 +3,7 @@
 from pyspark.sql import SparkSession
 import pyspark.sql.functions as fun
 import json
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import click
 
 MS_FIELDS = ['client_id',
@@ -27,7 +27,7 @@ def get_test_pilot_addons():
     :return a list of addon_ids
     '''
     url = "https://testpilot.firefox.com/api/experiments.json"
-    response = urllib.urlopen(url)
+    response = urllib.request.urlopen(url)
     data = json.loads(response.read())
     all_tp_addons = (
         ["@testpilot-addon"] + [i.get("addon_id") for i in data['results'] if i.get("addon_id")]

--- a/mozetl/addon_aggregates/addon_aggregates.py
+++ b/mozetl/addon_aggregates/addon_aggregates.py
@@ -65,7 +65,7 @@ def load_main_summary(spark, input_bucket, input_prefix, input_version):
     :return SparkDF
     '''
     dest = get_dest(input_bucket, input_prefix, input_version)
-    print "loading...", dest
+    print("loading...", dest)
     return (spark
             .read
             .option("mergeSchema", True)

--- a/mozetl/basic/transform.py
+++ b/mozetl/basic/transform.py
@@ -20,12 +20,11 @@ class DataFrameConfig(object):
 
     def toStructType(self):
         return StructType(
-            map(lambda col: StructField(col.name, col.struct_type, True),
-                self.columns)
+            [StructField(col.name, col.struct_type, True) for col in self.columns]
         )
 
     def get_paths(self):
-        return map(lambda col: col.path, self.columns)
+        return [col.path for col in self.columns]
 
 
 def convert_pings(sqlContext, pings, data_frame_config):

--- a/mozetl/clientsdaily/rollup.py
+++ b/mozetl/clientsdaily/rollup.py
@@ -103,19 +103,19 @@ def extract_search_counts(frame):
 
 
 def to_profile_day_aggregates(frame_with_extracts):
-    from fields import MAIN_SUMMARY_FIELD_AGGREGATORS
+    from .fields import MAIN_SUMMARY_FIELD_AGGREGATORS
     if "activity_date" not in frame_with_extracts.columns:
-        from fields import ACTIVITY_DATE_COLUMN
+        from .fields import ACTIVITY_DATE_COLUMN
         with_activity_date = frame_with_extracts.select(
             "*", ACTIVITY_DATE_COLUMN
         )
     else:
         with_activity_date = frame_with_extracts
     if "geo_subdivision1" not in with_activity_date.columns:
-        from fields import NULL_STRING_COLUMN
+        from .fields import NULL_STRING_COLUMN
         with_activity_date = with_activity_date.withColumn("geo_subdivision1", NULL_STRING_COLUMN)
     if "geo_subdivision2" not in with_activity_date.columns:
-        from fields import NULL_STRING_COLUMN
+        from .fields import NULL_STRING_COLUMN
         with_activity_date = with_activity_date.withColumn("geo_subdivision2", NULL_STRING_COLUMN)
     grouped = with_activity_date.groupby('client_id', 'activity_date')
     return grouped.agg(*MAIN_SUMMARY_FIELD_AGGREGATORS)

--- a/mozetl/engagement/churn/job.py
+++ b/mozetl/engagement/churn/job.py
@@ -36,6 +36,7 @@ from pyspark.sql.window import Window
 from . import release, utils
 from .schema import churn_schema
 from .utils import DS, DS_NODASH
+from functools import reduce
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -375,7 +376,7 @@ def clean_columns(prepared_clients, effective_version, start_ds):
     # Set the attributes to null if it's invalid
     select_attr = utils.build_col_expr({
         attr: F.when(F.col(is_valid), expr).otherwise(F.lit(None))
-        for attr, expr in utils.preprocess_col_expr(attr_mapping).iteritems()
+        for attr, expr in utils.preprocess_col_expr(attr_mapping).items()
     })
     select_metrics = utils.build_col_expr(metric_mapping)
     select_expr = select_attr + select_metrics
@@ -456,7 +457,7 @@ def transform(main_summary, effective_version, start_ds):
     records = (
         cleaned_data
         .groupBy(*attributes)
-        .agg(*agg_expr.values())
+        .agg(*list(agg_expr.values()))
     )
 
     return records.select(columns)

--- a/mozetl/engagement/churn/release.py
+++ b/mozetl/engagement/churn/release.py
@@ -20,7 +20,7 @@ def create_date_to_version(release_info):
     d2v = {}
     # Start with all the available version release days:
     for t in ["major", "minor"]:
-        for m, d in release_info[t].iteritems():
+        for m, d in release_info[t].items():
             if d < start_date_str:
                 continue
             if d not in d2v or compare_ver(m, d2v[d]) > 0:
@@ -121,7 +121,7 @@ def create_effective_version_table(spark):
     :returns:       DataFrame containing the effective version information
     """
     d2v = create_date_to_version(get_release_info())
-    rows = [Row(date, version) for date, version in d2v.iteritems()]
+    rows = [Row(date, version) for date, version in d2v.items()]
     df = spark.createDataFrame(rows, ["date", "effective_version"])
     return df
 

--- a/mozetl/engagement/churn/utils.py
+++ b/mozetl/engagement/churn/utils.py
@@ -60,9 +60,9 @@ def preprocess_col_expr(mapping):
      """
     select_expr = {}
 
-    for name, expr in mapping.iteritems():
+    for name, expr in mapping.items():
         column_expr = expr if expr is not None else name
-        if isinstance(column_expr, basestring):
+        if isinstance(column_expr, str):
             column_expr = F.expr(column_expr)
         select_expr[name] = column_expr.alias(name)
 
@@ -82,6 +82,6 @@ def build_col_expr(mapping):
     select_expr = []
 
     preprocessed = preprocess_col_expr(mapping)
-    for name, expr in preprocessed.iteritems():
+    for name, expr in preprocessed.items():
         select_expr.append(expr.alias(name))
     return select_expr

--- a/mozetl/engagement/churn_to_csv/job.py
+++ b/mozetl/engagement/churn_to_csv/job.py
@@ -7,10 +7,11 @@ import click
 from boto3.s3.transfer import S3Transfer
 from moztelemetry.standards import snap_to_beginning_of_week
 from pyspark.sql import SparkSession, functions as F
+from six import text_type
 
 
 def csv(f):
-    return ",".join([unicode(a) for a in f])
+    return ",".join([text_type(a) for a in f])
 
 
 def fmt(d, date_format="%Y%m%d"):

--- a/mozetl/engagement/churn_to_csv/job.py
+++ b/mozetl/engagement/churn_to_csv/job.py
@@ -113,10 +113,10 @@ def convert_week(spark, config, week_start=None):
 def assert_valid_config(config):
     """ Assert that the configuration looks correct. """
     # This could be replaced with python schema's
-    assert set(["source", "uploads", "search_cohort"]).issubset(config.keys())
-    assert set(["bucket", "prefix"]).issubset(config['search_cohort'].keys())
+    assert set(["source", "uploads", "search_cohort"]).issubset(list(config.keys()))
+    assert set(["bucket", "prefix"]).issubset(list(config['search_cohort'].keys()))
     for entry in config["uploads"]:
-        assert set(["name", "bucket", "prefix"]).issubset(entry.keys())
+        assert set(["name", "bucket", "prefix"]).issubset(list(entry.keys()))
 
 
 @click.command()

--- a/mozetl/engagement/retention/job.py
+++ b/mozetl/engagement/retention/job.py
@@ -43,6 +43,7 @@ from mozetl.engagement.churn.job import (
     MAX_SUBSESSION_LENGTH
 )
 from .schema import retention_schema
+from functools import reduce
 
 
 def valid_pcd(pcd, client_date):

--- a/mozetl/hardware_report/check_output.py
+++ b/mozetl/hardware_report/check_output.py
@@ -30,12 +30,12 @@ def _check_most_recent_change(values, min_change=.05, min_value=0.01, missing_va
     assert missing_val > 0
 
     recent_week = max(values.keys())
-    second_recent_week = max(values.viewkeys() - {recent_week})
+    second_recent_week = max(values.keys() - {recent_week})
 
     base, compare = values[second_recent_week], values[recent_week]
     changes = [
         (k, (compare.get(k, missing_val) / base.get(k, missing_val)) - 1)
-        for k in base.viewkeys() | compare.viewkeys()
+        for k in base.keys() | compare.keys()
     ]
 
     return {
@@ -53,7 +53,7 @@ def _make_report(changes):
         return "{}: Last week = {:.2f}%, This week = {:.2f}%".format(k, v1, v2)
 
     change_strings = [(v['change'], mk_line(k, v['old_value']*100, v['new_value']*100))
-                      for k, v in changes.iteritems()]
+                      for k, v in changes.items()]
     return '\n'.join([x[1] for x in sorted(change_strings, key=lambda x: x[0])])
 
 

--- a/mozetl/hardware_report/check_output.py
+++ b/mozetl/hardware_report/check_output.py
@@ -30,12 +30,12 @@ def _check_most_recent_change(values, min_change=.05, min_value=0.01, missing_va
     assert missing_val > 0
 
     recent_week = max(values.keys())
-    second_recent_week = max(values.keys() - {recent_week})
+    second_recent_week = max(set(values.keys()) - {recent_week})
 
     base, compare = values[second_recent_week], values[recent_week]
     changes = [
         (k, (compare.get(k, missing_val) / base.get(k, missing_val)) - 1)
-        for k in base.keys() | compare.keys()
+        for k in set(base.keys()) | set(compare.keys())
     ]
 
     return {

--- a/mozetl/hardware_report/hardware_dashboard.py
+++ b/mozetl/hardware_report/hardware_dashboard.py
@@ -7,8 +7,8 @@ https://hardware.metrics.mozilla.com/
 import click
 import json
 import glob
-import summarize_json
-from check_output import check_output
+from . import summarize_json
+from .check_output import check_output
 from click_datetime import Datetime
 from datetime import datetime, timedelta
 from pyspark.sql import SparkSession

--- a/mozetl/hardware_report/hardware_dashboard.py
+++ b/mozetl/hardware_report/hardware_dashboard.py
@@ -48,7 +48,7 @@ def main(start_date, end_date, bucket):
     summarize_json.fetch_previous_state("hwsurvey-weekly.json", "hwsurvey-weekly-prev.json",
                                         bucket)
     # Concat the json files into the output.
-    print "Joining JSON files..."
+    print("Joining JSON files...")
 
     new_files = set(report.keys())
     read_files = set(glob.glob("*.json"))

--- a/mozetl/hardware_report/summarize_json.py
+++ b/mozetl/hardware_report/summarize_json.py
@@ -11,6 +11,7 @@ import botocore
 import requests
 import logging
 import moztelemetry.standards as moz_std
+from six import text_type
 
 # Reasons why the data for a client can be discarded.
 REASON_INACTIVE = "inactive"
@@ -462,7 +463,7 @@ def finalize_data(data, sample_count, broken_ratio,
     for k, v in data.items():
         # The old key is a tuple (key, value). We translate the key part and concatenate the
         # value as a string.
-        new_key = keys_translation[k[0]] + unicode(k[1])
+        new_key = keys_translation[k[0]] + text_type(k[1])
         aggregated_percentages[new_key] = v / denom
 
     return aggregated_percentages

--- a/mozetl/hardware_report/summarize_json.py
+++ b/mozetl/hardware_report/summarize_json.py
@@ -129,10 +129,10 @@ def invert_device_map(m):
 
     """
     device_id_map = {}
-    for vendor, u in m.iteritems():
+    for vendor, u in m.items():
         device_id_map['0x' + vendor] = {}
-        for family, v in u.iteritems():
-            for chipset, ids in v.iteritems():
+        for family, v in u.items():
+            for chipset, ids in v.items():
                 device_id_map['0x' +
                               vendor].update({('0x' +
                                                gfx_id): [family, chipset] for gfx_id in ids})
@@ -212,7 +212,7 @@ def get_valid_client_record(r, data_index):
         data['has_flash'] = any(
             [True for p in plugins if p['name'] == 'Shockwave Flash'])
 
-    return REASON_BROKEN_DATA if None in data.values() else data
+    return REASON_BROKEN_DATA if None in list(data.values()) else data
 
 
 def get_latest_valid_per_client(entry, time_start, time_end):
@@ -358,7 +358,7 @@ def collapse_buckets(aggregated_data, count_threshold):
 
     """
     collapsed_groups = {}
-    for k, v in aggregated_data.iteritems():
+    for k, v in aggregated_data.items():
         key_type = k[0]
 
         # If the resolution is 0x0 (see bug 1324014), put that into the "Other"
@@ -400,7 +400,7 @@ def collapse_buckets(aggregated_data, count_threshold):
     # The previous grouping might have created additional groups. Let's check
     # again.
     final_groups = {}
-    for k, v in collapsed_groups.iteritems():
+    for k, v in collapsed_groups.items():
         # Don't clump this group into the "Other" bucket if it has enough
         # users it in.
         if (v > count_threshold and k[1] != 'Other') or k[0] in EXCLUSION_LIST:
@@ -459,7 +459,7 @@ def finalize_data(data, sample_count, broken_ratio,
     }
 
     # Compute the percentages from the raw numbers.
-    for k, v in data.iteritems():
+    for k, v in data.items():
         # The old key is a tuple (key, value). We translate the key part and concatenate the
         # value as a string.
         new_key = keys_translation[k[0]] + unicode(k[1])
@@ -501,7 +501,7 @@ def validate_finalized_data(data):
     # We expect to have at least a key in |data| whose name begins with one
     # of the keys in |keys_accumulator|. Iterate through the keys in |data|
     # and accumulate their values in the accumulator.
-    for key, value in data.iteritems():
+    for key, value in data.items():
         if key in ["inactive", "broken", "date"]:
             continue
 
@@ -514,7 +514,7 @@ def validate_finalized_data(data):
         keys_accumulator[property_name] += value
 
     # Make sure all the properties add up to 1.0 (or close enough).
-    for key, value in keys_accumulator.iteritems():
+    for key, value in keys_accumulator.items():
         if abs(1.0 - value) > 0.05:
             logger.warning(
                 "{} values do not add up to 1.0. Their sum is {}.".format(
@@ -532,7 +532,7 @@ def get_file_name(suffix=""):
 def serialize_results(date_to_json):
     """Save each aggregated data item as an entry in the JSON."""
     logger.info("Serializing results locally...")
-    for file_name, aggregated_data in date_to_json.items():
+    for file_name, aggregated_data in list(date_to_json.items()):
         # This either appends to an existing file, or creates a new one.
         if os.path.exists(file_name):
             logger.info("{} exists, we will overwrite it.".format(file_name))

--- a/mozetl/landfill/sampler.py
+++ b/mozetl/landfill/sampler.py
@@ -55,7 +55,7 @@ def _process(message):
     Generic Ingestion URI Specification:
         /submit/<namespace>/<doc_type>/<doc_version>/<doc_id>
     """
-    meta = {k: v for k, v in message['meta'].items() if k in META_WHITELIST}
+    meta = {k: v for k, v in list(message['meta'].items()) if k in META_WHITELIST}
 
     # Parse the uri, start by setting the path relative to `/submit`
     # Some paths do not adhere to the spec, so append empty values to avoid index errors.

--- a/mozetl/main.py
+++ b/mozetl/main.py
@@ -41,10 +41,10 @@ def etl_job(sc, sqlContext):
     results = transform_pings(get_data(sc))
 
     # Display results:
-    total = sum(map(operator.itemgetter(1), results.iteritems()))
+    total = sum(map(operator.itemgetter(1), iter(results.items())))
     # Print the OS and client_id counts in descending order:
     sorted_results = sorted(
-        results.iteritems(),
+        iter(results.items()),
         key=operator.itemgetter(1),
         reverse=True,
     )

--- a/mozetl/search/aggregates.py
+++ b/mozetl/search/aggregates.py
@@ -46,7 +46,7 @@ def search_clients_daily(main_summary):
             'engine',
             'source',
         ],
-        map(agg_first, [
+        list(map(agg_first, [
             'country',
             'app_version',
             'distribution_id',
@@ -60,7 +60,7 @@ def search_clients_daily(main_summary):
             'default_search_engine_data_load_path',
             'default_search_engine_data_submission_url',
             'sample_id',
-        ]) + [
+        ])) + [
             # Count of 'first' subsessions seen for this client_day
             (
                 count(when(col('subsession_counter') == 1, 1))

--- a/mozetl/taar/taar_amodump.py
+++ b/mozetl/taar/taar_amodump.py
@@ -6,6 +6,7 @@ import logging
 import logging.config
 import typing
 from six.moves import urllib
+from six import text_type
 import queue as queue
 
 from .taar_utils import store_json_to_s3
@@ -244,8 +245,8 @@ class Undefined:
 def marshal(value, name, type_def):
     serializers = {typing.List: list,
                    typing.Dict: dict,
-                   str: unicode,
-                   unicode: unicode,
+                   str: text_type,
+                   text_type: text_type,
                    int: int,
                    float: float,
                    bool: bool}

--- a/mozetl/taar/taar_amodump.py
+++ b/mozetl/taar/taar_amodump.py
@@ -5,7 +5,7 @@ import json
 import logging
 import logging.config
 import typing
-import urllib.request, urllib.parse, urllib.error
+from six.moves import urllib
 import queue as queue
 
 from .taar_utils import store_json_to_s3

--- a/mozetl/taar/taar_amodump.py
+++ b/mozetl/taar/taar_amodump.py
@@ -5,9 +5,8 @@ import json
 import logging
 import logging.config
 import typing
-from six.moves import urllib
+from six.moves import urllib, queue
 from six import text_type
-import queue as queue
 
 from .taar_utils import store_json_to_s3
 

--- a/mozetl/taar/taar_amowhitelist.py
+++ b/mozetl/taar/taar_amowhitelist.py
@@ -13,7 +13,7 @@ from abc import abstractmethod
 from dateutil.parser import parse
 import datetime
 
-from taar_utils import read_from_s3, store_json_to_s3
+from .taar_utils import read_from_s3, store_json_to_s3
 
 AMO_DUMP_BUCKET = "telemetry-parquet"
 AMO_DUMP_PREFIX = "telemetry-ml/addon_recommender/"
@@ -151,8 +151,8 @@ class AMOTransformer:
           https://github.com/mozilla/taar-lite/issues/1
         """
 
-        for guid, addon_data in json_data.items():
-            for acc in self._accumulators.values():
+        for guid, addon_data in list(json_data.items()):
+            for acc in list(self._accumulators.values()):
                 acc.process_record(guid, addon_data)
 
         return self.get_whitelist()

--- a/mozetl/taar/taar_dynamo.py
+++ b/mozetl/taar/taar_dynamo.py
@@ -155,7 +155,7 @@ def list_transformer(row_jsonstr):
     jdata['start_date'] = start_date
 
     # Filter out keys with an empty value
-    jdata = {key: value for key, value in jdata.items() if value}
+    jdata = {key: value for key, value in list(jdata.items()) if value}
 
     # We need to return a 4-tuple of values
     # (numrec_dynamodb_pushed, json_list_length, json_list, error_json)

--- a/mozetl/taar/taar_lite_guidguid.py
+++ b/mozetl/taar/taar_lite_guidguid.py
@@ -79,7 +79,7 @@ def extract_telemetry(spark):
             users_df.rdd
                     .map(lambda p: (p["client_id"],
                                     [guid
-                                     for guid, data in p["active_addons"].items()
+                                     for guid, data in list(p["active_addons"].items())
                                      if is_valid_addon(guid, data)]))
                     .filter(lambda p: len(p[1]) > 1)
                     .toDF(["client_id", "addon_ids"])

--- a/mozetl/taar/taar_locale.py
+++ b/mozetl/taar/taar_locale.py
@@ -15,8 +15,8 @@ import logging
 from pyspark.sql import SparkSession, Row
 from pyspark.sql.functions import col, rank, desc
 from pyspark.sql.window import Window
-from taar_utils import store_json_to_s3
-from taar_utils import load_amo_curated_whitelist
+from .taar_utils import store_json_to_s3
+from .taar_utils import load_amo_curated_whitelist
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -22,8 +22,8 @@ from pyspark.ml import Pipeline
 from pyspark.mllib.stat import KernelDensity
 from pyspark.statcounter import StatCounter
 from scipy.spatial import distance
-from taar_utils import store_json_to_s3
-from taar_utils import load_amo_curated_whitelist
+from .taar_utils import store_json_to_s3
+from .taar_utils import load_amo_curated_whitelist
 from mozetl.utils import stop_session_safely
 
 # Define the set of feature names to be used in the donor computations.
@@ -160,7 +160,7 @@ def get_donor_pools(users_df, clusters_df, num_donors, random_seed=None):
     # Compute the proportion of user in each cluster.
     total_donors_in_clusters = sum(counts)
     clust_sample = [float(t) / total_donors_in_clusters for t in counts]
-    sampling_proportions = dict(zip(clusters, clust_sample))
+    sampling_proportions = dict(list(zip(clusters, clust_sample)))
 
     # Sample the users in each cluster according to the proportions
     # and pass along the random seed if needed for tests.
@@ -337,7 +337,7 @@ def get_lr_curves(
     numerator_density = kd_sc.estimate(lr_index)
 
     # Structure this in the correct output format.
-    return zip(lr_index, zip(numerator_density, denominator_density))
+    return list(zip(lr_index, list(zip(numerator_density, denominator_density))))
 
 
 def today_minus_90_days():

--- a/mozetl/taar/taar_utils.py
+++ b/mozetl/taar/taar_utils.py
@@ -104,7 +104,7 @@ def load_amo_external_whitelist():
         # Load the most current AMO dump JSON resource.
         s3 = boto3.client('s3')
         s3_contents = s3.get_object(Bucket=AMO_DUMP_BUCKET, Key=AMO_WHITELIST_KEY)
-        amo_dump = json.loads(s3_contents['Body'].read())
+        amo_dump = json.loads(s3_contents['Body'].read().decode('utf-8'))
     except ClientError:
         logger.exception("Failed to download from S3", extra={
             "bucket": AMO_DUMP_BUCKET,

--- a/mozetl/taar/taar_utils.py
+++ b/mozetl/taar/taar_utils.py
@@ -111,7 +111,7 @@ def load_amo_external_whitelist():
             "key": AMO_DUMP_KEY})
 
     # If the load fails, we will have an empty whitelist, this may be problematic.
-    for key, value in amo_dump.items():
+    for key, value in list(amo_dump.items()):
         addon_files = value.get('current_version', {}).get('files', {})
         # If any of the addon files are web_extensions compatible, it can be recommended.
         if any([f.get("is_webextension", False) for f in addon_files]):

--- a/mozetl/tab_spinner/generate_counts.py
+++ b/mozetl/tab_spinner/generate_counts.py
@@ -46,7 +46,7 @@ def run_spinner_etl(sc):
         build_results[build_type] = get_short_and_long_spinners(pings)
 
     s3_client = boto3.client('s3')
-    for result_key, results in build_results.iteritems():
+    for result_key, results in build_results.items():
         filename = "severities_by_build_id_%s.json" % result_key
         results_json = json.dumps(results, ensure_ascii=False)
 

--- a/mozetl/tab_spinner/generate_counts.py
+++ b/mozetl/tab_spinner/generate_counts.py
@@ -21,7 +21,7 @@ def run_spinner_etl(sc):
             (b.startswith(end_date) or b < end_date)
         )
 
-    print "Start Date: {}, End Date: {}".format(start_date, end_date)
+    print("Start Date: {}, End Date: {}".format(start_date, end_date))
 
     build_results = {}
 

--- a/mozetl/tab_spinner/utils.py
+++ b/mozetl/tab_spinner/utils.py
@@ -153,9 +153,9 @@ def get_short_and_long_spinners(pings):
     )
 
     if round(final_result_short[0][1][2:].sum(), 3) == round(final_result_long[0][1][1], 3):
-        print "Short and long counts match"
+        print("Short and long counts match")
     else:
-        print "Error: Short and long counts do not match"
+        print("Error: Short and long counts do not match")
 
     return {
         'long': final_result_long,

--- a/mozetl/testpilot/pulse.py
+++ b/mozetl/testpilot/pulse.py
@@ -36,13 +36,13 @@ class Request(object):
     def __init__(self, request_dict):
         args = {
             field: conversion(request_dict.get(field))
-            for field, (conversion, sql_type) in Request.field_types.iteritems()
+            for field, (conversion, sql_type) in Request.field_types.items()
         }
         self.row = Row(**args)
 
 
 def _requests_to_rows(requests):
-    out = {k: Request(v).row for k, v in requests.iteritems()}
+    out = {k: Request(v).row for k, v in requests.items()}
     return out
 
 

--- a/mozetl/testpilot/pulse.py
+++ b/mozetl/testpilot/pulse.py
@@ -25,11 +25,10 @@ class Request(object):
 
     # python3 work-around to keep field_types in scope since class variables
     # are not in the local scope of list comprehensions.
-    _create_struct = lambda x: StructField(x[0], x[1][1], True)  # noqa
     _keys = sorted(field_types.keys())
     _dtypes = map(field_types.get, _keys)
 
-    StructType = StructType(list(map(_create_struct, zip(_keys, _dtypes))))
+    StructType = StructType([StructField(x[0], x[1][1], True) for x in zip(_keys, _dtypes)])
 
     def __init__(self, request_dict):
         args = {

--- a/mozetl/testpilot/pulse.py
+++ b/mozetl/testpilot/pulse.py
@@ -23,15 +23,13 @@ class Request(object):
         'time': int_type,
     }
 
-    StructType = StructType([
-        # For some reason, field_types needs to be sorted. Use
-        # PYTHONHASHSEED = 3201792604 to reproduce failure
-        StructField(
-            key,
-            field_types[key][1],
-            True
-        ) for key in sorted(field_types)
-    ])
+    # python3 work-around to keep field_types in scope since class variables
+    # are not in the local scope of list comprehensions.
+    _create_struct = lambda x: StructField(x[0], x[1][1], True)  # noqa
+    _keys = sorted(field_types.keys())
+    _dtypes = map(field_types.get, _keys)
+
+    StructType = StructType(list(map(_create_struct, zip(_keys, _dtypes))))
 
     def __init__(self, request_dict):
         args = {

--- a/mozetl/topline/schema.py
+++ b/mozetl/topline/schema.py
@@ -20,7 +20,7 @@ def schema_from_json(path):
     :path str: Path the the json data
     """
     with pkg_resources.resource_stream(mozetl.topline.__name__, path) as f:
-        data = json.load(f)
+        data = json.loads(f.read().decode("utf-8"))
         return StructType.fromJson(data)
 
 

--- a/mozetl/topline/topline_dashboard.py
+++ b/mozetl/topline/topline_dashboard.py
@@ -84,7 +84,7 @@ def reformat_data(df):
     # which equates to ignoring aggregates over multiple dates.
     cubed_df = (
         df
-        .select(*topline_columns.values())
+        .select(*list(topline_columns.values()))
         .cube(*attributes)
         .agg(*[F.sum(F.col(x)).alias(x) for x in aggregates])
         .where(F.col('date').isNotNull())

--- a/mozetl/topline/topline_summary.py
+++ b/mozetl/topline/topline_summary.py
@@ -9,6 +9,7 @@ from pyspark.sql.window import Window
 
 from mozetl.topline.schema import topline_schema
 from mozetl.constants import SEARCH_SOURCE_WHITELIST
+from functools import reduce
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -110,7 +111,7 @@ def clean_input(dataframe, start, end):
         dataframe
         .where(F.col("submission_date_s3") >= start)
         .where(F.col("submission_date_s3") < end)
-        .select([expr.alias(name) for name, expr in columns.iteritems()])
+        .select([expr.alias(name) for name, expr in columns.items()])
     )
 
     return clean
@@ -178,7 +179,7 @@ def client_aggregates(dataframe, timestamp, attributes):
 
     clients = (
         dataframe
-        .select([expr.alias(name) for name, expr in select_expr.iteritems()])
+        .select([expr.alias(name) for name, expr in select_expr.items()])
         .where("clientid_rank = 1")
         .groupBy(attributes)
         .agg(
@@ -214,7 +215,7 @@ def transform(dataframe, start, mode):
         .join(searches, attributes, "outer")
         .join(hours, attributes, "outer")
         .withColumnRenamed('country', 'geo')
-        .withColumn('crashes', F.lit(0L))
+        .withColumn('crashes', F.lit(0))
         .na.fill(0)
     )
 

--- a/mozetl/topline/topline_summary.py
+++ b/mozetl/topline/topline_summary.py
@@ -215,7 +215,7 @@ def transform(dataframe, start, mode):
         .join(searches, attributes, "outer")
         .join(hours, attributes, "outer")
         .withColumnRenamed('country', 'geo')
-        .withColumn('crashes', F.lit(0))
+        .withColumn('crashes', F.lit(0).astype("long"))
         .na.fill(0)
     )
 

--- a/mozetl/utils.py
+++ b/mozetl/utils.py
@@ -10,6 +10,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
 import boto3
+import six
 from six import text_type
 
 ACTIVITY_SUBMISSION_LAG = DT.timedelta(10)
@@ -54,14 +55,14 @@ def write_csv(dataframe, path, header=True):
     # an iterator over all partitions, collect everything into driver memory.
     logger.info("Writing {} rows to {}".format(dataframe.count(), path))
 
-    with open(path, 'wb') as fout:
+    with open(path, "wb") if six.PY2 else open(path, "w", newline="") as fout:
         writer = csv.writer(fout)
 
         if header:
             writer.writerow(dataframe.columns)
 
         for row in dataframe.collect():
-            row = [text_type(s).encode('utf-8') for s in row]
+            row = [text_type(s).encode('utf-8') for s in row] if six.PY2 else row
             writer.writerow(row)
 
 

--- a/mozetl/utils.py
+++ b/mozetl/utils.py
@@ -148,7 +148,7 @@ def extract_submission_window_for_activity_day(frame, date, lag_days):
     submission dates including the activity day itself plus 5 days of lag for
     a total of 6 days).
     """
-    from clientsdaily.fields import ACTIVITY_DATE_COLUMN
+    from .clientsdaily.fields import ACTIVITY_DATE_COLUMN
     end_date = DT.datetime.strptime(date, '%Y-%m-%d').date()
     # Rewind by `lag_days` to the desired activity date.
     start_date = end_date - DT.timedelta(lag_days)

--- a/mozetl/utils.py
+++ b/mozetl/utils.py
@@ -10,6 +10,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
 import boto3
+from six import text_type
 
 ACTIVITY_SUBMISSION_LAG = DT.timedelta(10)
 
@@ -60,7 +61,7 @@ def write_csv(dataframe, path, header=True):
             writer.writerow(dataframe.columns)
 
         for row in dataframe.collect():
-            row = [unicode(s).encode('utf-8') for s in row]
+            row = [text_type(s).encode('utf-8') for s in row]
             writer.writerow(row)
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
         'requests-toolbelt==0.8.0',
         'requests==2.20.1',
         'scipy==1.0.0rc1',
-        'typing==3.6.4'
+        'typing==3.6.4',
+        'six',
     ],
     tests_require=test_deps,
     extras_require=extras,

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'requests==2.20.1',
         'scipy==1.0.0rc1',
         'typing==3.6.4',
-        'six',
+        'six==1.11.0',
     ],
     tests_require=test_deps,
     extras_require=extras,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from pyspark.sql import SparkSession
+import json
 
 
 @pytest.fixture(scope="session")
@@ -33,7 +34,10 @@ def no_spark_stop(monkeypatch):
 @pytest.fixture
 def df_equals(row_to_dict):
     def to_comparable(df):
-        return sorted(map(row_to_dict, df.collect()))
+        # choose a unique ordering; lexographic ordering of dictionaries
+        return sorted(
+            map(row_to_dict, df.collect()), key=lambda x: json.dumps(x, sort_keys=True)
+        )
 
     def func(this, that):
         return to_comparable(this) == to_comparable(that)
@@ -44,8 +48,10 @@ def df_equals(row_to_dict):
 @pytest.fixture(scope="session")
 def row_to_dict():
     """Convert pyspark.Row to dict for easier unordered comparison"""
-    def func(row):
-        return {key: row[key] for key in row.__fields__}
+
+    def func(row, recursive=True):
+        return row.asDict(recursive=recursive)
+
     return func
 
 

--- a/tests/engagement/data.py
+++ b/tests/engagement/data.py
@@ -118,7 +118,7 @@ new_profile_sample = {
     "submission": SUBSESSION_START.format("YYYYMMDD"),
     "environment": {
         "profile": {
-            "creation_date": long(SUBSESSION_START.timestamp / SECONDS_PER_DAY)
+            "creation_date": int(SUBSESSION_START.timestamp / SECONDS_PER_DAY)
         },
         "build": {
             "version": "57.0.0",

--- a/tests/engagement/data.py
+++ b/tests/engagement/data.py
@@ -101,7 +101,7 @@ main_summary_sample = {
     "distribution_id": "mozilla42",
     "locale": "en-US",
     "normalized_channel": "release",
-    "profile_creation_date": SUBSESSION_START.timestamp / SECONDS_PER_DAY,
+    "profile_creation_date": int(SUBSESSION_START.timestamp / SECONDS_PER_DAY),
     "submission_date_s3": SUBSESSION_START.format("YYYYMMDD"),
     "subsession_length": 3600,
     "subsession_start_date": str(SUBSESSION_START),
@@ -155,7 +155,7 @@ def format_ssd(arrow_date):
 
 def format_pcd(arrow_date):
     """Format an arrow date into the profile_creation_date"""
-    return arrow_date.timestamp / SECONDS_PER_DAY
+    return int(arrow_date.timestamp / SECONDS_PER_DAY)
 
 
 def generate_dates(subsession_date, submission_offset=0, creation_offset=0):

--- a/tests/engagement/test_churn.py
+++ b/tests/engagement/test_churn.py
@@ -359,7 +359,7 @@ def test_sync_usage(test_transform):
         test_func = functools.partial(test_case, uid=uid, expect=expect)
         return snippet, test_func
 
-    snippets, test_func = zip(*[
+    snippets, test_func = list(zip(*[
         # unobservable
         case("1", "unknown", None, None, None),
         # no reported devices, and not configured
@@ -378,7 +378,7 @@ def test_sync_usage(test_transform):
         case("8", "multiple", 0, 2, False),
         # a mobile and desktop device, but not configured
         case("9", "multiple", 1, 1, False),
-    ])
+    ]))
 
     df = test_transform(list(snippets))
 

--- a/tests/engagement/test_churn_utils.py
+++ b/tests/engagement/test_churn_utils.py
@@ -44,7 +44,7 @@ def test_preprocess_col_expr(select_expr_dict, test_df, row_to_dict):
 
     assert row_to_dict(
         test_df
-        .select([v.alias(k) for k, v in actual.items()])
+        .select([v.alias(k) for k, v in list(actual.items())])
         .first()
     ) == expect
 

--- a/tests/hardware_report/test_check_output.py
+++ b/tests/hardware_report/test_check_output.py
@@ -22,11 +22,11 @@ def test_check_most_recent_change_min_change():
         }
     }
 
-    assert check_most_recent_change(test_data, min_change=0.5).keys()\
+    assert set(check_most_recent_change(test_data, min_change=0.5).keys())\
         == set()
-    assert check_most_recent_change(test_data, min_change=0.3).keys()\
+    assert set(check_most_recent_change(test_data, min_change=0.3).keys())\
         == {"bigchange"}
-    assert check_most_recent_change(test_data, min_change=0.05).keys()\
+    assert set(check_most_recent_change(test_data, min_change=0.05).keys())\
         == {"bigchange", "somechange"}
 
 
@@ -42,11 +42,11 @@ def test_check_most_recent_change_min_value():
         }
     }
 
-    assert check_most_recent_change(test_data, min_change=0.1, min_value=2.0).keys()\
+    assert set(check_most_recent_change(test_data, min_change=0.1, min_value=2.0).keys())\
         == set()
-    assert check_most_recent_change(test_data, min_change=0.1, min_value=1.0).keys()\
+    assert set(check_most_recent_change(test_data, min_change=0.1, min_value=1.0).keys())\
         == {"somechange1"}
-    assert check_most_recent_change(test_data, min_change=0.1, min_value=0.0).keys()\
+    assert set(check_most_recent_change(test_data, min_change=0.1, min_value=0.0).keys())\
         == {"somechange1", "somechange2"}
 
 
@@ -58,9 +58,9 @@ def test_check_most_recent_change_missing_val():
         20170702: {}
     }
 
-    assert check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=0.5).keys() == set()
-    assert check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=0.01).keys() == {"change"}
-    assert check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=1.0).keys() == {"change"}
+    assert set(check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=0.5).keys())== set()
+    assert set(check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=0.01).keys()) == {"change"}
+    assert set(check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=1.0).keys()) == {"change"}
 
 
 def test_get_data():

--- a/tests/hardware_report/test_check_output.py
+++ b/tests/hardware_report/test_check_output.py
@@ -22,11 +22,11 @@ def test_check_most_recent_change_min_change():
         }
     }
 
-    assert check_most_recent_change(test_data, min_change=0.5).viewkeys()\
+    assert check_most_recent_change(test_data, min_change=0.5).keys()\
         == set()
-    assert check_most_recent_change(test_data, min_change=0.3).viewkeys()\
+    assert check_most_recent_change(test_data, min_change=0.3).keys()\
         == {"bigchange"}
-    assert check_most_recent_change(test_data, min_change=0.05).viewkeys()\
+    assert check_most_recent_change(test_data, min_change=0.05).keys()\
         == {"bigchange", "somechange"}
 
 
@@ -42,11 +42,11 @@ def test_check_most_recent_change_min_value():
         }
     }
 
-    assert check_most_recent_change(test_data, min_change=0.1, min_value=2.0).viewkeys()\
+    assert check_most_recent_change(test_data, min_change=0.1, min_value=2.0).keys()\
         == set()
-    assert check_most_recent_change(test_data, min_change=0.1, min_value=1.0).viewkeys()\
+    assert check_most_recent_change(test_data, min_change=0.1, min_value=1.0).keys()\
         == {"somechange1"}
-    assert check_most_recent_change(test_data, min_change=0.1, min_value=0.0).viewkeys()\
+    assert check_most_recent_change(test_data, min_change=0.1, min_value=0.0).keys()\
         == {"somechange1", "somechange2"}
 
 
@@ -58,12 +58,9 @@ def test_check_most_recent_change_missing_val():
         20170702: {}
     }
 
-    assert check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=0.5)\
-        .viewkeys() == set()
-    assert check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=0.01)\
-        .viewkeys() == {"change"}
-    assert check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=1.0)\
-        .viewkeys() == {"change"}
+    assert check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=0.5).keys() == set()
+    assert check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=0.01).keys() == {"change"}
+    assert check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=1.0).keys() == {"change"}
 
 
 def test_get_data():

--- a/tests/hardware_report/test_check_output.py
+++ b/tests/hardware_report/test_check_output.py
@@ -51,16 +51,26 @@ def test_check_most_recent_change_min_value():
 
 
 def test_check_most_recent_change_missing_val():
-    test_data = {
-        20170701: {
-            "change": 0.5,
-        },
-        20170702: {}
-    }
+    test_data = {20170701: {"change": 0.5}, 20170702: {}}
 
-    assert set(check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=0.5).keys())== set()
-    assert set(check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=0.01).keys()) == {"change"}
-    assert set(check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=1.0).keys()) == {"change"}
+    assert (
+        set(
+            check_most_recent_change(
+                test_data, min_change=0.1, min_value=0.0, missing_val=0.5
+            ).keys()
+        )
+        == set()
+    )
+    assert set(
+        check_most_recent_change(
+            test_data, min_change=0.1, min_value=0.0, missing_val=0.01
+        ).keys()
+    ) == {"change"}
+    assert set(
+        check_most_recent_change(
+            test_data, min_change=0.1, min_value=0.0, missing_val=1.0
+        ).keys()
+    ) == {"change"}
 
 
 def test_get_data():

--- a/tests/hardware_report/test_summarize_json.py
+++ b/tests/hardware_report/test_summarize_json.py
@@ -30,7 +30,7 @@ def test_run_tests():
     inverted_device_data = summarize_json.invert_device_map(device_data)
     assert "0xfeee" in inverted_device_data, (
            "The vendor id must be prefixed with '0x' and be at the root of the map.")
-    assert len(inverted_device_data["0xfeee"].keys()) == 2, (
+    assert len(list(inverted_device_data["0xfeee"].keys())) == 2, (
            "There must be two devices for the '0xfeee' vendor.")
     assert all(device_id in inverted_device_data["0xfeee"] for device_id in ("0xd1d1", "0xd2d2")), (
            "The '0xfeee' vendor must contain the expected devices.")
@@ -234,7 +234,7 @@ def test_finalize_data():
            "The first day of the reporting period must be reported.")
 
     # Make sure that all the reported numbers are ratios.
-    all_ratios = [(v >= 0.0 and v <= 1.0) for (k, v) in finalized_data.iteritems() if k != 'date']
+    all_ratios = [(v >= 0.0 and v <= 1.0) for (k, v) in finalized_data.items() if k != 'date']
     assert all(all_ratios), "All the reported entries must be ratios."
 
 

--- a/tests/test_addon_aggregates.py
+++ b/tests/test_addon_aggregates.py
@@ -123,7 +123,7 @@ def test_addon_counts(aggregate_data):
 
     for client_id in true_client_counts:
         data = aggregate_data.filter(aggregate_data.client_id == client_id).collect()[0]
-        for key, value in true_client_counts[client_id].iteritems():
+        for key, value in true_client_counts[client_id].items():
             assert data[key] == value
 
 
@@ -144,7 +144,7 @@ def test_unix_dates(aggregate_data):
 
     }
 
-    for client_id, value in true_client_days_to_install.iteritems():
+    for client_id, value in true_client_days_to_install.items():
         data = aggregate_data.filter(aggregate_data.client_id == client_id).collect()[0]
         first_install = data.first_addon_install_date
         pcd = data.profile_creation_date

--- a/tests/test_addon_aggregates.py
+++ b/tests/test_addon_aggregates.py
@@ -148,7 +148,7 @@ def test_unix_dates(aggregate_data):
         data = aggregate_data.filter(aggregate_data.client_id == client_id).collect()[0]
         first_install = data.first_addon_install_date
         pcd = data.profile_creation_date
-        print first_install, pcd
+        print(first_install, pcd)
         fmt = '%Y%m%d'
         days_to_install = (
             dt.datetime.strptime(first_install, fmt) - dt.datetime.strptime(pcd, fmt)

--- a/tests/test_clientsdaily.py
+++ b/tests/test_clientsdaily.py
@@ -36,14 +36,14 @@ def clients_daily(main_summary_with_search):
 
 def test_extract_search_counts(main_summary_with_search):
     row = main_summary_with_search.agg({'search_count_all': 'sum'}).collect()[0]
-    total = row.asDict().values()[0]
+    total = list(row.asDict().values())[0]
     assert total == EXPECTED_INTEGER_VALUES['search_count_all_sum']
 
 
 def test_domains_count(main_summary_with_search):
     unique_domains = 'scalar_parent_browser_engagement_unique_domains_count'
     row = main_summary_with_search.agg({unique_domains: 'sum'}).collect()[0]
-    total = row.asDict().values()[0]
+    total = list(row.asDict().values())[0]
     assert total == 4402
 
 
@@ -53,7 +53,7 @@ def test_to_profile_day_aggregates(clients_daily):
     aggd = dict([(k, 'sum') for k in EXPECTED_INTEGER_VALUES])
     result = clients_daily.agg(aggd).collect()[0]
 
-    for k, expected in EXPECTED_INTEGER_VALUES.items():
+    for k, expected in list(EXPECTED_INTEGER_VALUES.items()):
         actual = int(result['sum({})'.format(k)])
         assert actual == expected
 
@@ -85,7 +85,7 @@ def test_profile_creation_date_fields(clients_daily):
         u'2017-04-27', u'2015-06-19'
     ])
     ten_pcds = clients_daily.select("profile_creation_date").take(10)
-    actual1 = set([r.asDict().values()[0][:10] for r in ten_pcds])
+    actual1 = set([list(r.asDict().values())[0][:10] for r in ten_pcds])
     assert actual1 in (expected_back, expected_utc, expected_forward)
 
     expected2_back = [
@@ -98,14 +98,14 @@ def test_profile_creation_date_fields(clients_daily):
         376, 892, 259, 1359, 99, 1654, 413, 27, 701, 100
     ]
     ten_pdas = clients_daily.select("profile_age_in_days").take(10)
-    actual2 = [r.asDict().values()[0] for r in ten_pdas]
+    actual2 = [list(r.asDict().values())[0] for r in ten_pdas]
     assert actual2 in (expected2_back, expected2_utc, expected2_forward)
 
 
 def test_sessions_started_on_this_day(clients_daily):
     expected = [2, 0, 3, 2, 1, 0, 1, 0, 0, 3]
     ten_ssotds = clients_daily.select("sessions_started_on_this_day").take(10)
-    actual = [r.asDict().values()[0] for r in ten_ssotds]
+    actual = [list(r.asDict().values())[0] for r in ten_ssotds]
     assert actual == expected
 
 
@@ -115,7 +115,7 @@ def test_sessions_started_on_this_day_sorted(clients_daily):
     expected = [1, 5, 1, 1, 1, 0, 0, 0, 0, 0]
     one_day = clients_daily.where("activity_date == '2017-05-25'").orderBy("client_id")
     ten_ssotds = one_day.select("sessions_started_on_this_day").take(10)
-    actual = [r.asDict().values()[0] for r in ten_ssotds]
+    actual = [list(r.asDict().values())[0] for r in ten_ssotds]
     assert actual == expected
 
 

--- a/tests/test_landfill_sampler.py
+++ b/tests/test_landfill_sampler.py
@@ -15,7 +15,7 @@ def sample_document():
             u'Date': u'Sun, 19 Aug 2018 15:08:00 GMT',
             u'Host': u'incoming.telemetry.mozilla.org',
             'Hostname': u'ip-1.1.1.1',
-            'Timestamp': 1534691279765301222L,
+            'Timestamp': 1534691279765301222,
             'Type': u'telemetry-raw',
             u'User-Agent': u'pingsender/1.0',
             u'X-Forwarded-For': u'127.0.0.1',
@@ -37,7 +37,7 @@ def generate_data(spark, sample_document):
         return doc
 
     def _generate_data(snippets):
-        return spark.sparkContext.parallelize(map(_update_meta, snippets))
+        return spark.sparkContext.parallelize(list(map(_update_meta, snippets)))
 
     return _generate_data
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,7 +13,7 @@ def simple_data():
                 ('c', 'linux'),
                 ('d', 'windows')]
 
-    return map(lambda raw: create_row(*raw), raw_data)
+    return [create_row(*raw) for raw in raw_data]
 
 
 def duplicate_data():

--- a/tests/test_maudau.py
+++ b/tests/test_maudau.py
@@ -111,7 +111,7 @@ def test_write_locally():
     try:
         os.chdir(tempdir)
         M.write_locally(results)
-        output = open(basename).read()
+        output = open(basename, "rb").read().decode()
         assert output == expected
     finally:
         os.chdir(cwd)

--- a/tests/test_maudau.py
+++ b/tests/test_maudau.py
@@ -27,7 +27,7 @@ def make_frame(spark):
         ('a', '2017-05-05', '20170507'),
     ]
     return spark.createDataFrame(
-        [dict(zip(cols, tup)) for tup in values],
+        [dict(list(zip(cols, tup))) for tup in values],
         schema=NARROW_SCHEMA)
 
 

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -81,4 +81,4 @@ def test_simple_transform(row_to_dict, simple_rdd, spark_context):
         'trackingProtection': False,
     }
 
-    assert row_to_dict(actual) == expected
+    assert row_to_dict(actual, recursive=False) == expected

--- a/tests/test_search_aggregates.py
+++ b/tests/test_search_aggregates.py
@@ -153,7 +153,7 @@ main_summary_schema = [
     ),
 ]
 
-exploded_schema = filter(lambda x: x[0] != 'search_counts', main_summary_schema) + [
+exploded_schema = [x for x in main_summary_schema if x[0] != 'search_counts'] + [
     ('engine', 'google', StringType(), False),
     ('source', 'urlbar', StringType(), False),
     ('count', 4, LongType(), False),
@@ -167,7 +167,7 @@ derived_schema = exploded_schema + [
 
 @pytest.fixture()
 def generate_main_summary_data(define_dataframe_factory):
-    return define_dataframe_factory(map(to_field, main_summary_schema))
+    return define_dataframe_factory(list(map(to_field, main_summary_schema)))
 
 
 @pytest.fixture
@@ -206,7 +206,7 @@ def simple_main_summary(generate_main_summary_data):
 
 @pytest.fixture()
 def generate_exploded_data(define_dataframe_factory):
-    return define_dataframe_factory(map(to_field, exploded_schema))
+    return define_dataframe_factory(list(map(to_field, exploded_schema)))
 
 
 @pytest.fixture()
@@ -233,7 +233,7 @@ def exploded_data_for_derived_cols(generate_exploded_data):
 @pytest.fixture()
 def derived_columns(define_dataframe_factory):
     # template for the expected results
-    factory = define_dataframe_factory(map(to_field, derived_schema))
+    factory = define_dataframe_factory(list(map(to_field, derived_schema)))
 
     return factory([
         {'source': 'sap:urlbar:SomeCodeHere',
@@ -256,7 +256,7 @@ def derived_columns(define_dataframe_factory):
 @pytest.fixture()
 def expected_search_dashboard_data(define_dataframe_factory):
     # template for the expected results
-    factory = define_dataframe_factory(map(to_field, [
+    factory = define_dataframe_factory(list(map(to_field, [
         ('submission_date', '20170101', StringType(), False),
         ('country', 'DE', StringType(), True),
         ('locale', 'de', StringType(), True),
@@ -275,7 +275,7 @@ def expected_search_dashboard_data(define_dataframe_factory):
         ('organic', None, LongType(), True),
         ('unknown', None, LongType(), True),
         ('client_count', 1, LongType(), True),
-    ]))
+    ])))
 
     return factory([
         {'country': 'US'},
@@ -290,7 +290,7 @@ def expected_search_dashboard_data(define_dataframe_factory):
 @pytest.fixture()
 def expected_search_clients_daily_data(define_dataframe_factory):
     # template for the expected results
-    factory = define_dataframe_factory(map(to_field, [
+    factory = define_dataframe_factory(list(map(to_field, [
         ('client_id', 'a', StringType(), False),
         ('sample_id', '42', StringType(), False),
         ('submission_date', '20170101', StringType(), False),
@@ -338,7 +338,7 @@ def expected_search_clients_daily_data(define_dataframe_factory):
         ('max_concurrent_tab_count_max', 10, LongType(), True),
         ('tab_open_event_count_sum', 5, LongType(), True),
         ('active_hours_sum', .5, DoubleType(), True),
-    ]))
+    ])))
 
     return factory([
         {'client_id': 'b', 'country': 'US'},

--- a/tests/test_sync_bookmark.py
+++ b/tests/test_sync_bookmark.py
@@ -110,7 +110,7 @@ def build_sync_summary_snippet(snippet, sample=sync_summary_sample):
     """
 
     result = {}
-    result.update({k: v for k, v in snippet.iteritems() if k != 'engines'})
+    result.update({k: v for k, v in snippet.items() if k != 'engines'})
 
     if 'engines' not in snippet or snippet['engines'] is None:
         return result
@@ -130,7 +130,7 @@ def build_sync_summary_snippet(snippet, sample=sync_summary_sample):
         engine = copy.deepcopy(base_engine)
 
         engine.update({
-            k: v for k, v in engine_snippet.iteritems()
+            k: v for k, v in engine_snippet.items()
             if k not in ["failure_reason", "validation"]
         })
 
@@ -157,7 +157,7 @@ def generate_data(dataframe_factory, sync_summary_schema):
     def _generate_data(snippets):
         return (
             dataframe_factory.create_dataframe(
-                map(build_sync_summary_snippet, snippets),
+                list(map(build_sync_summary_snippet, snippets)),
                 sync_summary_sample,
                 sync_summary_schema
             )
@@ -343,7 +343,7 @@ def test_total_users_per_day(test_transform, row_to_dict):
         .select('submission_day', 'total_validated_users')
         .collect()
     )
-    assert map(row_to_dict, rows) == [
+    assert list(map(row_to_dict, rows)) == [
         {
             'submission_day': to_submission_date(day_1),
             'total_validated_users': 3

--- a/tests/test_taar_amowhitelist.py
+++ b/tests/test_taar_amowhitelist.py
@@ -332,7 +332,7 @@ def test_transform_whitelist(s3_fixture):
     assert len(final_jdata) == 1
 
     today = datetime.datetime.today().replace(tzinfo=None)
-    for client_data in final_jdata.values():
+    for client_data in list(final_jdata.values()):
         assert client_data['current_version']['files'][0]['is_webextension']
         assert client_data['ratings']['average'] >= taar_amowhitelist.MIN_RATING
         create_datetime = parse(client_data['first_create_date']).replace(tzinfo=None)
@@ -363,7 +363,7 @@ def test_transform_featuredlist(s3_fixture):
     # featured
     assert len(final_jdata) == 3
 
-    for rec in final_jdata.values():
+    for rec in list(final_jdata.values()):
         assert rec['is_featured']
 
 

--- a/tests/test_taar_lite_guidguid.py
+++ b/tests/test_taar_lite_guidguid.py
@@ -104,7 +104,7 @@ def test_addon_keying():
 
 
 @mock_s3
-def test_transform_is_valid(spark):
+def test_transform_is_valid(spark, df_equals):
     """
     Check that the contents of a sample transformation of extracted
     data
@@ -113,13 +113,8 @@ def test_transform_is_valid(spark):
     df = spark.createDataFrame(MOCK_TELEMETRY_SAMPLE)
 
     result_data = taar_lite_guidguid.transform(df)
-
-    # Convert the dataframe into a plain list of dictionaries
-    result_data = sorted([r.asDict() for r in result_data.collect()])
-
-    # Convert the expected data into a plain list of dictionaries
-    expected = sorted([r.asDict() for r in EXPECTED_GUID_GUID_DATA])
-    assert expected == result_data
+    expected_data = spark.createDataFrame(EXPECTED_GUID_GUID_DATA)
+    assert df_equals(result_data, expected_data)
 
 
 @mock_s3

--- a/tests/test_taar_locale.py
+++ b/tests/test_taar_locale.py
@@ -146,7 +146,7 @@ def multi_locales_df(generate_data):
 
     sample_snippets = []
     counter = 0
-    for locale, count in LOCALE_COUNTS.iteritems():
+    for locale, count in LOCALE_COUNTS.items():
         for i in range(count):
             variation = {"locale": locale, "client_id": "client-{}".format(counter)}
             sample_snippets.append(variation)

--- a/tests/test_taar_similarity.py
+++ b/tests/test_taar_similarity.py
@@ -358,7 +358,7 @@ def test_compute_donors(spark, addon_whitelist, multi_clusters_df):
         ]
         donor = cluster_donors[0]
         for f in REQUIRED_FIELDS:
-            assert f in donor.keys()
+            assert f in list(donor.keys())
 
         # Verify that no system addon or unlisted addons are reported.
         assert "system-addon-guid" not in donor["active_addons"]

--- a/tests/test_taar_similarity.py
+++ b/tests/test_taar_similarity.py
@@ -188,7 +188,11 @@ def multi_clusters_df(generate_data):
             sample_snippets.append(variation)
             counter = counter + 1
 
-    return generate_data(sample_snippets)
+    dataframe = generate_data(sample_snippets)
+    dataframe.createOrReplaceTempView("clients_daily")
+    dataframe.cache()
+    yield dataframe
+    dataframe.unpersist()
 
 
 @pytest.fixture
@@ -306,7 +310,6 @@ def test_get_samples(spark, dataframe_factory):
 
 
 def test_get_addons(spark, addon_whitelist, multi_clusters_df):
-    multi_clusters_df.createOrReplaceTempView("clients_daily")
 
     samples_df = taar_similarity.get_samples(spark, date_from='20180101')
 
@@ -323,7 +326,6 @@ def test_get_addons(spark, addon_whitelist, multi_clusters_df):
 
 @pytest.mark.timeout(600)
 def test_compute_donors(spark, addon_whitelist, multi_clusters_df):
-    multi_clusters_df.createOrReplaceTempView("clients_daily")
 
     # Perform the clustering on our test data. We expect
     # 3 clusters out of this and 10 donors.

--- a/tests/test_taar_utils.py
+++ b/tests/test_taar_utils.py
@@ -52,8 +52,8 @@ def test_read_from_s3():
     conn = boto3.resource("s3", region_name="us-west-2")
     conn.create_bucket(Bucket=bucket)
 
-    with NamedTemporaryFile() as json_file:
-        json_file.write(json.dumps(SAMPLE_DATA))
+    with NamedTemporaryFile("w") as json_file:
+        json.dump(SAMPLE_DATA, json_file)
         # Seek to the beginning of the file to allow the tested
         # function to find the file content.
         json_file.seek(0)
@@ -73,8 +73,8 @@ def test_write_to_s3():
     conn = boto3.resource("s3", region_name="us-west-2")
     bucket_obj = conn.create_bucket(Bucket=bucket)
 
-    with NamedTemporaryFile() as json_file:
-        json_file.write(json.dumps(SAMPLE_DATA))
+    with NamedTemporaryFile("w") as json_file:
+        json.dump(SAMPLE_DATA, json_file)
         # Seek to the beginning of the file to allow the tested
         # function to find the file content.
         json_file.seek(0)

--- a/tests/test_tab_spinner_aggregates.py
+++ b/tests/test_tab_spinner_aggregates.py
@@ -21,7 +21,7 @@ def test_simple_transform(simple_rdd, spark_context):
     # get rid of pd index
     result = {
         k: {build_id: series.values for build_id, series in v}
-        for k, v in results.iteritems()
+        for k, v in results.items()
     }
 
     expected = {
@@ -29,6 +29,6 @@ def test_simple_transform(simple_rdd, spark_context):
         "long": {"20170101":  pd.Series([0, 0.0, 1.0, 0, 0, 0, 0, 0])}
     }
 
-    for k, v in expected.iteritems():
-        for build_id, series in v.iteritems():
+    for k, v in expected.items():
+        for build_id, series in v.items():
             assert all(result[k][build_id] == series)

--- a/tests/test_topline_historical_backfill.py
+++ b/tests/test_topline_historical_backfill.py
@@ -6,6 +6,7 @@ from click.testing import CliRunner
 
 from mozetl.topline import historical_backfill as backfill
 from mozetl.topline.schema import historical_schema
+from six import text_type
 
 
 @pytest.fixture(autouse=True)
@@ -107,7 +108,7 @@ def test_cli_monthly(generate_data, tmpdir, monkeypatch):
 
     csv_data = ','.join(input_df.columns) + '\n'
     for row in input_df.collect():
-        csv_data += ','.join([unicode(x) for x in row]) + '\n'
+        csv_data += ','.join([text_type(x) for x in row]) + '\n'
 
     input_csv.write(csv_data)
 

--- a/tests/test_topline_summary.py
+++ b/tests/test_topline_summary.py
@@ -26,10 +26,10 @@ def generate_dates(submission_date_s3, ts_offset=0, creation_offset=0):
     date_snippet = {
         "submission_date_s3": submission_date_s3,
         "profile_creation_date": (
-            long((creation - epoch).total_seconds() / seconds_per_day)
+            int((creation - epoch).total_seconds() / seconds_per_day)
         ),
         "timestamp": (
-            long((timestamp - epoch).total_seconds() * nanoseconds_per_second)
+            int((timestamp - epoch).total_seconds() * nanoseconds_per_second)
         )
     }
 
@@ -72,7 +72,7 @@ end_ds = "20170608"
 default_sample = {
     "document_id": "document-id",
     "client_id": "client-id",
-    "timestamp": long(1.4962752e+18),
+    "timestamp": int(1.4962752e+18),
     "is_default_browser": True,
     "search_counts": [search_row()],
     "country": "US",

--- a/tests/test_topline_summary.py
+++ b/tests/test_topline_summary.py
@@ -8,6 +8,7 @@ from pyspark.sql import functions as F, Row
 from pyspark.sql.types import (
     StructField, StructType, StringType, BooleanType, ArrayType, LongType
 )
+from six import text_type
 
 from mozetl.topline import topline_summary as topline
 
@@ -38,8 +39,8 @@ def generate_dates(submission_date_s3, ts_offset=0, creation_offset=0):
 
 def search_row(engine='hooli', count=1, source='searchbar'):
     return Row(
-        engine=unicode(engine),
-        source=unicode(source),
+        engine=text_type(engine),
+        source=text_type(source),
         count=count
     )
 

--- a/tests/test_topline_summary.py
+++ b/tests/test_topline_summary.py
@@ -11,6 +11,7 @@ from pyspark.sql.types import (
 from six import text_type
 
 from mozetl.topline import topline_summary as topline
+from mozetl.topline.schema import topline_schema
 
 
 def generate_dates(submission_date_s3, ts_offset=0, creation_offset=0):
@@ -340,3 +341,7 @@ def test_job_weekly(spark, generate_data, monkeypatch, tmpdir):
 
     row = df.first()
     assert row.actives == 3
+
+    # the module schema does not include the mode, and the partition column is a string
+    df = df.drop("mode").withColumn("report_start", F.col("report_start").astype("string"))
+    assert df.schema == topline_schema

--- a/tests/test_txp_mau_dau.py
+++ b/tests/test_txp_mau_dau.py
@@ -1,5 +1,5 @@
 from mozetl.testpilot.txp_mau_dau import get_experiments
-from utils import get_resource
+from .utils import get_resource
 import requests
 import json
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,7 +32,7 @@ def test_write_csv_ascii(generate_data, tmpdir):
     with open(path, 'rb') as f:
         data = f.read()
 
-    assert data.rstrip().split('\r\n')[1:] == test_data
+    assert [l.decode('utf-8') for l in data.rstrip().split(b'\r\n')[1:]] == test_data
 
 
 def test_generate_filter_parameters():
@@ -66,9 +66,9 @@ def test_write_csv_valid_unicode(generate_data, tmpdir):
     utils.write_csv(df, path)
 
     with open(path, 'rb') as f:
-        data = f.read().decode('utf-8')
+        data = f.read()
 
-    assert data.rstrip().split('\r\n')[1:] == test_data
+    assert [l.decode('utf-8') for l in data.rstrip().split(b'\r\n')[1:]] == test_data
 
 
 @mock_s3

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, flake8, black, docs
+envlist = py27, py35, flake8, black, docs
 
 [pytest]
 addopts =


### PR DESCRIPTION
This is part 2 of adding python 3 support in mozetl. This fixes broken tests by 2to3 and general incompatibilities between python 2 and 3.

See #290 for part 1 that adds CI
See #282 for the final state in this series of PRs