### PR TITLE
[part 3] Enforce formatting with black

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
 
   lint:
     docker:
-      - image: python:2.7
+      - image: python:3.6
     working_directory: ~/python_mozetl
     steps:
       - checkout
@@ -88,7 +88,7 @@ jobs:
       - run: *install_dependencies
       - run:
           name: run linter
-          command: tox -e flake8
+          command: tox -e flake8,black
       - save_cache: *save_cache_settings
 
   docs:

--- a/mozetl/addon_aggregates/addon_aggregates.py
+++ b/mozetl/addon_aggregates/addon_aggregates.py
@@ -1,4 +1,4 @@
-'''ETL code for the addon_aggregates dataset'''
+"""ETL code for the addon_aggregates dataset"""
 
 from pyspark.sql import SparkSession
 import pyspark.sql.functions as fun
@@ -6,37 +6,41 @@ import json
 from six.moves import urllib
 import click
 
-MS_FIELDS = ['client_id',
-             'normalized_channel',
-             'app_version',
-             'locale',
-             'sample_id',
-             'profile_creation_date']
+MS_FIELDS = [
+    "client_id",
+    "normalized_channel",
+    "app_version",
+    "locale",
+    "sample_id",
+    "profile_creation_date",
+]
 
-ADDON_FIELDS = ['addons.addon_id',
-                'addons.foreign_install',
-                'addons.is_system',
-                'addons.is_web_extension',
-                'addons.install_day']
+ADDON_FIELDS = [
+    "addons.addon_id",
+    "addons.foreign_install",
+    "addons.is_system",
+    "addons.is_web_extension",
+    "addons.install_day",
+]
 
 
 def get_test_pilot_addons():
-    '''
+    """
     Fetches all the live test pilot experiments listed in
     the experiments.json file.
     :return a list of addon_ids
-    '''
+    """
     url = "https://testpilot.firefox.com/api/experiments.json"
     response = urllib.request.urlopen(url)
     data = json.loads(response.read().decode("utf-8"))
-    all_tp_addons = (
-        ["@testpilot-addon"] + [i.get("addon_id") for i in data['results'] if i.get("addon_id")]
-        )
+    all_tp_addons = ["@testpilot-addon"] + [
+        i.get("addon_id") for i in data["results"] if i.get("addon_id")
+    ]
     return all_tp_addons
 
 
 def get_dest(output_bucket, output_prefix, output_version, date=None, sample_id=None):
-    '''
+    """
     Stitches together an s3 destination.
 
     :param output_bucket: s3 output_bucket
@@ -44,17 +48,22 @@ def get_dest(output_bucket, output_prefix, output_version, date=None, sample_id=
     :param output_version: dataset output_version
     :retrn str ->
     s3://output_bucket/output_prefix/output_version/submissin_date_s3=[date]/sample_id=[sid]
-    '''
-    suffix = ''
+    """
+    suffix = ""
     if date is not None:
         suffix += "/submission_date_s3={}".format(date)
     if sample_id is not None:
         suffix += "/sample_id={}".format(sample_id)
-    return 's3://' + '/'.join([output_bucket, output_prefix, output_version]) + suffix + '/'
+    return (
+        "s3://"
+        + "/".join([output_bucket, output_prefix, output_version])
+        + suffix
+        + "/"
+    )
 
 
 def load_main_summary(spark, input_bucket, input_prefix, input_version):
-    '''
+    """
     Loads main_summary from the bucket constructed from
     input_bucket, input_prefix, input_version
 
@@ -63,33 +72,30 @@ def load_main_summary(spark, input_bucket, input_prefix, input_version):
     :param input_prefix: s3 prefix (main_summary)
     :param input_version: dataset version (v4)
     :return SparkDF
-    '''
+    """
     dest = get_dest(input_bucket, input_prefix, input_version)
     print("loading...", dest)
-    return (spark
-            .read
-            .option("mergeSchema", True)
-            .parquet(dest))
+    return spark.read.option("mergeSchema", True).parquet(dest)
 
 
 def ms_explode_addons(ms):
-    '''
+    """
     Explodes the active_addons object in
     the ms DataFrame and selects relevant fields
 
     :param ms: a subset of main_summary
     :return SparkDF
-    '''
+    """
     addons_df = (
-        ms
-        .select(MS_FIELDS + [fun.explode('active_addons').alias('addons')])
+        ms.select(MS_FIELDS + [fun.explode("active_addons").alias("addons")])
         .select(MS_FIELDS + ADDON_FIELDS)
-        .withColumn("app_version", fun.substring("app_version", 1, 2)))
+        .withColumn("app_version", fun.substring("app_version", 1, 2))
+    )
     return addons_df
 
 
 def add_addon_columns(df):
-    '''
+    """
     Constructs additional indicator columns decribing the add-on/theme
     present in a given record. The columns are
 
@@ -104,32 +110,34 @@ def add_addon_columns(df):
     :param df: SparkDF, exploded on active_addons, each record
                maps to a single add-on
     :return df with the above columns added
-    '''
+    """
     addons_expanded = (
-        df
-        .withColumn("is_self_install",
-                    fun.when((df.addon_id.isNotNull()) &
-                             (~ df.is_system) &
-                             (~ df.foreign_install) &
-                             (~ df.addon_id.like('%mozilla%')) &
-                             (~ df.addon_id.like('%cliqz%')) &
-                             (~ df.addon_id.like('%@unified-urlbar%')) &
-                             (~ df.addon_id.isin(*NON_MOZ_TEST_PILOT_ADDONS)),
-                             1).otherwise(0))
-        .withColumn("is_shield_addon",
-                    fun.when(df.addon_id.like('%@shield.mozilla%'),
-                             1).otherwise(0))
-        .withColumn("is_foreign_install",
-                    fun.when(df.foreign_install, 1).otherwise(0))
-        .withColumn("is_system",
-                    fun.when(df.is_system, 1).otherwise(0))
-        .withColumn("is_web_extension",
-                    fun.when(df.is_web_extension, 1).otherwise(0)))
+        df.withColumn(
+            "is_self_install",
+            fun.when(
+                (df.addon_id.isNotNull())
+                & (~df.is_system)
+                & (~df.foreign_install)
+                & (~df.addon_id.like("%mozilla%"))
+                & (~df.addon_id.like("%cliqz%"))
+                & (~df.addon_id.like("%@unified-urlbar%"))
+                & (~df.addon_id.isin(*NON_MOZ_TEST_PILOT_ADDONS)),
+                1,
+            ).otherwise(0),
+        )
+        .withColumn(
+            "is_shield_addon",
+            fun.when(df.addon_id.like("%@shield.mozilla%"), 1).otherwise(0),
+        )
+        .withColumn("is_foreign_install", fun.when(df.foreign_install, 1).otherwise(0))
+        .withColumn("is_system", fun.when(df.is_system, 1).otherwise(0))
+        .withColumn("is_web_extension", fun.when(df.is_web_extension, 1).otherwise(0))
+    )
     return addons_expanded
 
 
 def aggregate_addons(df):
-    '''
+    """
     Aggregates add-on indicators by client, channel, version and locale.
     The result is a DataFrame with the additional aggregate columns:
 
@@ -146,52 +154,64 @@ def aggregate_addons(df):
     :param df: an expoded instance of main_summary by active_addons
                with various additional indicator columns
     :return SparkDF: an aggregated dataset with each of the above columns
-    '''
+    """
     addon_aggregates = (
-        df
-        .distinct().groupBy("client_id", "normalized_channel", "app_version", "locale")
-        .agg(fun.sum("is_self_install").alias("n_self_installed_addons"),
-             fun.sum("is_shield_addon").alias("n_shield_addons"),
-             fun.sum("is_foreign_install").alias("n_foreign_installed_addons"),
-             fun.sum("is_system").alias("n_system_addons"),
-             fun.sum("is_web_extension").alias("n_web_extensions"),
-             fun.min(fun.when(df.is_self_install == 1,
-                              fun.date_format(fun.from_unixtime(fun.col("install_day")*60*60*24),
-                                              "yyyyMMdd")).otherwise(None))
-             .alias("first_addon_install_date"),
-             fun.date_format(
-                fun.from_unixtime(
-                    fun.min("profile_creation_date")*60*60*24), "yyyyMMdd")
-             .alias("profile_creation_date")))
+        df.distinct()
+        .groupBy("client_id", "normalized_channel", "app_version", "locale")
+        .agg(
+            fun.sum("is_self_install").alias("n_self_installed_addons"),
+            fun.sum("is_shield_addon").alias("n_shield_addons"),
+            fun.sum("is_foreign_install").alias("n_foreign_installed_addons"),
+            fun.sum("is_system").alias("n_system_addons"),
+            fun.sum("is_web_extension").alias("n_web_extensions"),
+            fun.min(
+                fun.when(
+                    df.is_self_install == 1,
+                    fun.date_format(
+                        fun.from_unixtime(fun.col("install_day") * 60 * 60 * 24),
+                        "yyyyMMdd",
+                    ),
+                ).otherwise(None)
+            ).alias("first_addon_install_date"),
+            fun.date_format(
+                fun.from_unixtime(fun.min("profile_creation_date") * 60 * 60 * 24),
+                "yyyyMMdd",
+            ).alias("profile_creation_date"),
+        )
+    )
     return addon_aggregates
 
 
-NON_MOZ_TEST_PILOT_ADDONS = set([i for i in get_test_pilot_addons() if 'mozilla' not in i])
+NON_MOZ_TEST_PILOT_ADDONS = set(
+    [i for i in get_test_pilot_addons() if "mozilla" not in i]
+)
 DEFAULT_THEME_ID = "{972ce4c6-7e08-4474-a285-3208198ce6fd}"
 
 
 @click.command()
-@click.option('--date', required=True)
-@click.option('--input-bucket', default='telemetry-parquet')
-@click.option('--input-prefix', default='main_summary')
-@click.option('--input-version', default='v4')
-@click.option('--output-bucket', default='telemetry-parquet')
-@click.option('--output-prefix', default='addons/agg')
-@click.option('--output-version', default='v2')
-def main(date, input_bucket, input_prefix, input_version,
-         output_bucket, output_prefix, output_version):
-    '''
+@click.option("--date", required=True)
+@click.option("--input-bucket", default="telemetry-parquet")
+@click.option("--input-prefix", default="main_summary")
+@click.option("--input-version", default="v4")
+@click.option("--output-bucket", default="telemetry-parquet")
+@click.option("--output-prefix", default="addons/agg")
+@click.option("--output-version", default="v2")
+def main(
+    date,
+    input_bucket,
+    input_prefix,
+    input_version,
+    output_bucket,
+    output_prefix,
+    output_version,
+):
+    """
     Loads main_summary where submission_date_s3 == date
     Partition by sample_id and write aggregated data to s3
-    '''
-    spark = (SparkSession
-             .builder
-             .appName("addon_aggregates")
-             .getOrCreate())
+    """
+    spark = SparkSession.builder.appName("addon_aggregates").getOrCreate()
     # don't write _SUCCESS files, which interfere w/ReDash discovery
-    spark.conf.set(
-        "mapreduce.fileoutputcommitter.marksuccessfuljobs", "false"
-    )
+    spark.conf.set("mapreduce.fileoutputcommitter.marksuccessfuljobs", "false")
     # load main_summary
     ms = load_main_summary(spark, input_bucket, input_prefix, input_version)
     # filter main summary to the date supplied in the environment
@@ -203,8 +223,8 @@ def main(date, input_bucket, input_prefix, input_version,
         aggregates = aggregate_addons(exploded_addons)
         dest = get_dest(output_bucket, output_prefix, output_version, date, sample_id)
         # 1 partition is ~ 50MB
-        aggregates.repartition(1).write.format('parquet').save(dest, mode='overwrite')
+        aggregates.repartition(1).write.format("parquet").save(dest, mode="overwrite")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/mozetl/basic/transform.py
+++ b/mozetl/basic/transform.py
@@ -9,8 +9,9 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-ColumnConfig = namedtuple('ColumnConfig',
-                          ['name', 'path', 'cleaning_func', 'struct_type'])
+ColumnConfig = namedtuple(
+    "ColumnConfig", ["name", "path", "cleaning_func", "struct_type"]
+)
 
 
 class DataFrameConfig(object):
@@ -29,10 +30,9 @@ class DataFrameConfig(object):
 
 def convert_pings(sqlContext, pings, data_frame_config):
     """Performs basic data pipelining on raw telemetry pings """
-    filtered_pings = get_pings_properties(
-        pings,
-        data_frame_config.get_paths()
-    ).filter(data_frame_config.ping_filter)
+    filtered_pings = get_pings_properties(pings, data_frame_config.get_paths()).filter(
+        data_frame_config.ping_filter
+    )
 
     return convert_rdd(sqlContext, filtered_pings, data_frame_config)
 
@@ -45,8 +45,7 @@ def _build_cell(ping, column_config):
         try:
             return func(raw_value)
         except Exception as e:
-            logger.warning("Unable to apply transform on data '%s': %s",
-                           raw_value, e)
+            logger.warning("Unable to apply transform on data '%s': %s", raw_value, e)
             return None
     else:
         return raw_value
@@ -62,6 +61,5 @@ def convert_rdd(sqlContext, raw_data, data_frame_config):
         return [_build_cell(ping, col) for col in data_frame_config.columns]
 
     return sqlContext.createDataFrame(
-        raw_data.map(ping_to_row),
-        schema=data_frame_config.toStructType()
+        raw_data.map(ping_to_row), schema=data_frame_config.toStructType()
     )

--- a/mozetl/cli.py
+++ b/mozetl/cli.py
@@ -8,14 +8,16 @@ from mozetl.engagement.retention import job as retention_job
 from mozetl.experimentsdaily import rollup as experimentsdaily
 from mozetl.landfill import sampler as landfill_sampler
 from mozetl.maudau import maudau
-from mozetl.search.aggregates import (
-    search_aggregates_click, search_clients_daily_click
-)
+from mozetl.search.aggregates import search_aggregates_click, search_clients_daily_click
 from mozetl.sync import bookmark_validation
 from mozetl.taar import (
-    taar_locale, taar_similarity,
-    taar_dynamo, taar_amodump, taar_amowhitelist,
-    taar_lite_guidguid, taar_lite_guidranking
+    taar_locale,
+    taar_similarity,
+    taar_dynamo,
+    taar_amodump,
+    taar_amowhitelist,
+    taar_lite_guidguid,
+    taar_lite_guidranking,
 )
 
 
@@ -46,5 +48,5 @@ entry_point.add_command(landfill_sampler.main, "landfill_sampler")
 # Kept for backwards compatibility
 entry_point.add_command(search_aggregates_click, "search_dashboard")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     entry_point()

--- a/mozetl/clientsdaily/fields.py
+++ b/mozetl/clientsdaily/fields.py
@@ -6,7 +6,7 @@ VERSION = 1
 def get_alias(field_name, alias, kind):
     field_alias = alias
     if field_alias is None:
-        field_alias = '{}_{}'.format(field_name, kind)
+        field_alias = "{}_{}".format(field_name, kind)
     return field_alias
 
 
@@ -33,183 +33,193 @@ def agg_max(field_name, alias=None):
 
 
 _FIELD_AGGREGATORS = [
-    agg_sum('aborts_content'),
-    agg_sum('aborts_gmplugin'),
-    agg_sum('aborts_plugin'),
+    agg_sum("aborts_content"),
+    agg_sum("aborts_gmplugin"),
+    agg_sum("aborts_plugin"),
     # active_addons
-    agg_mean('active_addons_count'),
+    agg_mean("active_addons_count"),
     # MAIN_SUMMARY_FIELD_AGGREGATORS inserts here
-
     # active_theme
-    agg_sum('active_ticks', alias='active_hours_sum',
-            expression=F.expr('active_ticks/(3600.0/5)')),
-    agg_first('addon_compatibility_check_enabled'),
-    agg_first('app_build_id'),
-    agg_first('app_display_version'),
-    agg_first('app_name'),
-    agg_first('app_version'),
+    agg_sum(
+        "active_ticks",
+        alias="active_hours_sum",
+        expression=F.expr("active_ticks/(3600.0/5)"),
+    ),
+    agg_first("addon_compatibility_check_enabled"),
+    agg_first("app_build_id"),
+    agg_first("app_display_version"),
+    agg_first("app_name"),
+    agg_first("app_version"),
     # attribution
-    agg_first('blocklist_enabled'),
-    agg_first('channel'),
+    agg_first("blocklist_enabled"),
+    agg_first("channel"),
     F.first(
         F.expr(
-            "IF(country IS NOT NULL AND country != '??'," \
+            "IF(country IS NOT NULL AND country != '??',"
             " IF(city IS NOT NULL, city, '??'), NULL)"
         )
-    ).alias('city'),
+    ).alias("city"),
     F.first(
         F.expr(
-            "IF(country IS NOT NULL AND country != '??'," \
+            "IF(country IS NOT NULL AND country != '??',"
             " IF(geo_subdivision1 IS NOT NULL, geo_subdivision1, '??'), NULL)"
         )
-    ).alias('geo_subdivision1'),
+    ).alias("geo_subdivision1"),
     F.first(
         F.expr(
-            "IF(country IS NOT NULL AND country != '??'," \
+            "IF(country IS NOT NULL AND country != '??',"
             " IF(geo_subdivision2 IS NOT NULL, geo_subdivision2, '??'), NULL)"
         )
-    ).alias('geo_subdivision2'),
-    F.first(
-        F.expr("IF(country IS NOT NULL AND country != '??', country, NULL)")
-    ).alias('country'),
-    agg_sum('crashes_detected_content'),
-    agg_sum('crashes_detected_gmplugin'),
-    agg_sum('crashes_detected_plugin'),
-    agg_sum('crash_submit_attempt_content'),
-    agg_sum('crash_submit_attempt_main'),
-    agg_sum('crash_submit_attempt_plugin'),
-    agg_sum('crash_submit_success_content'),
-    agg_sum('crash_submit_success_main'),
-    agg_sum('crash_submit_success_plugin'),
-    agg_first('default_search_engine'),
-    agg_first('default_search_engine_data_load_path'),
-    agg_first('default_search_engine_data_name'),
-    agg_first('default_search_engine_data_origin'),
-    agg_first('default_search_engine_data_submission_url'),
-    agg_sum('devtools_toolbox_opened_count'),
-    agg_first('distribution_id'),
+    ).alias("geo_subdivision2"),
+    F.first(F.expr("IF(country IS NOT NULL AND country != '??', country, NULL)")).alias(
+        "country"
+    ),
+    agg_sum("crashes_detected_content"),
+    agg_sum("crashes_detected_gmplugin"),
+    agg_sum("crashes_detected_plugin"),
+    agg_sum("crash_submit_attempt_content"),
+    agg_sum("crash_submit_attempt_main"),
+    agg_sum("crash_submit_attempt_plugin"),
+    agg_sum("crash_submit_success_content"),
+    agg_sum("crash_submit_success_main"),
+    agg_sum("crash_submit_success_plugin"),
+    agg_first("default_search_engine"),
+    agg_first("default_search_engine_data_load_path"),
+    agg_first("default_search_engine_data_name"),
+    agg_first("default_search_engine_data_origin"),
+    agg_first("default_search_engine_data_submission_url"),
+    agg_sum("devtools_toolbox_opened_count"),
+    agg_first("distribution_id"),
     # userprefs/dom_ipc_process_count
-    agg_first('e10s_enabled'),
-    agg_first('env_build_arch'),
-    agg_first('env_build_id'),
-    agg_first('env_build_version'),
+    agg_first("e10s_enabled"),
+    agg_first("env_build_arch"),
+    agg_first("env_build_id"),
+    agg_first("env_build_version"),
     # events
     # EXPERIMENT_FIELD_AGGREGATORS inserts here
     # experiments
-    agg_mean('first_paint'),
+    agg_mean("first_paint"),
     # F.first(
     #     F.expr("userprefs.extensions_allow_non_mpc_extensions"
     #        ).alias("extensions_allow_non_mpc_extensions")
     # ),
-    agg_first('flash_version'),
-    agg_first('install_year'),
-    agg_first('is_default_browser'),
-    agg_first('is_wow64'),
-    agg_first('locale'),
+    agg_first("flash_version"),
+    agg_first("install_year"),
+    agg_first("is_default_browser"),
+    agg_first("is_wow64"),
+    agg_first("locale"),
     # main
-    agg_first('memory_mb'),  # mean?
-    agg_first('os'),
-    agg_first('os_service_pack_major'),
-    agg_first('os_service_pack_minor'),
-    agg_first('os_version'),
-    agg_first('normalized_channel'),
-    F.countDistinct('document_id').alias('pings_aggregated_by_this_row'),
-    agg_mean('places_bookmarks_count'),
-    agg_mean('places_pages_count'),
-    agg_sum('plugin_hangs'),
-    agg_sum('plugins_infobar_allow'),
-    agg_sum('plugins_infobar_block'),
-    agg_sum('plugins_infobar_shown'),
-    agg_sum('plugins_notification_shown'),
+    agg_first("memory_mb"),  # mean?
+    agg_first("os"),
+    agg_first("os_service_pack_major"),
+    agg_first("os_service_pack_minor"),
+    agg_first("os_version"),
+    agg_first("normalized_channel"),
+    F.countDistinct("document_id").alias("pings_aggregated_by_this_row"),
+    agg_mean("places_bookmarks_count"),
+    agg_mean("places_pages_count"),
+    agg_sum("plugin_hangs"),
+    agg_sum("plugins_infobar_allow"),
+    agg_sum("plugins_infobar_block"),
+    agg_sum("plugins_infobar_shown"),
+    agg_sum("plugins_notification_shown"),
     # plugins_notification_user_action
     # popup_notification_stats
     F.first(
         F.expr(
-            "datediff(subsession_start_date, " \
+            "datediff(subsession_start_date, "
             "from_unixtime(profile_creation_date*24*60*60))"
         )
     ).alias("profile_age_in_days"),
-    F.first(
-        F.expr("from_unixtime(profile_creation_date*24*60*60)")
-    ).alias('profile_creation_date'),
-    agg_sum('push_api_notify'),
-    agg_first('sample_id'),
-    agg_first('scalar_parent_aushelper_websense_reg_version'),
-    agg_max('scalar_parent_browser_engagement_max_concurrent_tab_count'),
-    agg_max('scalar_parent_browser_engagement_max_concurrent_window_count'),
+    F.first(F.expr("from_unixtime(profile_creation_date*24*60*60)")).alias(
+        "profile_creation_date"
+    ),
+    agg_sum("push_api_notify"),
+    agg_first("sample_id"),
+    agg_first("scalar_parent_aushelper_websense_reg_version"),
+    agg_max("scalar_parent_browser_engagement_max_concurrent_tab_count"),
+    agg_max("scalar_parent_browser_engagement_max_concurrent_window_count"),
     # scalar_parent_browser_engagement_navigation_about_home
     # scalar_parent_browser_engagement_navigation_about_newtab
     # scalar_parent_browser_engagement_navigation_contextmenu
     # scalar_parent_browser_engagement_navigation_searchbar
     # scalar_parent_browser_engagement_navigation_urlbar
-    agg_sum('scalar_parent_browser_engagement_tab_open_event_count'),
-    agg_sum('scalar_parent_browser_engagement_total_uri_count'),
-    agg_sum('scalar_parent_browser_engagement_unfiltered_uri_count'),
+    agg_sum("scalar_parent_browser_engagement_tab_open_event_count"),
+    agg_sum("scalar_parent_browser_engagement_total_uri_count"),
+    agg_sum("scalar_parent_browser_engagement_unfiltered_uri_count"),
     # Include both max and mean for unique domains:
-    agg_max('scalar_parent_browser_engagement_unique_domains_count'),
-    agg_mean('scalar_parent_browser_engagement_unique_domains_count'),
-    agg_sum('scalar_parent_browser_engagement_window_open_event_count'),
+    agg_max("scalar_parent_browser_engagement_unique_domains_count"),
+    agg_mean("scalar_parent_browser_engagement_unique_domains_count"),
+    agg_sum("scalar_parent_browser_engagement_window_open_event_count"),
     # F.sum('scalar_parent_browser_browser_usage_graphite').alias(
     #     'scalar_parent_browser_browser_usage_graphite_sum')
-    agg_sum('scalar_parent_devtools_copy_full_css_selector_opened'),
-    agg_sum('scalar_parent_devtools_copy_unique_css_selector_opened'),
-    agg_sum('scalar_parent_devtools_toolbar_eyedropper_opened'),
-    agg_sum('scalar_parent_dom_contentprocess_troubled_due_to_memory'),
-    agg_sum('scalar_parent_navigator_storage_estimate_count'),
-    agg_sum('scalar_parent_navigator_storage_persist_count'),
-    agg_first('scalar_parent_services_sync_fxa_verification_method'),
-    agg_sum('scalar_parent_storage_sync_api_usage_extensions_using'),
+    agg_sum("scalar_parent_devtools_copy_full_css_selector_opened"),
+    agg_sum("scalar_parent_devtools_copy_unique_css_selector_opened"),
+    agg_sum("scalar_parent_devtools_toolbar_eyedropper_opened"),
+    agg_sum("scalar_parent_dom_contentprocess_troubled_due_to_memory"),
+    agg_sum("scalar_parent_navigator_storage_estimate_count"),
+    agg_sum("scalar_parent_navigator_storage_persist_count"),
+    agg_first("scalar_parent_services_sync_fxa_verification_method"),
+    agg_sum("scalar_parent_storage_sync_api_usage_extensions_using"),
     # scalar_parent_storage_sync_api_usage_items_stored
     # scalar_parent_storage_sync_api_usage_storage_consumed
-    agg_first('scalar_parent_telemetry_os_shutting_down'),
-    agg_sum('scalar_parent_webrtc_nicer_stun_retransmits'),
-    agg_sum('scalar_parent_webrtc_nicer_turn_401s'),
-    agg_sum('scalar_parent_webrtc_nicer_turn_403s'),
-    agg_sum('scalar_parent_webrtc_nicer_turn_438s'),
-    agg_first('search_cohort'),
-    agg_sum('search_count_all'),
-    agg_sum('search_count_abouthome'),
-    agg_sum('search_count_contextmenu'),
-    agg_sum('search_count_newtab'),
-    agg_sum('search_count_searchbar'),
-    agg_sum('search_count_system'),
-    agg_sum('search_count_urlbar'),
-    agg_mean('session_restored'),
-    agg_sum('subsession_counter', alias='sessions_started_on_this_day',
-            expression=F.expr("IF(subsession_counter = 1, 1, 0)")),
-    agg_sum('shutdown_kill'),
-    agg_sum('subsession_length', alias='subsession_hours_sum',
-            expression=F.expr('subsession_length/3600.0')),
+    agg_first("scalar_parent_telemetry_os_shutting_down"),
+    agg_sum("scalar_parent_webrtc_nicer_stun_retransmits"),
+    agg_sum("scalar_parent_webrtc_nicer_turn_401s"),
+    agg_sum("scalar_parent_webrtc_nicer_turn_403s"),
+    agg_sum("scalar_parent_webrtc_nicer_turn_438s"),
+    agg_first("search_cohort"),
+    agg_sum("search_count_all"),
+    agg_sum("search_count_abouthome"),
+    agg_sum("search_count_contextmenu"),
+    agg_sum("search_count_newtab"),
+    agg_sum("search_count_searchbar"),
+    agg_sum("search_count_system"),
+    agg_sum("search_count_urlbar"),
+    agg_mean("session_restored"),
+    agg_sum(
+        "subsession_counter",
+        alias="sessions_started_on_this_day",
+        expression=F.expr("IF(subsession_counter = 1, 1, 0)"),
+    ),
+    agg_sum("shutdown_kill"),
+    agg_sum(
+        "subsession_length",
+        alias="subsession_hours_sum",
+        expression=F.expr("subsession_length/3600.0"),
+    ),
     # ssl_handshake_result
-    agg_sum('ssl_handshake_result_failure'),
-    agg_sum('ssl_handshake_result_success'),
-    agg_first('sync_configured'),
-    agg_sum('sync_count_desktop'),  # TODO: max
-    agg_sum('sync_count_mobile'),   # TODO: max
-    agg_first('telemetry_enabled'),
-    agg_first('timezone_offset'),
-    agg_sum('total_time', alias='total_hours_sum',
-            expression=F.expr('total_time/3600.0')),
-    agg_first('vendor'),
-    agg_sum('web_notification_shown'),
-    agg_first('windows_build_number'),
-    agg_first('windows_ubr'),
+    agg_sum("ssl_handshake_result_failure"),
+    agg_sum("ssl_handshake_result_success"),
+    agg_first("sync_configured"),
+    agg_sum("sync_count_desktop"),  # TODO: max
+    agg_sum("sync_count_mobile"),  # TODO: max
+    agg_first("telemetry_enabled"),
+    agg_first("timezone_offset"),
+    agg_sum(
+        "total_time", alias="total_hours_sum", expression=F.expr("total_time/3600.0")
+    ),
+    agg_first("vendor"),
+    agg_sum("web_notification_shown"),
+    agg_first("windows_build_number"),
+    agg_first("windows_ubr"),
 ]
 
 
-MAIN_SUMMARY_FIELD_AGGREGATORS = _FIELD_AGGREGATORS[:4] + [
-    agg_first('active_experiment_branch'),
-    agg_first('active_experiment_id'),
-] + _FIELD_AGGREGATORS[4:]
+MAIN_SUMMARY_FIELD_AGGREGATORS = (
+    _FIELD_AGGREGATORS[:4]
+    + [agg_first("active_experiment_branch"), agg_first("active_experiment_id")]
+    + _FIELD_AGGREGATORS[4:]
+)
 
 
-EXPERIMENT_FIELD_AGGREGATORS = _FIELD_AGGREGATORS[:15] + [
-    agg_first('experiment_branch'),
-] + _FIELD_AGGREGATORS[15:]
+EXPERIMENT_FIELD_AGGREGATORS = (
+    _FIELD_AGGREGATORS[:15] + [agg_first("experiment_branch")] + _FIELD_AGGREGATORS[15:]
+)
 
 
-ACTIVITY_DATE_COLUMN = F.expr(
-    "substr(subsession_start_date, 1, 10)"
-).alias("activity_date")
+ACTIVITY_DATE_COLUMN = F.expr("substr(subsession_start_date, 1, 10)").alias(
+    "activity_date"
+)
 
 NULL_STRING_COLUMN = F.expr("STRING(NULL)")

--- a/mozetl/clientsdaily/rollup.py
+++ b/mozetl/clientsdaily/rollup.py
@@ -5,23 +5,22 @@ from mozetl.utils import extract_submission_window_for_activity_day
 from mozetl.utils import format_spark_path
 
 SEARCH_ACCESS_POINTS = [
-    'abouthome', 'contextmenu', 'newtab', 'searchbar', 'system', 'urlbar'
+    "abouthome",
+    "contextmenu",
+    "newtab",
+    "searchbar",
+    "system",
+    "urlbar",
 ]
-SEARCH_ACCESS_COLUMN_TEMPLATE = 'search_count_{}'
+SEARCH_ACCESS_COLUMN_TEMPLATE = "search_count_{}"
 SEARCH_ACCESS_COLUMNS = [
-    SEARCH_ACCESS_COLUMN_TEMPLATE.format(sap)
-    for sap in SEARCH_ACCESS_POINTS
+    SEARCH_ACCESS_COLUMN_TEMPLATE.format(sap) for sap in SEARCH_ACCESS_POINTS
 ]
 
 
 def load_main_summary(spark, input_bucket, input_prefix):
     main_summary_path = format_spark_path(input_bucket, input_prefix)
-    return (
-        spark
-        .read
-        .option("mergeSchema", "true")
-        .parquet(main_summary_path)
-    )
+    return spark.read.option("mergeSchema", "true").parquet(main_summary_path)
 
 
 def extract_search_counts(frame):
@@ -45,11 +44,11 @@ def extract_search_counts(frame):
       Replace (JOIN with WHERE NULL) with fillna() to an array literal.
       Maybe use a PIVOT.
     """
-    two_columns = frame.select(F.col("document_id").alias("did"),
-                               "search_counts")
+    two_columns = frame.select(F.col("document_id").alias("did"), "search_counts")
     # First, each row becomes N rows, N == len(search_counts)
     exploded = two_columns.select(
-        "did", F.explode("search_counts").alias("search_struct"))
+        "did", F.explode("search_counts").alias("search_struct")
+    )
     # Remove any rows where the values are corrupt
     exploded = exploded.where("search_struct.count > -1").where(
         "search_struct.source in %s" % str(tuple(SEARCH_ACCESS_POINTS))
@@ -68,14 +67,11 @@ def extract_search_counts(frame):
     #     0 as search_count_OTHER5
     if_template = "IF(search_struct.source = '{}', search_struct.count, 0)"
     if_expressions = [
-        F.expr(if_template.format(sap)).alias(
-            SEARCH_ACCESS_COLUMN_TEMPLATE.format(sap))
+        F.expr(if_template.format(sap)).alias(SEARCH_ACCESS_COLUMN_TEMPLATE.format(sap))
         for sap in SEARCH_ACCESS_POINTS
     ]
     unpacked = exploded.select(
-        "did",
-        F.expr("search_struct.count").alias("search_count_atom"),
-        *if_expressions
+        "did", F.expr("search_struct.count").alias("search_count_atom"), *if_expressions
     )
 
     # Collapse the exploded search_counts rows into a single output row.
@@ -83,19 +79,20 @@ def extract_search_counts(frame):
     grouping_dict["search_count_atom"] = "sum"
     grouped = unpacked.groupBy("did").agg(grouping_dict)
     extracted = grouped.select(
-        "did", F.col("sum(search_count_atom)").alias("search_count_all"),
-        *[
-            F.col("sum({})".format(c)).alias(c)
-            for c in SEARCH_ACCESS_COLUMNS
-         ]
+        "did",
+        F.col("sum(search_count_atom)").alias("search_count_all"),
+        *[F.col("sum({})".format(c)).alias(c) for c in SEARCH_ACCESS_COLUMNS]
     )
     # Create a homologous output row for each input row
     # where search_counts is NULL.
-    nulls = two_columns.select(
-        "did").where(
-        "search_counts is NULL").select(
-        "did", F.lit(0).alias("search_count_all"),
-        *[F.lit(0).alias(c) for c in SEARCH_ACCESS_COLUMNS]
+    nulls = (
+        two_columns.select("did")
+        .where("search_counts is NULL")
+        .select(
+            "did",
+            F.lit(0).alias("search_count_all"),
+            *[F.lit(0).alias(c) for c in SEARCH_ACCESS_COLUMNS]
+        )
     )
     intermediate = extracted.unionAll(nulls)
     result = frame.join(intermediate, frame.document_id == intermediate.did)
@@ -104,70 +101,82 @@ def extract_search_counts(frame):
 
 def to_profile_day_aggregates(frame_with_extracts):
     from .fields import MAIN_SUMMARY_FIELD_AGGREGATORS
+
     if "activity_date" not in frame_with_extracts.columns:
         from .fields import ACTIVITY_DATE_COLUMN
-        with_activity_date = frame_with_extracts.select(
-            "*", ACTIVITY_DATE_COLUMN
-        )
+
+        with_activity_date = frame_with_extracts.select("*", ACTIVITY_DATE_COLUMN)
     else:
         with_activity_date = frame_with_extracts
     if "geo_subdivision1" not in with_activity_date.columns:
         from .fields import NULL_STRING_COLUMN
-        with_activity_date = with_activity_date.withColumn("geo_subdivision1", NULL_STRING_COLUMN)
+
+        with_activity_date = with_activity_date.withColumn(
+            "geo_subdivision1", NULL_STRING_COLUMN
+        )
     if "geo_subdivision2" not in with_activity_date.columns:
         from .fields import NULL_STRING_COLUMN
-        with_activity_date = with_activity_date.withColumn("geo_subdivision2", NULL_STRING_COLUMN)
-    grouped = with_activity_date.groupby('client_id', 'activity_date')
+
+        with_activity_date = with_activity_date.withColumn(
+            "geo_subdivision2", NULL_STRING_COLUMN
+        )
+    grouped = with_activity_date.groupby("client_id", "activity_date")
     return grouped.agg(*MAIN_SUMMARY_FIELD_AGGREGATORS)
 
 
 def write_one_activity_day(results, date, output_prefix, partition_count):
-    output_path = "{}/activity_date_s3={}".format(output_prefix, date.strftime('%Y-%m-%d'))
+    output_path = "{}/activity_date_s3={}".format(
+        output_prefix, date.strftime("%Y-%m-%d")
+    )
     to_write = results.coalesce(partition_count)
-    to_write.write.parquet(output_path, mode='overwrite')
+    to_write.write.parquet(output_path, mode="overwrite")
     to_write.unpersist()
 
 
 def get_partition_count_for_writing(is_sampled):
-    '''
+    """
     Return a reasonable partition count.
 
     using_sample_id: boolean
     One day is O(140MB) if filtering down to a single sample_id, but
     O(14GB) if not. Google reports 256MB < partition size < 1GB as ideal.
-    '''
+    """
     if is_sampled:
         return 1
     return 25
 
 
 @click.command()
-@click.option('--date',
-              default=None,
-              help='Start date to run on')
-@click.option('--input-bucket',
-              default='telemetry-parquet',
-              help='Bucket of the input dataset')
-@click.option('--input-prefix',
-              default='main_summary/v4',
-              help='Prefix of the input dataset')
-@click.option('--output-bucket',
-              default='net-mozaws-prod-us-west-2-pipeline-analysis',
-              help='Bucket of the output dataset')
-@click.option('--output-prefix',
-              default='/clients_daily',
-              help='Prefix of the output dataset')
-@click.option('--output-version',
-              default=5,
-              help='Version of the output dataset')
-@click.option('--sample-id',
-              default=None,
-              help='Sample_id to restrict results to')
-@click.option('--lag-days',
-              default=10,
-              help='Number of days to allow for submission latency')
-def main(date, input_bucket, input_prefix, output_bucket,
-         output_prefix, output_version, sample_id, lag_days):
+@click.option("--date", default=None, help="Start date to run on")
+@click.option(
+    "--input-bucket", default="telemetry-parquet", help="Bucket of the input dataset"
+)
+@click.option(
+    "--input-prefix", default="main_summary/v4", help="Prefix of the input dataset"
+)
+@click.option(
+    "--output-bucket",
+    default="net-mozaws-prod-us-west-2-pipeline-analysis",
+    help="Bucket of the output dataset",
+)
+@click.option(
+    "--output-prefix", default="/clients_daily", help="Prefix of the output dataset"
+)
+@click.option("--output-version", default=5, help="Version of the output dataset")
+@click.option("--sample-id", default=None, help="Sample_id to restrict results to")
+@click.option(
+    "--lag-days", default=10, help="Number of days to allow for submission latency"
+)
+def main(
+    date,
+    input_bucket,
+    input_prefix,
+    output_bucket,
+    output_prefix,
+    output_version,
+    sample_id,
+    lag_days,
+):
     """
     Aggregate by (client_id, day) for a given day.
 
@@ -178,26 +187,24 @@ def main(date, input_bucket, input_prefix, output_bucket,
     including the activity day itself plus 5 days of lag for a total
     of 6 days).
     """
-    spark = (SparkSession
-             .builder
-             .appName("clients_daily")
-             .getOrCreate())
+    spark = SparkSession.builder.appName("clients_daily").getOrCreate()
     # Per https://issues.apache.org/jira/browse/PARQUET-142 ,
     # don't write _SUCCESS files, which interfere w/ReDash discovery
-    spark.conf.set(
-        "mapreduce.fileoutputcommitter.marksuccessfuljobs", "false"
-    )
+    spark.conf.set("mapreduce.fileoutputcommitter.marksuccessfuljobs", "false")
     main_summary = load_main_summary(spark, input_bucket, input_prefix)
-    day_frame, start_date = extract_submission_window_for_activity_day(main_summary, date, lag_days)
+    day_frame, start_date = extract_submission_window_for_activity_day(
+        main_summary, date, lag_days
+    )
     if sample_id:
         day_frame = day_frame.where("sample_id = '{}'".format(sample_id))
     with_searches = extract_search_counts(day_frame)
     results = to_profile_day_aggregates(with_searches)
     partition_count = get_partition_count_for_writing(bool(sample_id))
     output_base_path = "{}/v{}/".format(
-        format_spark_path(output_bucket, output_prefix), output_version)
+        format_spark_path(output_bucket, output_prefix), output_version
+    )
     write_one_activity_day(results, start_date, output_base_path, partition_count)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/mozetl/constants.py
+++ b/mozetl/constants.py
@@ -3,6 +3,13 @@
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1367554
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1368089
 SEARCH_SOURCE_WHITELIST = [
-    'searchbar', 'urlbar', 'abouthome', 'newtab', 'contextmenu', 'system',
-    'activitystream', 'webextension', 'alias'
+    "searchbar",
+    "urlbar",
+    "abouthome",
+    "newtab",
+    "contextmenu",
+    "system",
+    "activitystream",
+    "webextension",
+    "alias",
 ]

--- a/mozetl/engagement/churn/job.py
+++ b/mozetl/engagement/churn/job.py
@@ -64,10 +64,44 @@ SOURCE_COLUMNS = [
 ]
 
 TOP_COUNTRIES = {
-    "US", "DE", "FR", "RU", "BR", "IN", "PL", "ID", "GB", "CN",
-    "IT", "JP", "CA", "ES", "UA", "MX", "AU", "VN", "EG", "AR",
-    "PH", "NL", "IR", "CZ", "HU", "TR", "RO", "GR", "AT", "CH",
-    "HK", "TW", "BE", "FI", "VE", "SE", "DZ", "MY"
+    "US",
+    "DE",
+    "FR",
+    "RU",
+    "BR",
+    "IN",
+    "PL",
+    "ID",
+    "GB",
+    "CN",
+    "IT",
+    "JP",
+    "CA",
+    "ES",
+    "UA",
+    "MX",
+    "AU",
+    "VN",
+    "EG",
+    "AR",
+    "PH",
+    "NL",
+    "IR",
+    "CZ",
+    "HU",
+    "TR",
+    "RO",
+    "GR",
+    "AT",
+    "CH",
+    "HK",
+    "TW",
+    "BE",
+    "FI",
+    "VE",
+    "SE",
+    "DZ",
+    "MY",
 }
 
 # The number of seconds in a single hour, casted to float, so we get
@@ -75,7 +109,7 @@ TOP_COUNTRIES = {
 SECONDS_PER_HOUR = float(60 * 60)
 SECONDS_PER_DAY = 24 * 60 * 60
 MAX_SUBSESSION_LENGTH = 60 * 60 * 48  # 48 hours in seconds.
-DEFAULT_DATE = '2000-01-01'  # The default date used for cleaning columns
+DEFAULT_DATE = "2000-01-01"  # The default date used for cleaning columns
 
 
 def clean_new_profile(new_profile):
@@ -97,17 +131,20 @@ def clean_new_profile(new_profile):
         "locale": "environment.settings.locale",
         "normalized_channel": "metadata.normalized_channel",
         "profile_creation_date": "environment.profile.creation_date",
-        "subsession_length": F.lit(None).cast('long'),
+        "subsession_length": F.lit(None).cast("long"),
         # The subsession_start_date is the profile_creation_date
         "subsession_start_date": F.from_unixtime(
-            F.col("metadata.creation_timestamp") / 10 ** 9, iso8601_tz_format),
+            F.col("metadata.creation_timestamp") / 10 ** 9, iso8601_tz_format
+        ),
         # no access to `WEAVE_CONFIGURED`, `WEAVE_DEVICE_COUNT_*` histograms in the new_profile
         "sync_configured": F.lit(None).cast("boolean"),
         "sync_count_desktop": F.lit(None).cast("int"),
         "sync_count_mobile": F.lit(None).cast("int"),
         "timestamp": F.col("metadata.timestamp"),
         "scalar_parent_browser_engagement_total_uri_count": F.lit(None).cast("int"),
-        "scalar_parent_browser_engagement_unique_domains_count": F.lit(None).cast("int"),
+        "scalar_parent_browser_engagement_unique_domains_count": F.lit(None).cast(
+            "int"
+        ),
         "sample_id": F.expr("crc32(encode(client_id, 'UTF-8')) % 100").cast("string"),
         "submission_date_s3": "submission",
     }
@@ -131,8 +168,9 @@ def coalesce_new_profile_attribution(main_summary, new_profile):
     np_attribution = (
         new_profile
         # filter null and empty attribution
-        .where(F.col("attribution").isNotNull() &
-               F.coalesce(*nested_attr_cols).isNotNull())
+        .where(
+            F.col("attribution").isNotNull() & F.coalesce(*nested_attr_cols).isNotNull()
+        )
         .groupBy("client_id")
         # some clients contain more than one attribution code
         .agg(F.first("attribution").alias("attribution"))
@@ -140,8 +178,7 @@ def coalesce_new_profile_attribution(main_summary, new_profile):
     )
 
     coalesced_ms = (
-        main_summary
-        .join(np_attribution, "client_id", "left")
+        main_summary.join(np_attribution, "client_id", "left")
         .withColumn("attribution", F.coalesce(np_attr_col, "attribution"))
         .select(main_summary.columns)
     )
@@ -167,25 +204,21 @@ def extract(main_summary, new_profile, start_ds, period, slack, is_sampled):
         (F.col("subsession_start_date") >= utils.format_date(start, DS)),
         (F.col("subsession_start_date") < utils.format_date(start, DS, period)),
         (F.col("submission_date_s3") >= utils.format_date(start, DS_NODASH)),
-        (F.col("submission_date_s3") < utils.format_date(start, DS_NODASH,
-                                                         period + slack)),
+        (
+            F.col("submission_date_s3")
+            < utils.format_date(start, DS_NODASH, period + slack)
+        ),
     ]
 
     if is_sampled:
         predicates.append((F.col("sample_id") == "57"))
 
-    extract_ms = (
-        main_summary
-        .where(reduce(operator.__and__, predicates))
-        .select(SOURCE_COLUMNS)
+    extract_ms = main_summary.where(reduce(operator.__and__, predicates)).select(
+        SOURCE_COLUMNS
     )
 
     np = clean_new_profile(new_profile)
-    extract_np = (
-        np
-        .where(reduce(operator.__and__, predicates))
-        .select(SOURCE_COLUMNS)
-    )
+    extract_np = np.where(reduce(operator.__and__, predicates)).select(SOURCE_COLUMNS)
 
     coalesced_ms = coalesce_new_profile_attribution(extract_ms, np)
 
@@ -200,69 +233,62 @@ def prepare_client_rows(main_summary):
         "timestamp",
         "scalar_parent_browser_engagement_total_uri_count",
         "scalar_parent_browser_engagement_unique_domains_count",
-        "subsession_length"
+        "subsession_length",
     }
-    out_columns = (
-        set(main_summary.columns) |
-        {
-            "usage_seconds",
-            "total_uri_count",
-            "unique_domains_count_per_profile"
-        }
-    )
-    assert(in_columns <= set(main_summary.columns))
+    out_columns = set(main_summary.columns) | {
+        "usage_seconds",
+        "total_uri_count",
+        "unique_domains_count_per_profile",
+    }
+    assert in_columns <= set(main_summary.columns)
 
     # Get the newest ping per client and append to original dataframe
-    window_spec = (
-        Window
-        .partitionBy(F.col('client_id'))
-        .orderBy(F.col('timestamp').desc())
+    window_spec = Window.partitionBy(F.col("client_id")).orderBy(
+        F.col("timestamp").desc()
     )
-    newest_per_client = (
-        main_summary
-        .withColumn('client_rank', F.row_number().over(window_spec))
-        .where(F.col("client_rank") == 1)
-    )
+    newest_per_client = main_summary.withColumn(
+        "client_rank", F.row_number().over(window_spec)
+    ).where(F.col("client_rank") == 1)
 
     # Compute per client aggregates lost during newest client computation
-    select_expr = utils.build_col_expr({
-        "client_id": None,
-        "total_uri_count": (
-            F.coalesce(
-                "scalar_parent_browser_engagement_total_uri_count",
-                F.lit(0)
-            )),
-        "unique_domains_count": (
-            F.coalesce(
-                "scalar_parent_browser_engagement_unique_domains_count",
-                F.lit(0)
-            )),
-        # Clamp broken subsession values to [0, MAX_SUBSESSION_LENGTH].
-        "subsession_length": (
-            F.when(F.col('subsession_length') > MAX_SUBSESSION_LENGTH,
-                   MAX_SUBSESSION_LENGTH)
-            .otherwise(
-                F.when(F.col('subsession_length') < 0, 0)
-                .otherwise(F.col('subsession_length'))))
-    })
+    select_expr = utils.build_col_expr(
+        {
+            "client_id": None,
+            "total_uri_count": (
+                F.coalesce("scalar_parent_browser_engagement_total_uri_count", F.lit(0))
+            ),
+            "unique_domains_count": (
+                F.coalesce(
+                    "scalar_parent_browser_engagement_unique_domains_count", F.lit(0)
+                )
+            ),
+            # Clamp broken subsession values to [0, MAX_SUBSESSION_LENGTH].
+            "subsession_length": (
+                F.when(
+                    F.col("subsession_length") > MAX_SUBSESSION_LENGTH,
+                    MAX_SUBSESSION_LENGTH,
+                ).otherwise(
+                    F.when(F.col("subsession_length") < 0, 0).otherwise(
+                        F.col("subsession_length")
+                    )
+                )
+            ),
+        }
+    )
 
     per_client_aggregates = (
-        main_summary
-        .select(*select_expr)
-        .groupby('client_id')
+        main_summary.select(*select_expr)
+        .groupby("client_id")
         .agg(
-            F.sum('subsession_length').alias('usage_seconds'),
-            F.sum('total_uri_count').alias('total_uri_count'),
-            F.avg('unique_domains_count')
-            .alias('unique_domains_count_per_profile')
+            F.sum("subsession_length").alias("usage_seconds"),
+            F.sum("total_uri_count").alias("total_uri_count"),
+            F.avg("unique_domains_count").alias("unique_domains_count_per_profile"),
         )
     )
 
     # Join the two intermediate datasets
-    return (
-        newest_per_client
-        .join(per_client_aggregates, 'client_id', 'inner')
-        .select(*out_columns)
+    return newest_per_client.join(per_client_aggregates, "client_id", "inner").select(
+        *out_columns
     )
 
 
@@ -274,18 +300,15 @@ def sync_usage(desktop_count, mobile_count, sync_configured):
     :param sync_configured:     Column name for "sync_configured"
     :return:                    One of `multiple`, `single`, `no`, `null`
     """
-    device_count = (
-        F.coalesce(F.col(desktop_count), F.lit(0)) +
-        F.coalesce(F.col(mobile_count), F.lit(0))
+    device_count = F.coalesce(F.col(desktop_count), F.lit(0)) + F.coalesce(
+        F.col(mobile_count), F.lit(0)
     )
-    return (
-        F.when(device_count > 1, F.lit("multiple"))
-        .otherwise(
-            F.when((device_count == 1) | F.col(sync_configured),
-                   F.lit("single"))
-            .otherwise(
-                F.when(F.col(sync_configured).isNotNull(), F.lit("no"))
-                .otherwise(F.lit(None))))
+    return F.when(device_count > 1, F.lit("multiple")).otherwise(
+        F.when((device_count == 1) | F.col(sync_configured), F.lit("single")).otherwise(
+            F.when(F.col(sync_configured).isNotNull(), F.lit("no")).otherwise(
+                F.lit(None)
+            )
+        )
     )
 
 
@@ -295,9 +318,8 @@ def in_top_countries(country):
     :param country:    Column name for "country"
     :return:           set(TOP_COUNTRIES) | "ROW"
     """
-    return (
-        F.when(F.col(country).isin(TOP_COUNTRIES), F.col(country))
-        .otherwise(F.lit("ROW"))
+    return F.when(F.col(country).isin(TOP_COUNTRIES), F.col(country)).otherwise(
+        F.lit("ROW")
     )
 
 
@@ -321,63 +343,69 @@ def clean_columns(prepared_clients, effective_version, start_ds):
     is_valid = "_is_valid"
 
     pcd = F.from_unixtime(F.col("profile_creation_date") * SECONDS_PER_DAY)
-    client_date = utils.to_datetime('subsession_start_date', "yyyy-MM-dd")
+    client_date = utils.to_datetime("subsession_start_date", "yyyy-MM-dd")
     days_since_creation = F.datediff(client_date, pcd)
 
-    is_funnelcake = F.col('distribution_id').rlike("^mozilla[0-9]+.*$")
+    is_funnelcake = F.col("distribution_id").rlike("^mozilla[0-9]+.*$")
 
     attr_mapping = {
-        'distribution_id': None,
-        'default_search_engine': None,
-        'locale': None,
-        'subsession_start': client_date,
-        'channel': (
-            F.when(is_funnelcake, F.concat(
-                F.col("normalized_channel"), F.lit("-cck-"), F.col("distribution_id")
-            ))
-            .otherwise(F.col(("normalized_channel")))),
-        'geo': in_top_countries("country"),
-        # Bug 1289573: Support values like "mozilla86" and "mozilla86-utility-existing"
-        'is_funnelcake': (
-            F.when(is_funnelcake, F.lit("yes"))
-            .otherwise(F.lit("no"))),
-        'acquisition_period': F.date_format(
-            F.date_sub(F.next_day(pcd, 'Sun'), 7),
-            "yyyy-MM-dd"),
-        'sync_usage': sync_usage(
-            "sync_count_desktop",
-            "sync_count_mobile",
-            "sync_configured"
+        "distribution_id": None,
+        "default_search_engine": None,
+        "locale": None,
+        "subsession_start": client_date,
+        "channel": (
+            F.when(
+                is_funnelcake,
+                F.concat(
+                    F.col("normalized_channel"),
+                    F.lit("-cck-"),
+                    F.col("distribution_id"),
+                ),
+            ).otherwise(F.col(("normalized_channel")))
         ),
-        'current_version': F.col("app_version"),
-        'current_week': (
+        "geo": in_top_countries("country"),
+        # Bug 1289573: Support values like "mozilla86" and "mozilla86-utility-existing"
+        "is_funnelcake": (F.when(is_funnelcake, F.lit("yes")).otherwise(F.lit("no"))),
+        "acquisition_period": F.date_format(
+            F.date_sub(F.next_day(pcd, "Sun"), 7), "yyyy-MM-dd"
+        ),
+        "sync_usage": sync_usage(
+            "sync_count_desktop", "sync_count_mobile", "sync_configured"
+        ),
+        "current_version": F.col("app_version"),
+        "current_week": (
             # -1 is a placeholder for bad data
             F.when(days_since_creation < 0, F.lit(-1))
             .otherwise(F.floor(days_since_creation / 7))
-            .cast("long")),
-        'source': F.col('attribution.source'),
-        'medium': F.col('attribution.medium'),
-        'campaign': F.col('attribution.campaign'),
-        'content': F.col('attribution.content'),
-        'is_active': (
-            F.when(client_date < utils.to_datetime(F.lit(start_ds)), F.lit("no"))
-            .otherwise(F.lit("yes"))),
+            .cast("long")
+        ),
+        "source": F.col("attribution.source"),
+        "medium": F.col("attribution.medium"),
+        "campaign": F.col("attribution.campaign"),
+        "content": F.col("attribution.content"),
+        "is_active": (
+            F.when(
+                client_date < utils.to_datetime(F.lit(start_ds)), F.lit("no")
+            ).otherwise(F.lit("yes"))
+        ),
     }
 
-    usage_hours = F.col('usage_seconds') / SECONDS_PER_HOUR
+    usage_hours = F.col("usage_seconds") / SECONDS_PER_HOUR
     metric_mapping = {
-        'n_profiles': F.lit(1),
-        'total_uri_count': None,
-        'unique_domains_count_per_profile': None,
-        'usage_hours': usage_hours,
-        'sum_squared_usage_hours': F.pow(usage_hours, 2),
+        "n_profiles": F.lit(1),
+        "total_uri_count": None,
+        "unique_domains_count_per_profile": None,
+        "usage_hours": usage_hours,
+        "sum_squared_usage_hours": F.pow(usage_hours, 2),
     }
 
     # Set the attributes to null if it's invalid
-    select_attr = utils.build_col_expr({
-        attr: F.when(F.col(is_valid), expr).otherwise(F.lit(None))
-        for attr, expr in utils.preprocess_col_expr(attr_mapping).items()
-    })
+    select_attr = utils.build_col_expr(
+        {
+            attr: F.when(F.col(is_valid), expr).otherwise(F.lit(None))
+            for attr, expr in utils.preprocess_col_expr(attr_mapping).items()
+        }
+    )
     select_metrics = utils.build_col_expr(metric_mapping)
     select_expr = select_attr + select_metrics
 
@@ -388,12 +416,15 @@ def clean_columns(prepared_clients, effective_version, start_ds):
         # is to make sure that a profile is always created before a sub-session.
         # Unlike `sane_date` in previous versions, this is idempotent and only
         # depends on the data.
-        .withColumn("profile_creation", F.date_format(pcd, 'yyyy-MM-dd'))
-        .withColumn(is_valid, (
-            F.col("profile_creation").isNotNull() &
-            (F.col("profile_creation") > DEFAULT_DATE) &
-            (pcd <= client_date)
-        ))
+        .withColumn("profile_creation", F.date_format(pcd, "yyyy-MM-dd"))
+        .withColumn(
+            is_valid,
+            (
+                F.col("profile_creation").isNotNull()
+                & (F.col("profile_creation") > DEFAULT_DATE)
+                & (pcd <= client_date)
+            ),
+        )
         .select(
             # avoid acquisition dates in the future
             (
@@ -404,19 +435,19 @@ def clean_columns(prepared_clients, effective_version, start_ds):
             *select_expr
         )
         # Set default values for the rows
-        .fillna({
-            'acquisition_period': DEFAULT_DATE,
-            'is_funnelcake': "no",
-            "current_week": -1,
-        })
+        .fillna(
+            {
+                "acquisition_period": DEFAULT_DATE,
+                "is_funnelcake": "no",
+                "current_week": -1,
+            }
+        )
         .fillna(0)
         .fillna(0.0)
-        .fillna('unknown')
+        .fillna("unknown")
     )
     result = release.with_effective_version(
-        cleaned_data,
-        effective_version,
-        "profile_creation"
+        cleaned_data, effective_version, "profile_creation"
     )
 
     return result
@@ -454,88 +485,67 @@ def transform(main_summary, effective_version, start_ds):
     agg_expr[udcpp] = (agg_expr[udcpp] / agg_expr["n_profiles"]).alias(udcpp)
 
     # final aggregated data
-    records = (
-        cleaned_data
-        .groupBy(*attributes)
-        .agg(*list(agg_expr.values()))
-    )
+    records = cleaned_data.groupBy(*attributes).agg(*list(agg_expr.values()))
 
     return records.select(columns)
 
 
 def save(dataframe, bucket, prefix, start_ds):
-    path = utils.format_spark_path(
-        bucket, '{}/week_start={}'.format(prefix, start_ds)
-    )
+    path = utils.format_spark_path(bucket, "{}/week_start={}".format(prefix, start_ds))
 
     logger.info("Writing output as parquet to {}".format(path))
 
-    (
-        dataframe
-        .repartition(1)
-        .write
-        .parquet(path, mode="overwrite")
-    )
+    (dataframe.repartition(1).write.parquet(path, mode="overwrite"))
 
     logger.info("Finished week {}".format(start_ds))
 
 
 @click.command()
-@click.option('--start_date', required=True)
-@click.option('--bucket', required=True)
-@click.option('--prefix', default='churn/v3',
-              help="output prefix associated with the s3 bucket")
-@click.option('--input-bucket', default='telemetry-parquet',
-              help="input bucket containing main_summary")
-@click.option('--input-prefix', default='main_summary/v4',
-              help="input prefix containing main_summary")
-@click.option('--period', default=7,
-              help="length of the retention period in days")
-@click.option('--slack', default=10,
-              help="number of days to account for submission latency")
-@click.option('--sample/--no-sample', default=False)
-def main(start_date, bucket, prefix, input_bucket, input_prefix,
-         period, slack, sample):
+@click.option("--start_date", required=True)
+@click.option("--bucket", required=True)
+@click.option(
+    "--prefix", default="churn/v3", help="output prefix associated with the s3 bucket"
+)
+@click.option(
+    "--input-bucket",
+    default="telemetry-parquet",
+    help="input bucket containing main_summary",
+)
+@click.option(
+    "--input-prefix",
+    default="main_summary/v4",
+    help="input prefix containing main_summary",
+)
+@click.option("--period", default=7, help="length of the retention period in days")
+@click.option(
+    "--slack", default=10, help="number of days to account for submission latency"
+)
+@click.option("--sample/--no-sample", default=False)
+def main(start_date, bucket, prefix, input_bucket, input_prefix, period, slack, sample):
     """Compute churn / retention information for unique segments of
     Firefox users acquired during a specific period of time.
     """
-    spark = (
-        SparkSession
-        .builder
-        .appName("churn")
-        .getOrCreate()
-    )
+    spark = SparkSession.builder.appName("churn").getOrCreate()
     spark.conf.set("spark.sql.session.timeZone", "UTC")
 
     shuffle_partitions = max(
         spark.sparkContext.defaultParallelism * 4,
-        int(spark.conf.get("spark.sql.shuffle.partitions"))
+        int(spark.conf.get("spark.sql.shuffle.partitions")),
     )
     spark.conf.set("spark.sql.shuffle.partitions", shuffle_partitions)
 
     # If this job is scheduled, we need the input date to lag a total of
     # 10 days of slack for incoming data. Airflow subtracts 7 days to
     # account for the weekly nature of this report.
-    start_ds = utils.format_date(
-        arrow.get(start_date, DS_NODASH),
-        DS_NODASH,
-        -slack
+    start_ds = utils.format_date(arrow.get(start_date, DS_NODASH), DS_NODASH, -slack)
+
+    main_summary = spark.read.option("mergeSchema", "true").parquet(
+        utils.format_spark_path(input_bucket, input_prefix)
     )
 
-    main_summary = (
-        spark
-        .read
-        .option("mergeSchema", "true")
-        .parquet(utils.format_spark_path(input_bucket, input_prefix))
-    )
-
-    new_profile = (
-        spark
-        .read
-        .parquet(
-            "s3://net-mozaws-prod-us-west-2-pipeline-data/"
-            "telemetry-new-profile-parquet/v1/"
-        )
+    new_profile = spark.read.parquet(
+        "s3://net-mozaws-prod-us-west-2-pipeline-data/"
+        "telemetry-new-profile-parquet/v1/"
     )
 
     extracted = extract(main_summary, new_profile, start_ds, period, slack, sample)
@@ -547,5 +557,5 @@ def main(start_date, bucket, prefix, input_bucket, input_prefix,
     save(churn, bucket, prefix, start_ds)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/mozetl/engagement/churn/schema.py
+++ b/mozetl/engagement/churn/schema.py
@@ -1,92 +1,150 @@
-from pyspark.sql.types import (DoubleType, LongType, StringType, StructField,
-                               StructType)
+from pyspark.sql.types import DoubleType, LongType, StringType, StructField, StructType
 
-churn_schema = StructType([
-    StructField('channel', StringType(), True, metadata={
-        'description':
-            'The application update channel.'
-    }),
-    StructField('geo', StringType(), True, metadata={
-        'description':
-            'Bucketed by the top 30 countries and rest of the world (ROW).'
-    }),
-    StructField('is_funnelcake', StringType(), True, metadata={
-        'description':
-            'Does the channel contain "-cck-"?'
-    }),
-    StructField('acquisition_period', StringType(), True, metadata={
-        'description':
-            'The starting week of a cohort, defined by the '
-            'profile creation date.'
-    }),
-    StructField('start_version', StringType(), True, metadata={
-        'description':
-            'The version of the application when the profile was created'
-    }),
-    StructField('sync_usage', StringType(), True, metadata={
-        'description':
-            'Sync usage broken down into "no", "single" or "multiple" devices'
-    }),
-    StructField('current_version', StringType(), True, metadata={
-        'description':
-            'The current application version'
-    }),
-    StructField('current_week', LongType(), True, metadata={
-        'description':
-            'The current week'
-    }),
-    StructField('source', StringType(), True, metadata={
-        'description':
-            'Attribution: origin of the install traffic'
-    }),
-    StructField('medium', StringType(), True, metadata={
-        'description':
-            'Attribution: general category of the traffic source'
-    }),
-    StructField('campaign', StringType(), True, metadata={
-        'description':
-            'Attribution: campaign'
-    }),
-    StructField('content', StringType(), True, metadata={
-        'description':
-            'Attribution: groups of several sources with the same medium'
-    }),
-    StructField('distribution_id', StringType(), True, metadata={
-        'description':
-            'Funnelcake associated with profile'
-    }),
-    StructField('default_search_engine', StringType(), True, metadata={
-        'description':
-            'The default search engine'
-    }),
-    StructField('locale', StringType(), True, metadata={
-        'description':
-            'The locale'
-    }),
-    StructField('is_active', StringType(), True, metadata={
-        'description':
-            'Used to determine if the profile seen during processing is active'
-            'during the particular week of churn.'
-    }),
-    StructField('n_profiles', LongType(), True, metadata={
-        'description':
-            'Count of matching client_ids'
-    }),
-    StructField('usage_hours', DoubleType(), True, metadata={
-        'description':
-            'sum of the per-client subsession lengths, '
-            'clamped in the [0, MAX_SUBSESSION_LENGTH] range'
-    }),
-    StructField('sum_squared_usage_hours', DoubleType(), True, metadata={
-        'description':
-            'The sum of squares of the usage hours'
-    }),
-    StructField('total_uri_count', LongType(), True, metadata={
-        'description':
-            'The sum of per-client uri counts'
-    }),
-    StructField('unique_domains_count_per_profile', DoubleType(), True, metadata={
-        'description':
-            'The average of the average unique domains per-client'
-    }),
-])
+churn_schema = StructType(
+    [
+        StructField(
+            "channel",
+            StringType(),
+            True,
+            metadata={"description": "The application update channel."},
+        ),
+        StructField(
+            "geo",
+            StringType(),
+            True,
+            metadata={
+                "description": "Bucketed by the top 30 countries and rest of the world (ROW)."
+            },
+        ),
+        StructField(
+            "is_funnelcake",
+            StringType(),
+            True,
+            metadata={"description": 'Does the channel contain "-cck-"?'},
+        ),
+        StructField(
+            "acquisition_period",
+            StringType(),
+            True,
+            metadata={
+                "description": "The starting week of a cohort, defined by the "
+                "profile creation date."
+            },
+        ),
+        StructField(
+            "start_version",
+            StringType(),
+            True,
+            metadata={
+                "description": "The version of the application when the profile was created"
+            },
+        ),
+        StructField(
+            "sync_usage",
+            StringType(),
+            True,
+            metadata={
+                "description": 'Sync usage broken down into "no", "single" or "multiple" devices'
+            },
+        ),
+        StructField(
+            "current_version",
+            StringType(),
+            True,
+            metadata={"description": "The current application version"},
+        ),
+        StructField(
+            "current_week",
+            LongType(),
+            True,
+            metadata={"description": "The current week"},
+        ),
+        StructField(
+            "source",
+            StringType(),
+            True,
+            metadata={"description": "Attribution: origin of the install traffic"},
+        ),
+        StructField(
+            "medium",
+            StringType(),
+            True,
+            metadata={
+                "description": "Attribution: general category of the traffic source"
+            },
+        ),
+        StructField(
+            "campaign",
+            StringType(),
+            True,
+            metadata={"description": "Attribution: campaign"},
+        ),
+        StructField(
+            "content",
+            StringType(),
+            True,
+            metadata={
+                "description": "Attribution: groups of several sources with the same medium"
+            },
+        ),
+        StructField(
+            "distribution_id",
+            StringType(),
+            True,
+            metadata={"description": "Funnelcake associated with profile"},
+        ),
+        StructField(
+            "default_search_engine",
+            StringType(),
+            True,
+            metadata={"description": "The default search engine"},
+        ),
+        StructField(
+            "locale", StringType(), True, metadata={"description": "The locale"}
+        ),
+        StructField(
+            "is_active",
+            StringType(),
+            True,
+            metadata={
+                "description": "Used to determine if the profile seen during processing is active"
+                "during the particular week of churn."
+            },
+        ),
+        StructField(
+            "n_profiles",
+            LongType(),
+            True,
+            metadata={"description": "Count of matching client_ids"},
+        ),
+        StructField(
+            "usage_hours",
+            DoubleType(),
+            True,
+            metadata={
+                "description": "sum of the per-client subsession lengths, "
+                "clamped in the [0, MAX_SUBSESSION_LENGTH] range"
+            },
+        ),
+        StructField(
+            "sum_squared_usage_hours",
+            DoubleType(),
+            True,
+            metadata={"description": "The sum of squares of the usage hours"},
+        ),
+        StructField(
+            "total_uri_count",
+            LongType(),
+            True,
+            metadata={"description": "The sum of per-client uri counts"},
+        ),
+        StructField(
+            "unique_domains_count_per_profile",
+            DoubleType(),
+            True,
+            metadata={
+                "description": "The average of the average unique domains per-client"
+            },
+        ),
+    ]
+)

--- a/mozetl/engagement/churn/utils.py
+++ b/mozetl/engagement/churn/utils.py
@@ -20,7 +20,7 @@ def format_date(start_date, format, offset=None):
     return start_date.format(format)
 
 
-def to_datetime(col, format='yyyyMMdd'):
+def to_datetime(col, format="yyyyMMdd"):
     """Convert a StringType column into a DateType column.
 
     Default format is `yyyyMMdd`. Formats are specified by SimpleDateFormats_.
@@ -29,15 +29,13 @@ def to_datetime(col, format='yyyyMMdd'):
 
     .. _SimpleDateFormats: http://docs.oracle.com/javase/tutorial/i18n/format/simpleDateFormat.html
     """
-    return (
-        F.from_unixtime(
-            F.unix_timestamp(col, format))
-        .alias("to_datetime({}, {})".format(col, format))
+    return F.from_unixtime(F.unix_timestamp(col, format)).alias(
+        "to_datetime({}, {})".format(col, format)
     )
 
 
 def format_spark_path(bucket, prefix):
-    return 's3://{}/{}'.format(bucket, prefix)
+    return "s3://{}/{}".format(bucket, prefix)
 
 
 def preprocess_col_expr(mapping):

--- a/mozetl/engagement/churn_to_csv/job.py
+++ b/mozetl/engagement/churn_to_csv/job.py
@@ -20,13 +20,13 @@ def fmt(d, date_format="%Y%m%d"):
 
 def collect_and_upload_csv(df, filename, upload_config):
     """ Collect the dataframe into a csv file and upload to target locations. """
-    client = boto3.client('s3', 'us-west-2')
+    client = boto3.client("s3", "us-west-2")
     transfer = S3Transfer(client)
 
     print("{}: Writing output to {}".format(datetime.utcnow(), filename))
 
     # Write the file out as gzipped csv
-    with gzip.open(filename, 'wb') as fout:
+    with gzip.open(filename, "wb") as fout:
         fout.write(",".join(df.columns) + "\n")
         print("{}: Wrote header to {}".format(datetime.utcnow(), filename))
         records = df.rdd.collect()
@@ -35,20 +35,31 @@ def collect_and_upload_csv(df, filename, upload_config):
                 fout.write(csv(r))
                 fout.write("\n")
             except UnicodeEncodeError as e:
-                print("{}: Error writing line: {} // {}".format(datetime.utcnow(), e, r))
+                print(
+                    "{}: Error writing line: {} // {}".format(datetime.utcnow(), e, r)
+                )
         print("{}: finished writing lines".format(datetime.utcnow()))
 
     # upload files to s3
     try:
         for config in upload_config:
-            print("{}: Uploading to {} at s3://{}/{}/{}".format(
-                datetime.utcnow(), config["name"], config["bucket"],
-                config["prefix"], filename))
+            print(
+                "{}: Uploading to {} at s3://{}/{}/{}".format(
+                    datetime.utcnow(),
+                    config["name"],
+                    config["bucket"],
+                    config["prefix"],
+                    filename,
+                )
+            )
 
             s3_path = "{}/{}".format(config["prefix"], filename)
-            transfer.upload_file(filename, config["bucket"], s3_path,
-                                 extra_args={
-                                     'ACL': 'bucket-owner-full-control'})
+            transfer.upload_file(
+                filename,
+                config["bucket"],
+                s3_path,
+                extra_args={"ACL": "bucket-owner-full-control"},
+            )
     except botocore.exceptions.ClientError as e:
         print("File for {} already exists, skipping upload: {}".format(filename, e))
 
@@ -78,14 +89,20 @@ def convert_week(spark, config, week_start=None):
     df = df.where(df.week_start == week_start)
 
     # marginalize the dataframe to the original attributes and upload to s3
-    initial_attributes = ['channel', 'geo', 'is_funnelcake',
-                          'acquisition_period', 'start_version', 'sync_usage',
-                          'current_version', 'current_week', 'is_active']
-    initial_aggregates = ['n_profiles', 'usage_hours',
-                          'sum_squared_usage_hours']
+    initial_attributes = [
+        "channel",
+        "geo",
+        "is_funnelcake",
+        "acquisition_period",
+        "start_version",
+        "sync_usage",
+        "current_version",
+        "current_week",
+        "is_active",
+    ]
+    initial_aggregates = ["n_profiles", "usage_hours", "sum_squared_usage_hours"]
 
-    upload_df = marginalize_dataframe(df, initial_attributes,
-                                      initial_aggregates)
+    upload_df = marginalize_dataframe(df, initial_attributes, initial_aggregates)
     filename = "churn-{}-{}.by_activity.csv.gz".format(week_start, week_end)
     collect_and_upload_csv(upload_df, filename, config["uploads"])
 
@@ -93,20 +110,24 @@ def convert_week(spark, config, week_start=None):
     # The size of the data explodes significantly with extra dimensions and is too
     # large to fit into the driver memory. We can write directly to s3 from a
     # dataframe.
-    bucket = config['search_cohort']['bucket']
-    prefix = config['search_cohort']['prefix']
+    bucket = config["search_cohort"]["bucket"]
+    prefix = config["search_cohort"]["prefix"]
     location = "s3://{}/{}/week_start={}".format(bucket, prefix, week_start)
 
     print("Saving additional search cohort churn data to {}".format(location))
 
     search_attributes = [
-        'source', 'medium', 'campaign', 'content',
-        'distribution_id', 'default_search_engine', 'locale'
+        "source",
+        "medium",
+        "campaign",
+        "content",
+        "distribution_id",
+        "default_search_engine",
+        "locale",
     ]
     attributes = initial_attributes + search_attributes
     upload_df = marginalize_dataframe(df, attributes, initial_aggregates)
-    upload_df.write.csv(location, header=True, mode='overwrite',
-                        compression='gzip')
+    upload_df.write.csv(location, header=True, mode="overwrite", compression="gzip")
 
     print("Sucessfully finished churn_to_csv")
 
@@ -115,22 +136,17 @@ def assert_valid_config(config):
     """ Assert that the configuration looks correct. """
     # This could be replaced with python schema's
     assert set(["source", "uploads", "search_cohort"]).issubset(list(config.keys()))
-    assert set(["bucket", "prefix"]).issubset(list(config['search_cohort'].keys()))
+    assert set(["bucket", "prefix"]).issubset(list(config["search_cohort"].keys()))
     for entry in config["uploads"]:
         assert set(["name", "bucket", "prefix"]).issubset(list(entry.keys()))
 
 
 @click.command()
-@click.option('--start_date', required=True)
-@click.option('--debug', default=False)
+@click.option("--start_date", required=True)
+@click.option("--debug", default=False)
 def main(start_date, debug):
 
-    spark = (
-        SparkSession
-        .builder
-        .appName("churn")
-        .getOrCreate()
-    )
+    spark = SparkSession.builder.appName("churn").getOrCreate()
 
     config = {
         "source": "s3://telemetry-parquet/churn/v2",
@@ -138,18 +154,18 @@ def main(start_date, debug):
             {
                 "name": "Pipeline-Analysis",
                 "bucket": "net-mozaws-prod-us-west-2-pipeline-analysis",
-                "prefix": "mreid/churn"
+                "prefix": "mreid/churn",
             },
             {
                 "name": "Dashboard",
                 "bucket": "net-mozaws-prod-metrics-data",
-                "prefix": "telemetry-churn"
-            }
+                "prefix": "telemetry-churn",
+            },
         ],
         "search_cohort": {
             "bucket": "net-mozaws-prod-us-west-2-pipeline-analysis",
-            "prefix": "amiyaguchi/churn_csv"
-        }
+            "prefix": "amiyaguchi/churn_csv",
+        },
     }
     assert_valid_config(config)
 
@@ -158,19 +174,19 @@ def main(start_date, debug):
             {
                 "name": "Testing",
                 "bucket": "net-mozaws-prod-us-west-2-pipeline-analysis",
-                "prefix": "amiyaguchi/churn_csv_testing"
+                "prefix": "amiyaguchi/churn_csv_testing",
             }
         ]
-        config['search_cohort'] = {
+        config["search_cohort"] = {
             "bucket": "net-mozaws-prod-us-west-2-pipeline-analysis",
-            "prefix": "amiyaguchi/churn_csv_testing"
+            "prefix": "amiyaguchi/churn_csv_testing",
         }
         assert_valid_config(config)
 
     # Churn waits 10 days for pings to be sent from the client
     week_start_date = snap_to_beginning_of_week(
-        datetime.strptime(start_date, "%Y%m%d") - timedelta(10),
-        "Sunday")
+        datetime.strptime(start_date, "%Y%m%d") - timedelta(10), "Sunday"
+    )
     week_start = fmt(week_start_date)
 
     convert_week(spark, config, week_start)

--- a/mozetl/engagement/retention/job.py
+++ b/mozetl/engagement/retention/job.py
@@ -39,8 +39,10 @@ from pyspark.sql import SparkSession, functions as F
 from mozetl.engagement.churn import job as churn_job
 from mozetl.engagement.churn import utils
 from mozetl.engagement.churn.job import (
-    SECONDS_PER_DAY, DEFAULT_DATE, SECONDS_PER_HOUR,
-    MAX_SUBSESSION_LENGTH
+    SECONDS_PER_DAY,
+    DEFAULT_DATE,
+    SECONDS_PER_HOUR,
+    MAX_SUBSESSION_LENGTH,
 )
 from .schema import retention_schema
 from functools import reduce
@@ -49,88 +51,83 @@ from functools import reduce
 def valid_pcd(pcd, client_date):
     """Determine if the profile creation date column is valid given the date
     reported by the client."""
-    pcd_format = F.date_format(pcd, 'yyyy-MM-dd')
+    pcd_format = F.date_format(pcd, "yyyy-MM-dd")
     is_valid_pcd = [
         pcd_format.isNotNull(),
         (pcd_format > DEFAULT_DATE),
         (pcd <= client_date),
     ]
-    return (
-        F.when(reduce(operator.__and__, is_valid_pcd), pcd)
-        .otherwise(F.lit(None))
-    )
+    return F.when(reduce(operator.__and__, is_valid_pcd), pcd).otherwise(F.lit(None))
 
 
 def transform(main_summary, start_ds):
     """Process a subset of `main_summary` to be used in aggregates."""
-    client_date = utils.to_datetime('subsession_start_date', 'yyyy-MM-dd')
+    client_date = utils.to_datetime("subsession_start_date", "yyyy-MM-dd")
 
     pcd = valid_pcd(
-        F.from_unixtime(F.col('profile_creation_date') * SECONDS_PER_DAY),
-        client_date
+        F.from_unixtime(F.col("profile_creation_date") * SECONDS_PER_DAY), client_date
     )
 
     days_since_creation = F.datediff(client_date, pcd)
 
     # Bug 1289573: Support values like 'mozilla86' and 'mozilla86-utility-existing'
-    is_funnelcake = F.col('distribution_id').rlike('^mozilla[0-9]+.*$')
+    is_funnelcake = F.col("distribution_id").rlike("^mozilla[0-9]+.*$")
 
-    subsession_length = (
-        F.when(F.col('subsession_length') > MAX_SUBSESSION_LENGTH, MAX_SUBSESSION_LENGTH)
-        .otherwise(F.when(F.col('subsession_length') < 0, 0)
-                   .otherwise(F.col('subsession_length')))
+    subsession_length = F.when(
+        F.col("subsession_length") > MAX_SUBSESSION_LENGTH, MAX_SUBSESSION_LENGTH
+    ).otherwise(
+        F.when(F.col("subsession_length") < 0, 0).otherwise(F.col("subsession_length"))
     )
     usage_hours = subsession_length / SECONDS_PER_HOUR
 
     mapping = {
         # attributes
-        'client_id': None,
-        'subsession_start': F.date_format(client_date, 'yyyy-MM-dd'),
-        'profile_creation': F.date_format(pcd, 'yyyy-MM-dd'),
-        'days_since_creation': (
+        "client_id": None,
+        "subsession_start": F.date_format(client_date, "yyyy-MM-dd"),
+        "profile_creation": F.date_format(pcd, "yyyy-MM-dd"),
+        "days_since_creation": (
             F.when(days_since_creation < 0, F.lit(-1))  # -1 is the value for bad data
             .otherwise(days_since_creation)
-            .cast('long')),
-        'channel': 'normalized_channel',
-        'app_version': (
+            .cast("long")
+        ),
+        "channel": "normalized_channel",
+        "app_version": (
             # Support before Firefox 55 is limited due to high submission latency
-            F.when(F.col('app_version').isNull() |
-                   (F.split('app_version', '\\.')[0] >= '55'), F.col('app_version'))
-            .otherwise(F.lit("older"))
+            F.when(
+                F.col("app_version").isNull()
+                | (F.split("app_version", "\\.")[0] >= "55"),
+                F.col("app_version"),
+            ).otherwise(F.lit("older"))
         ),
-        'geo': churn_job.in_top_countries('country'),
-        'distribution_id': None,
-        'is_funnelcake': is_funnelcake,
-        'source': 'attribution.source',
-        'medium': 'attribution.medium',
-        'campaign': 'attribution.campaign',
-        'content': 'attribution.content',
-        'sync_usage': churn_job.sync_usage(
-            'sync_count_desktop',
-            'sync_count_mobile',
-            'sync_configured'
+        "geo": churn_job.in_top_countries("country"),
+        "distribution_id": None,
+        "is_funnelcake": is_funnelcake,
+        "source": "attribution.source",
+        "medium": "attribution.medium",
+        "campaign": "attribution.campaign",
+        "content": "attribution.content",
+        "sync_usage": churn_job.sync_usage(
+            "sync_count_desktop", "sync_count_mobile", "sync_configured"
         ),
-        'is_active': client_date <= utils.to_datetime(F.lit(start_ds)),
+        "is_active": client_date <= utils.to_datetime(F.lit(start_ds)),
         # metrics
-        'usage_hours': usage_hours,
-        'sum_squared_usage_hours': usage_hours ** 2,
-        'total_uri_count':
-            F.col('scalar_parent_browser_engagement_total_uri_count').cast('long'),
-        'unique_domains_count':
-            F.col('scalar_parent_browser_engagement_unique_domains_count').cast('long'),
+        "usage_hours": usage_hours,
+        "sum_squared_usage_hours": usage_hours ** 2,
+        "total_uri_count": F.col(
+            "scalar_parent_browser_engagement_total_uri_count"
+        ).cast("long"),
+        "unique_domains_count": F.col(
+            "scalar_parent_browser_engagement_unique_domains_count"
+        ).cast("long"),
     }
     expr = utils.build_col_expr(mapping)
 
     cleaned_data = (
-        main_summary
-        .select(expr)
-        .fillna({
-            'profile_creation': DEFAULT_DATE,
-            'days_since_creation': -1,
-        })
+        main_summary.select(expr)
+        .fillna({"profile_creation": DEFAULT_DATE, "days_since_creation": -1})
         .fillna(0)
         .fillna(0.0)
-        .fillna('unknown')
+        .fillna("unknown")
         .select([field.name for field in retention_schema.fields])
     )
 
@@ -138,56 +135,57 @@ def transform(main_summary, start_ds):
 
 
 def save(cleaned, path):
-    cleaned.write.parquet(path, mode='overwrite')
+    cleaned.write.parquet(path, mode="overwrite")
 
 
 @click.command()
-@click.option('--start-date', required=True)
-@click.option('--path', default='retention_intermediate',
-              help='Spark compatible route for sharing intermediate data '
-                   'with the aggregate job.')
-@click.option('--input-bucket', default='telemetry-parquet',
-              help='input bucket containing main_summary')
-@click.option('--input-prefix', default='main_summary/v4',
-              help='input prefix containing main_summary')
-@click.option('--period', default=1,
-              help='length of the retention period in days')
-@click.option('--slack', default=2,
-              help='number of days to account for submission latency')
-@click.option('--sample/--no-sample', default=False)
-def main(start_date, path, input_bucket, input_prefix,
-         period, slack, sample):
+@click.option("--start-date", required=True)
+@click.option(
+    "--path",
+    default="retention_intermediate",
+    help="Spark compatible route for sharing intermediate data "
+    "with the aggregate job.",
+)
+@click.option(
+    "--input-bucket",
+    default="telemetry-parquet",
+    help="input bucket containing main_summary",
+)
+@click.option(
+    "--input-prefix",
+    default="main_summary/v4",
+    help="input prefix containing main_summary",
+)
+@click.option("--period", default=1, help="length of the retention period in days")
+@click.option(
+    "--slack", default=2, help="number of days to account for submission latency"
+)
+@click.option("--sample/--no-sample", default=False)
+def main(start_date, path, input_bucket, input_prefix, period, slack, sample):
 
-    spark = SparkSession.builder.appName('retention').getOrCreate()
-    spark.conf.set('spark.sql.session.timeZone', 'UTC')
+    spark = SparkSession.builder.appName("retention").getOrCreate()
+    spark.conf.set("spark.sql.session.timeZone", "UTC")
 
     start_ds = utils.format_date(
-        arrow.get(start_date, utils.DS_NODASH),
-        utils.DS_NODASH,
-        -slack
+        arrow.get(start_date, utils.DS_NODASH), utils.DS_NODASH, -slack
     )
 
-    main_summary = (
-        spark
-        .read
-        .option('mergeSchema', 'true')
-        .parquet(utils.format_spark_path(input_bucket, input_prefix))
+    main_summary = spark.read.option("mergeSchema", "true").parquet(
+        utils.format_spark_path(input_bucket, input_prefix)
     )
 
-    new_profile = (
-        spark
-        .read
-        .parquet(
-            "s3://net-mozaws-prod-us-west-2-pipeline-data/"
-            "telemetry-new-profile-parquet/v1/"
-        )
+    new_profile = spark.read.parquet(
+        "s3://net-mozaws-prod-us-west-2-pipeline-data/"
+        "telemetry-new-profile-parquet/v1/"
     )
 
-    extracted = churn_job.extract(main_summary, new_profile, start_ds, period, slack, sample)
+    extracted = churn_job.extract(
+        main_summary, new_profile, start_ds, period, slack, sample
+    )
 
     retention = transform(extracted, start_ds)
     save(retention, path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/mozetl/engagement/retention/schema.py
+++ b/mozetl/engagement/retention/schema.py
@@ -1,24 +1,32 @@
-from pyspark.sql.types import (DoubleType, LongType, StringType, StructField,
-                               StructType, BooleanType)
+from pyspark.sql.types import (
+    DoubleType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+    BooleanType,
+)
 
-retention_schema = StructType([
-    StructField("client_id", StringType(), True),
-    StructField("subsession_start", StringType(), True),
-    StructField("profile_creation", StringType(), True),
-    StructField("days_since_creation", LongType(), True),
-    StructField("channel", StringType(), True),
-    StructField("app_version", StringType(), True),
-    StructField("geo", StringType(), True),
-    StructField("distribution_id", StringType(), True),
-    StructField("is_funnelcake", BooleanType(), True),
-    StructField("source", StringType(), True),
-    StructField("medium", StringType(), True),
-    StructField("campaign", StringType(), True),
-    StructField("content", StringType(), True),
-    StructField("sync_usage", StringType(), True),
-    StructField("is_active", BooleanType(), True),
-    StructField('usage_hours', DoubleType(), True),
-    StructField('sum_squared_usage_hours', DoubleType(), True),
-    StructField('total_uri_count', LongType(), True),
-    StructField('unique_domains_count', LongType(), True),
-])
+retention_schema = StructType(
+    [
+        StructField("client_id", StringType(), True),
+        StructField("subsession_start", StringType(), True),
+        StructField("profile_creation", StringType(), True),
+        StructField("days_since_creation", LongType(), True),
+        StructField("channel", StringType(), True),
+        StructField("app_version", StringType(), True),
+        StructField("geo", StringType(), True),
+        StructField("distribution_id", StringType(), True),
+        StructField("is_funnelcake", BooleanType(), True),
+        StructField("source", StringType(), True),
+        StructField("medium", StringType(), True),
+        StructField("campaign", StringType(), True),
+        StructField("content", StringType(), True),
+        StructField("sync_usage", StringType(), True),
+        StructField("is_active", BooleanType(), True),
+        StructField("usage_hours", DoubleType(), True),
+        StructField("sum_squared_usage_hours", DoubleType(), True),
+        StructField("total_uri_count", LongType(), True),
+        StructField("unique_domains_count", LongType(), True),
+    ]
+)

--- a/mozetl/experimentsdaily/rollup.py
+++ b/mozetl/experimentsdaily/rollup.py
@@ -4,14 +4,12 @@ from mozetl.clientsdaily.rollup import extract_search_counts
 from mozetl.utils import extract_submission_window_for_activity_day
 from mozetl.utils import format_spark_path
 
-EXCLUDED_ID = 'pref-flip-screenshots-release-1369150'
+EXCLUDED_ID = "pref-flip-screenshots-release-1369150"
 
 
 def load_experiments_summary(spark, parquet_path):
     return (
-        spark
-        .read
-        .option("mergeSchema", "true")
+        spark.read.option("mergeSchema", "true")
         .parquet(parquet_path)
         .where("experiment_id != '{}'".format(EXCLUDED_ID))
     )
@@ -20,41 +18,44 @@ def load_experiments_summary(spark, parquet_path):
 def to_experiment_profile_day_aggregates(frame_with_extracts):
     from mozetl.clientsdaily.fields import EXPERIMENT_FIELD_AGGREGATORS
     from mozetl.clientsdaily.fields import ACTIVITY_DATE_COLUMN
+
     if "activity_date" not in frame_with_extracts.columns:
-        with_activity_date = frame_with_extracts.select(
-            "*", ACTIVITY_DATE_COLUMN
-        )
+        with_activity_date = frame_with_extracts.select("*", ACTIVITY_DATE_COLUMN)
     else:
         with_activity_date = frame_with_extracts
-    grouped = with_activity_date.groupby(
-        'experiment_id', 'client_id', 'activity_date')
+    grouped = with_activity_date.groupby("experiment_id", "client_id", "activity_date")
     return grouped.agg(*EXPERIMENT_FIELD_AGGREGATORS)
 
 
 @click.command()
-@click.option('--date',
-              default=None,
-              help='Start date to run on')
-@click.option('--input-bucket',
-              default='telemetry-parquet',
-              help='Bucket of the input dataset')
-@click.option('--input-prefix',
-              default='experiments/v1/',
-              help='Prefix of the input dataset')
-@click.option('--output-bucket',
-              default='net-mozaws-prod-us-west-2-pipeline-analysis',
-              help='Bucket of the output dataset')
-@click.option('--output-prefix',
-              default='/experiments_daily',
-              help='Prefix of the output dataset')
-@click.option('--output-version',
-              default=3,
-              help='Version of the output dataset')
-@click.option('--lag-days',
-              default=10,
-              help='Number of days to allow for submission latency')
-def main(date, input_bucket, input_prefix, output_bucket,
-         output_prefix, output_version, lag_days):
+@click.option("--date", default=None, help="Start date to run on")
+@click.option(
+    "--input-bucket", default="telemetry-parquet", help="Bucket of the input dataset"
+)
+@click.option(
+    "--input-prefix", default="experiments/v1/", help="Prefix of the input dataset"
+)
+@click.option(
+    "--output-bucket",
+    default="net-mozaws-prod-us-west-2-pipeline-analysis",
+    help="Bucket of the output dataset",
+)
+@click.option(
+    "--output-prefix", default="/experiments_daily", help="Prefix of the output dataset"
+)
+@click.option("--output-version", default=3, help="Version of the output dataset")
+@click.option(
+    "--lag-days", default=10, help="Number of days to allow for submission latency"
+)
+def main(
+    date,
+    input_bucket,
+    input_prefix,
+    output_bucket,
+    output_prefix,
+    output_version,
+    lag_days,
+):
     """
     Aggregate by (client_id, experiment_id, day).
 
@@ -68,7 +69,9 @@ def main(date, input_bucket, input_prefix, output_bucket,
     spark = SparkSession.builder.appName("experiments_daily").getOrCreate()
     parquet_path = format_spark_path(input_bucket, input_prefix)
     frame = load_experiments_summary(spark, parquet_path)
-    day_frame, start_date = extract_submission_window_for_activity_day(frame, date, lag_days)
+    day_frame, start_date = extract_submission_window_for_activity_day(
+        frame, date, lag_days
+    )
     searches_frame = extract_search_counts(frame)
     results = to_experiment_profile_day_aggregates(searches_frame)
     spark.conf.set(
@@ -77,9 +80,10 @@ def main(date, input_bucket, input_prefix, output_bucket,
     output_base_path = "{}/v{}/activity_date_s3={}".format(
         format_spark_path(output_bucket, output_prefix),
         output_version,
-        start_date.strftime('%Y-%m-%d'))
+        start_date.strftime("%Y-%m-%d"),
+    )
     results.write.mode("overwrite").parquet(output_base_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/mozetl/hardware_report/check_output.py
+++ b/mozetl/hardware_report/check_output.py
@@ -6,7 +6,7 @@ from mozetl.utils import send_ses
 
 def check_output():
     data = _get_data()
-    changes = _check_most_recent_change(data, min_change=.3)
+    changes = _check_most_recent_change(data, min_change=0.3)
 
     if len(changes) > 0:
         _report_changes(changes)
@@ -21,12 +21,17 @@ def _get_data():
     into { 20170101: {data1: some1, ...}, 20170102: {data1:some2, ...} }
     """
     with open("hwsurvey-weekly.json", "r") as hwsurvey:
-        data = ujson.loads(''.join(hwsurvey.readlines()))
+        data = ujson.loads("".join(hwsurvey.readlines()))
 
-    return {int(re.sub('-', '', e['date'])): {k: e[k] for k in e if k != 'date'} for e in data}
+    return {
+        int(re.sub("-", "", e["date"])): {k: e[k] for k in e if k != "date"}
+        for e in data
+    }
 
 
-def _check_most_recent_change(values, min_change=.05, min_value=0.01, missing_val=.01):
+def _check_most_recent_change(
+    values, min_change=0.05, min_value=0.01, missing_val=0.01
+):
     assert missing_val > 0
 
     recent_week = max(values.keys())
@@ -39,12 +44,13 @@ def _check_most_recent_change(values, min_change=.05, min_value=0.01, missing_va
     ]
 
     return {
-        k: {'change': c,
-            'old_value': base.get(k, missing_val),
-            'new_value': compare.get(k, missing_val)}
+        k: {
+            "change": c,
+            "old_value": base.get(k, missing_val),
+            "new_value": compare.get(k, missing_val),
+        }
         for k, c in changes
-        if abs(c) > min_change
-        and base.get(k, missing_val) >= min_value
+        if abs(c) > min_change and base.get(k, missing_val) >= min_value
     }
 
 
@@ -52,15 +58,17 @@ def _make_report(changes):
     def mk_line(k, v1, v2):
         return "{}: Last week = {:.2f}%, This week = {:.2f}%".format(k, v1, v2)
 
-    change_strings = [(v['change'], mk_line(k, v['old_value']*100, v['new_value']*100))
-                      for k, v in changes.items()]
-    return '\n'.join([x[1] for x in sorted(change_strings, key=lambda x: x[0])])
+    change_strings = [
+        (v["change"], mk_line(k, v["old_value"] * 100, v["new_value"] * 100))
+        for k, v in changes.items()
+    ]
+    return "\n".join([x[1] for x in sorted(change_strings, key=lambda x: x[0])])
 
 
 def _report_changes(changes):
     send_ses(
-        'telemetry-alerts@mozilla.com',
-        'Hardware Report Validation Checks',
+        "telemetry-alerts@mozilla.com",
+        "Hardware Report Validation Checks",
         _make_report(changes),
-        'firefox-hardware-report-feedback@mozilla.com'
+        "firefox-hardware-report-feedback@mozilla.com",
     )

--- a/mozetl/hardware_report/hardware_dashboard.py
+++ b/mozetl/hardware_report/hardware_dashboard.py
@@ -14,39 +14,36 @@ from datetime import datetime, timedelta
 from pyspark.sql import SparkSession
 
 
-datetime_type = Datetime(format='%Y%m%d')
+datetime_type = Datetime(format="%Y%m%d")
 
 
 @click.command()
-@click.option('--start_date',
-              type=datetime_type,
-              required=True,
-              help='Start date (e.g. yyyymmdd)')
-@click.option('--end_date',
-              type=datetime_type,
-              default=None,
-              help='End date (e.g. yyyymmdd)')
-@click.option('--bucket',
-              required=True,
-              help='Output bucket for JSON data')
+@click.option(
+    "--start_date", type=datetime_type, required=True, help="Start date (e.g. yyyymmdd)"
+)
+@click.option(
+    "--end_date", type=datetime_type, default=None, help="End date (e.g. yyyymmdd)"
+)
+@click.option("--bucket", required=True, help="Output bucket for JSON data")
 def main(start_date, end_date, bucket):
     """Generate this week's report and append it to previous report."""
     # Set default end date to a week after start date if end date not provided
     if not end_date:
         end_date = start_date + timedelta(days=6)
 
-    spark = (SparkSession
-             .builder
-             .appName("hardware_report_dashboard")
-             .enableHiveSupport()
-             .getOrCreate())
+    spark = (
+        SparkSession.builder.appName("hardware_report_dashboard")
+        .enableHiveSupport()
+        .getOrCreate()
+    )
 
     # Generate the report for the desired period.
     report = summarize_json.generate_report(start_date, end_date, spark)
     summarize_json.serialize_results(report)
     # Fetch the previous data from S3 and save it locally.
-    summarize_json.fetch_previous_state("hwsurvey-weekly.json", "hwsurvey-weekly-prev.json",
-                                        bucket)
+    summarize_json.fetch_previous_state(
+        "hwsurvey-weekly.json", "hwsurvey-weekly-prev.json", bucket
+    )
     # Concat the json files into the output.
     print("Joining JSON files...")
 
@@ -59,9 +56,9 @@ def main(start_date, end_date, bucket):
         # the next function throws. We process new files first, which
         # in effect overwrites data on reruns.
         for f in list(new_files) + list(read_files - new_files):
-            with open(f, 'r+') as in_file:
+            with open(f, "r+") as in_file:
                 for data in json.load(in_file):
-                    if data['date'] not in [j['date'] for j in consolidated_json]:
+                    if data["date"] not in [j["date"] for j in consolidated_json]:
                         consolidated_json.append(data)
 
         report_json.write(json.dumps(consolidated_json, indent=2))
@@ -69,13 +66,16 @@ def main(start_date, end_date, bucket):
     # Store the new state to S3. Since S3 doesn't support symlinks, make
     # two copies of the file: one will always contain the latest data,
     # the other for archiving.
-    archived_file_copy = "hwsurvey-weekly-" + \
-        datetime.today().strftime("%Y%d%m") + ".json"
+    archived_file_copy = (
+        "hwsurvey-weekly-" + datetime.today().strftime("%Y%d%m") + ".json"
+    )
     summarize_json.store_new_state("hwsurvey-weekly.json", archived_file_copy, bucket)
-    summarize_json.store_new_state("hwsurvey-weekly.json", "hwsurvey-weekly.json", bucket)
+    summarize_json.store_new_state(
+        "hwsurvey-weekly.json", "hwsurvey-weekly.json", bucket
+    )
 
     check_output()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/mozetl/hardware_report/summarize_json.py
+++ b/mozetl/hardware_report/summarize_json.py
@@ -55,19 +55,19 @@ def get_OS_arch(browser_arch, os_name, is_wow64):
         'x86' if the underlying OS is 32bit, 'x86-64' if it's a 64bit OS.
 
     """
-    is_64bit_browser = browser_arch == 'x86-64'
+    is_64bit_browser = browser_arch == "x86-64"
     # If it's a 64bit browser build, then we're on a 64bit system.
     if is_64bit_browser:
-        return 'x86-64'
+        return "x86-64"
 
-    is_windows = os_name == 'Windows_NT'
+    is_windows = os_name == "Windows_NT"
     # If we're on Windows, with a 32bit browser build, and |isWow64 = true|,
     # then we're on a 64 bit system.
     if is_windows and is_wow64:
-        return 'x86-64'
+        return "x86-64"
 
     # Otherwise we're probably on a 32 bit system.
-    return 'x86'
+    return "x86"
 
 
 def vendor_name_from_id(id):
@@ -84,17 +84,17 @@ def vendor_name_from_id(id):
     # TODO: We need to make this an external resource for easier
     # future updates.
     vendor_map = {
-        '0x1013': 'Cirrus Logic',
-        '0x1002': 'AMD',
-        '0x8086': 'Intel',
-        '0x5333': 'S3 Graphics',
-        '0x1039': 'SIS',
-        '0x1106': 'VIA',
-        '0x10de': 'NVIDIA',
-        '0x102b': 'Matrox',
-        '0x15ad': 'VMWare',
-        '0x80ee': 'Oracle VirtualBox',
-        '0x1414': 'Microsoft Basic',
+        "0x1013": "Cirrus Logic",
+        "0x1002": "AMD",
+        "0x8086": "Intel",
+        "0x5333": "S3 Graphics",
+        "0x1039": "SIS",
+        "0x1106": "VIA",
+        "0x10de": "NVIDIA",
+        "0x102b": "Matrox",
+        "0x15ad": "VMWare",
+        "0x80ee": "Oracle VirtualBox",
+        "0x1414": "Microsoft Basic",
     }
 
     return vendor_map.get(id, "Other")
@@ -131,23 +131,20 @@ def invert_device_map(m):
     """
     device_id_map = {}
     for vendor, u in m.items():
-        device_id_map['0x' + vendor] = {}
+        device_id_map["0x" + vendor] = {}
         for family, v in u.items():
             for chipset, ids in v.items():
-                device_id_map['0x' +
-                              vendor].update({('0x' +
-                                               gfx_id): [family, chipset] for gfx_id in ids})
+                device_id_map["0x" + vendor].update(
+                    {("0x" + gfx_id): [family, chipset] for gfx_id in ids}
+                )
     return device_id_map
 
 
 def build_device_map():
     """Build a dictionary that will help us map vendor/device ids to device families."""
-    intel_raw = fetch_json(
-        "https://github.com/jrmuizel/gpu-db/raw/master/intel.json")
-    nvidia_raw = fetch_json(
-        "https://github.com/jrmuizel/gpu-db/raw/master/nvidia.json")
-    amd_raw = fetch_json(
-        "https://github.com/jrmuizel/gpu-db/raw/master/amd.json")
+    intel_raw = fetch_json("https://github.com/jrmuizel/gpu-db/raw/master/intel.json")
+    nvidia_raw = fetch_json("https://github.com/jrmuizel/gpu-db/raw/master/nvidia.json")
+    amd_raw = fetch_json("https://github.com/jrmuizel/gpu-db/raw/master/amd.json")
 
     device_map = {}
     device_map.update(invert_device_map(intel_raw))
@@ -192,26 +189,27 @@ def get_valid_client_record(r, data_index):
     # At this point, we should have filtered out all the weirdness. Fetch
     # the data we need.
     data = {
-        'browser_arch': r["build"][data_index]["architecture"],
-        'os_name': r["system_os"][data_index]["name"],
-        'os_version': r["system_os"][data_index]["version"],
-        'memory_mb': r["system"][data_index]["memory_mb"],
-        'is_wow64': is_wow64,
-        'gfx0_vendor_id': gfx_adapters[0]["vendor_id"],
-        'gfx0_device_id': gfx_adapters[0]["device_id"],
-        'screen_width': screen_width,
-        'screen_height': screen_height,
-        'cpu_cores': r["system_cpu"][data_index]["cores"],
-        'cpu_vendor': r["system_cpu"][data_index]["vendor"],
-        'cpu_speed': r["system_cpu"][data_index]["speed_mhz"],
-        'has_flash': False
+        "browser_arch": r["build"][data_index]["architecture"],
+        "os_name": r["system_os"][data_index]["name"],
+        "os_version": r["system_os"][data_index]["version"],
+        "memory_mb": r["system"][data_index]["memory_mb"],
+        "is_wow64": is_wow64,
+        "gfx0_vendor_id": gfx_adapters[0]["vendor_id"],
+        "gfx0_device_id": gfx_adapters[0]["device_id"],
+        "screen_width": screen_width,
+        "screen_height": screen_height,
+        "cpu_cores": r["system_cpu"][data_index]["cores"],
+        "cpu_vendor": r["system_cpu"][data_index]["vendor"],
+        "cpu_speed": r["system_cpu"][data_index]["speed_mhz"],
+        "has_flash": False,
     }
 
     # The plugins data can still be null or empty, account for that.
     plugins = r["active_plugins"][data_index] if r["active_plugins"] else None
     if plugins:
-        data['has_flash'] = any(
-            [True for p in plugins if p['name'] == 'Shockwave Flash'])
+        data["has_flash"] = any(
+            [True for p in plugins if p["name"] == "Shockwave Flash"]
+        )
 
     return REASON_BROKEN_DATA if None in list(data.values()) else data
 
@@ -242,11 +240,9 @@ def get_latest_valid_per_client(entry, time_start, time_end):
     latest_entry = None
     for index, pkt_date in enumerate(entry["submission_date"]):
         try:
-            sub_date = dt.datetime.strptime(
-                pkt_date, "%Y-%m-%dT%H:%M:%S.%fZ").date()
+            sub_date = dt.datetime.strptime(pkt_date, "%Y-%m-%dT%H:%M:%S.%fZ").date()
         except ValueError:
-            sub_date = dt.datetime.strptime(
-                pkt_date, "%Y-%m-%dT%H:%M:%SZ").date()
+            sub_date = dt.datetime.strptime(pkt_date, "%Y-%m-%dT%H:%M:%SZ").date()
 
         # The data is in descending order, the most recent ping comes first.
         # The first item less or equal than the time_end date is our thing.
@@ -270,8 +266,12 @@ def get_latest_valid_per_client(entry, time_start, time_end):
     # Don't enforce the presence of "active_plugins", as it's not included
     # by the pipeline if no plugin is reported by Firefox (see bug 1333806).
     desired_sections = [
-        "build", "system_os", "submission_date", "system",
-        "system_gfx", "system_cpu"
+        "build",
+        "system_os",
+        "submission_date",
+        "system",
+        "system_gfx",
+        "system_cpu",
     ]
 
     for field in desired_sections:
@@ -293,41 +293,43 @@ def prepare_data(p, device_map):
     e.g. unit conversion, vendor id to string, etc.
 
     """
-    cpu_speed = round(p['cpu_speed'] / 1000.0, 1)
+    cpu_speed = round(p["cpu_speed"] / 1000.0, 1)
     return {
-        'browser_arch': p['browser_arch'],
-        'cpu_cores': p['cpu_cores'],
-        'cpu_cores_speed': str(p['cpu_cores']) + '_' + str(cpu_speed),
-        'cpu_vendor': p['cpu_vendor'],
-        'cpu_speed': cpu_speed,
-        'gfx0_vendor_name': vendor_name_from_id(p['gfx0_vendor_id']),
-        'gfx0_model': get_device_family_chipset(p['gfx0_vendor_id'], p['gfx0_device_id'],
-                                                device_map),
-        'resolution': str(p['screen_width']) + 'x' + str(p['screen_height']),
-        'memory_gb': int(round(p['memory_mb'] / 1024.0)),
-        'os': p['os_name'] + '-' + p['os_version'],
-        'os_arch': get_OS_arch(p['browser_arch'], p['os_name'], p['is_wow64']),
-        'has_flash': p['has_flash']
+        "browser_arch": p["browser_arch"],
+        "cpu_cores": p["cpu_cores"],
+        "cpu_cores_speed": str(p["cpu_cores"]) + "_" + str(cpu_speed),
+        "cpu_vendor": p["cpu_vendor"],
+        "cpu_speed": cpu_speed,
+        "gfx0_vendor_name": vendor_name_from_id(p["gfx0_vendor_id"]),
+        "gfx0_model": get_device_family_chipset(
+            p["gfx0_vendor_id"], p["gfx0_device_id"], device_map
+        ),
+        "resolution": str(p["screen_width"]) + "x" + str(p["screen_height"]),
+        "memory_gb": int(round(p["memory_mb"] / 1024.0)),
+        "os": p["os_name"] + "-" + p["os_version"],
+        "os_arch": get_OS_arch(p["browser_arch"], p["os_name"], p["is_wow64"]),
+        "has_flash": p["has_flash"],
     }
 
 
 def aggregate_data(processed_data):
     """Return aggregated data."""
+
     def seq(acc, v):
         # The dimensions over which we want to aggregate the different values.
         keys_to_aggregate = [
-            'browser_arch',
-            'cpu_cores',
-            'cpu_cores_speed',
-            'cpu_vendor',
-            'cpu_speed',
-            'gfx0_vendor_name',
-            'gfx0_model',
-            'resolution',
-            'memory_gb',
-            'os',
-            'os_arch',
-            'has_flash'
+            "browser_arch",
+            "cpu_cores",
+            "cpu_cores_speed",
+            "cpu_vendor",
+            "cpu_speed",
+            "gfx0_vendor_name",
+            "gfx0_model",
+            "resolution",
+            "memory_gb",
+            "os",
+            "os_arch",
+            "has_flash",
         ]
 
         for key_name in keys_to_aggregate:
@@ -364,10 +366,9 @@ def collapse_buckets(aggregated_data, count_threshold):
 
         # If the resolution is 0x0 (see bug 1324014), put that into the "Other"
         # bucket.
-        if key_type == 'resolution' and k[1] == '0x0':
-            other_key = ('resolution', 'Other')
-            collapsed_groups[other_key] = collapsed_groups.get(
-                other_key, 0) + v
+        if key_type == "resolution" and k[1] == "0x0":
+            other_key = ("resolution", "Other")
+            collapsed_groups[other_key] = collapsed_groups.get(other_key, 0) + v
             continue
 
         # Don't clump this group into the "Other" bucket if it has enough
@@ -378,20 +379,20 @@ def collapse_buckets(aggregated_data, count_threshold):
 
         # If we're here, it means that the key has not enough elements.
         # Fall through the next cases and try to group things together.
-        new_group_key = 'Other'
+        new_group_key = "Other"
 
         # Let's try to group similar resolutions together.
-        if key_type == 'resolution':
+        if key_type == "resolution":
             # Extract the resolution.
-            [w, h] = k[1].split('x')
+            [w, h] = k[1].split("x")
             # Round to the nearest hundred.
             w = int(round(int(w), -2))
             h = int(round(int(h), -2))
             # Build up a new key.
-            new_group_key = '~' + str(w) + 'x' + str(h)
-        elif key_type == 'os':
-            [os, ver] = k[1].split('-', 1)
-            new_group_key = os + '-' + 'Other'
+            new_group_key = "~" + str(w) + "x" + str(h)
+        elif key_type == "os":
+            [os, ver] = k[1].split("-", 1)
+            new_group_key = os + "-" + "Other"
 
         # We don't have enough data for this particular group/configuration.
         # Aggregate it with the data in the "Other" bucket
@@ -404,20 +405,19 @@ def collapse_buckets(aggregated_data, count_threshold):
     for k, v in collapsed_groups.items():
         # Don't clump this group into the "Other" bucket if it has enough
         # users it in.
-        if (v > count_threshold and k[1] != 'Other') or k[0] in EXCLUSION_LIST:
+        if (v > count_threshold and k[1] != "Other") or k[0] in EXCLUSION_LIST:
             final_groups[k] = v
             continue
 
         # We don't have enough data for this particular group/configuration.
         # Aggregate it with the data in the "Other" bucket
-        other_key = (k[0], 'Other')
+        other_key = (k[0], "Other")
         final_groups[other_key] = final_groups.get(other_key, 0) + v
 
     return final_groups
 
 
-def finalize_data(data, sample_count, broken_ratio,
-                  inactive_ratio, report_date):
+def finalize_data(data, sample_count, broken_ratio, inactive_ratio, report_date):
     """Finalize the aggregated data.
 
     Translate raw sample numbers to percentages and add the date for the reported
@@ -439,24 +439,24 @@ def finalize_data(data, sample_count, broken_ratio,
     denom = float(sample_count)
 
     aggregated_percentages = {
-        'date': report_date.date().isoformat(),
-        'broken': broken_ratio,
-        'inactive': inactive_ratio,
+        "date": report_date.date().isoformat(),
+        "broken": broken_ratio,
+        "inactive": inactive_ratio,
     }
 
     keys_translation = {
-        'browser_arch': 'browserArch_',
-        'cpu_cores': 'cpuCores_',
-        'cpu_cores_speed': 'cpuCoresSpeed_',
-        'cpu_vendor': 'cpuVendor_',
-        'cpu_speed': 'cpuSpeed_',
-        'gfx0_vendor_name': 'gpuVendor_',
-        'gfx0_model': 'gpuModel_',
-        'resolution': 'resolution_',
-        'memory_gb': 'ram_',
-        'os': 'osName_',
-        'os_arch': 'osArch_',
-        'has_flash': 'hasFlash_'
+        "browser_arch": "browserArch_",
+        "cpu_cores": "cpuCores_",
+        "cpu_cores_speed": "cpuCoresSpeed_",
+        "cpu_vendor": "cpuVendor_",
+        "cpu_speed": "cpuSpeed_",
+        "gfx0_vendor_name": "gpuVendor_",
+        "gfx0_model": "gpuModel_",
+        "resolution": "resolution_",
+        "memory_gb": "ram_",
+        "os": "osName_",
+        "os_arch": "osArch_",
+        "has_flash": "hasFlash_",
     }
 
     # Compute the percentages from the raw numbers.
@@ -485,18 +485,18 @@ def validate_finalized_data(data):
 
     """
     keys_accumulator = {
-        'browserArch': 0.0,
-        'cpuCores': 0.0,
-        'cpuCoresSpeed': 0.0,
-        'cpuVendor': 0.0,
-        'cpuSpeed': 0.0,
-        'gpuVendor': 0.0,
-        'gpuModel': 0.0,
-        'resolution': 0.0,
-        'ram': 0.0,
-        'osName': 0.0,
-        'osArch': 0.0,
-        'hasFlash': 0.0
+        "browserArch": 0.0,
+        "cpuCores": 0.0,
+        "cpuCoresSpeed": 0.0,
+        "cpuVendor": 0.0,
+        "cpuSpeed": 0.0,
+        "gpuVendor": 0.0,
+        "gpuModel": 0.0,
+        "resolution": 0.0,
+        "ram": 0.0,
+        "osName": 0.0,
+        "osArch": 0.0,
+        "hasFlash": 0.0,
     }
 
     # We expect to have at least a key in |data| whose name begins with one
@@ -507,7 +507,7 @@ def validate_finalized_data(data):
             continue
 
         # Get the name of the property to look it up in the accumulator.
-        property_name = key.split('_')[0]
+        property_name = key.split("_")[0]
         if property_name not in keys_accumulator:
             logger.warning("Cannot find {} in |keys_accumulator|".format(property_name))
             return False
@@ -518,8 +518,8 @@ def validate_finalized_data(data):
     for key, value in keys_accumulator.items():
         if abs(1.0 - value) > 0.05:
             logger.warning(
-                "{} values do not add up to 1.0. Their sum is {}.".format(
-                    key, value))
+                "{} values do not add up to 1.0. Their sum is {}.".format(key, value)
+            )
             return False
 
     return True
@@ -542,7 +542,7 @@ def serialize_results(date_to_json):
         json_entry = json.dumps(aggregated_data)
 
         with open(file_name, "w") as json_file:
-            json_file.write("[" + json_entry.encode('utf8') + "]\n")
+            json_file.write("[" + json_entry.encode("utf8") + "]\n")
 
 
 def fetch_previous_state(s3_source_file_name, local_file_name, bucket):
@@ -553,7 +553,7 @@ def fetch_previous_state(s3_source_file_name, local_file_name, bucket):
         local_file_name: The name of the file to save to, locally.
     """
     # Fetch the previous state.
-    client = boto3.client('s3', 'us-west-2')
+    client = boto3.client("s3", "us-west-2")
     transfer = boto3.s3.transfer.S3Transfer(client)
     key_path = S3_DATA_PATH + s3_source_file_name
 
@@ -561,7 +561,7 @@ def fetch_previous_state(s3_source_file_name, local_file_name, bucket):
         transfer.download_file(bucket, key_path, local_file_name)
     except botocore.exceptions.ClientError as e:
         # If the file wasn't there, that's ok. Otherwise, abort!
-        if e.response['Error']['Code'] != "404":
+        if e.response["Error"]["Code"] != "404":
             raise e
         else:
             logger.exception("Did not find an existing file at '{}'".format(key_path))
@@ -574,7 +574,7 @@ def store_new_state(source_file_name, s3_dest_file_name, bucket):
         source_file_name: The name of the local source file.
         s3_dest_file_name: The name of the destination file on S3.
     """
-    client = boto3.client('s3', 'us-west-2')
+    client = boto3.client("s3", "us-west-2")
     transfer = boto3.s3.transfer.S3Transfer(client)
 
     # Update the state in the analysis bucket.
@@ -608,10 +608,10 @@ def generate_report(start_date, end_date, spark):
 
     last_week = moz_std.get_last_week_range()
     date_range = (
-        moz_std.snap_to_beginning_of_week(
-            start_date, "Sunday") if start_date is not None else last_week[0],
-        end_date if (
-            end_date is not None and start_date is not None) else last_week[1]
+        moz_std.snap_to_beginning_of_week(start_date, "Sunday")
+        if start_date is not None
+        else last_week[0],
+        end_date if (end_date is not None and start_date is not None) else last_week[1],
     )
 
     # Split the submission period in chunks, so we don't run out of resources while aggregating if
@@ -642,46 +642,54 @@ def generate_report(start_date, end_date, spark):
                       normalized_channel = 'release'
                    AND
                       build is not null and build[0].application_name = 'Firefox'
-                   """.format(longitudinal_version)
+                   """.format(
+            longitudinal_version
+        )
 
         frame = spark.sql(sqlQuery)
 
         # The number of all the fetched records (including inactive and broken).
         records_count = frame.count()
-        logger.info("Total record count for {}: {}".format(
-          chunk_start.strftime("%Y%m%d"), records_count))
+        logger.info(
+            "Total record count for {}: {}".format(
+                chunk_start.strftime("%Y%m%d"), records_count
+            )
+        )
 
         # Fetch the data we need.
         data = frame.rdd.map(
-            lambda r: get_latest_valid_per_client(
-                r, chunk_start, chunk_end))
+            lambda r: get_latest_valid_per_client(r, chunk_start, chunk_end)
+        )
 
         # Filter out broken data.
         filtered_data = data.filter(
-            lambda r: r not in [
-                REASON_BROKEN_DATA,
-                REASON_INACTIVE])
+            lambda r: r not in [REASON_BROKEN_DATA, REASON_INACTIVE]
+        )
 
         # Count the broken records and inactive records.
         discarded = data.filter(
-            lambda r: r in [
-                REASON_BROKEN_DATA,
-                REASON_INACTIVE]).countByValue()
+            lambda r: r in [REASON_BROKEN_DATA, REASON_INACTIVE]
+        ).countByValue()
 
         broken_count = discarded[REASON_BROKEN_DATA]
         inactive_count = discarded[REASON_INACTIVE]
         broken_ratio = broken_count / float(records_count)
         inactive_ratio = inactive_count / float(records_count)
-        logger.info("Broken pings ratio: {}; Inactive clients ratio: {}"
-                    .format(broken_ratio, inactive_ratio))
+        logger.info(
+            "Broken pings ratio: {}; Inactive clients ratio: {}".format(
+                broken_ratio, inactive_ratio
+            )
+        )
 
         # If we're not seeing sane values for the broken or inactive ratios,
         # bail out early on. There's no point in aggregating.
         if broken_ratio >= 0.9 or inactive_ratio >= 0.9:
             raise Exception(
                 "Unexpected ratio of broken pings or inactive clients. Broken ratio: {0},\
-                inactive ratio: {1}"
-                .format(broken_ratio, inactive_ratio))
+                inactive ratio: {1}".format(
+                    broken_ratio, inactive_ratio
+                )
+            )
 
         # Process the data, transforming it in the form we desire.
         device_map = build_device_map()
@@ -697,25 +705,30 @@ def generate_report(start_date, end_date, spark):
         # Collapse together groups that count less than 1% of our samples.
         threshold_to_collapse = int(valid_records_count * 0.01)
 
-        logger.info("Collapsing smaller groups into the other bucket (threshold {th})"
-                    .format(th=threshold_to_collapse))
-        collapsed_aggregates = collapse_buckets(
-            aggregated_pings, threshold_to_collapse)
+        logger.info(
+            "Collapsing smaller groups into the other bucket (threshold {th})".format(
+                th=threshold_to_collapse
+            )
+        )
+        collapsed_aggregates = collapse_buckets(aggregated_pings, threshold_to_collapse)
 
         logger.info("Post-processing raw values...")
 
-        processed_aggregates = finalize_data(collapsed_aggregates,
-                                             valid_records_count,
-                                             broken_ratio,
-                                             inactive_ratio,
-                                             chunk_start)
+        processed_aggregates = finalize_data(
+            collapsed_aggregates,
+            valid_records_count,
+            broken_ratio,
+            inactive_ratio,
+            chunk_start,
+        )
 
         if not validate_finalized_data(processed_aggregates):
             raise Exception("The aggregates failed to validate.")
 
         # Write the week start/end in the filename.
-        suffix = "-" + chunk_start.strftime("%Y%d%m") + \
-                 "-" + chunk_end.strftime("%Y%d%m")
+        suffix = (
+            "-" + chunk_start.strftime("%Y%d%m") + "-" + chunk_end.strftime("%Y%d%m")
+        )
         file_name = get_file_name(suffix)
 
         date_to_json[file_name] = processed_aggregates

--- a/mozetl/landfill/sampler.py
+++ b/mozetl/landfill/sampler.py
@@ -26,8 +26,18 @@ from pyspark.sql.types import StructType, StructField, StringType
 META_ARG_VERSION = re.compile(r"v=([\d]+)")
 
 # whitelist for fields to keep from the ingestion metadata
-META_WHITELIST = {'Content-Length', 'Date', 'Host', 'Timestamp', 'Type', 'User-Agent',
-                  'X-PingSender-Version', 'args', 'protocol', 'uri'}
+META_WHITELIST = {
+    "Content-Length",
+    "Date",
+    "Host",
+    "Timestamp",
+    "Type",
+    "User-Agent",
+    "X-PingSender-Version",
+    "args",
+    "protocol",
+    "uri",
+}
 
 # offsets into the URI specification where namespace is index 0
 TELEMETRY_DOC_TYPE = 2
@@ -39,8 +49,7 @@ GENERIC_DOC_ID = 3
 
 def extract(sc, submission_date, sample=0.01):
     landfill = (
-        Dataset
-        .from_source("landfill")
+        Dataset.from_source("landfill")
         .where(submissionDate=submission_date)
         .records(sc, sample=sample)
     )
@@ -55,16 +64,16 @@ def _process(message):
     Generic Ingestion URI Specification:
         /submit/<namespace>/<doc_type>/<doc_version>/<doc_id>
     """
-    meta = {k: v for k, v in list(message['meta'].items()) if k in META_WHITELIST}
+    meta = {k: v for k, v in list(message["meta"].items()) if k in META_WHITELIST}
 
     # Parse the uri, start by setting the path relative to `/submit`
     # Some paths do not adhere to the spec, so append empty values to avoid index errors.
-    path = meta['uri'].split('/')[2:] + [None, None, None, None]
+    path = meta["uri"].split("/")[2:] + [None, None, None, None]
     namespace = path[0]
 
-    if namespace == 'telemetry':
+    if namespace == "telemetry":
         doc_type = path[TELEMETRY_DOC_TYPE]
-        arg = META_ARG_VERSION.search(meta.get('args', ''))
+        arg = META_ARG_VERSION.search(meta.get("args", ""))
         doc_version = arg.group(1) if arg else None
         doc_id = path[TELEMETRY_DOC_ID]
     else:
@@ -72,33 +81,37 @@ def _process(message):
         doc_version = path[GENERIC_DOC_VER]
         doc_id = path[GENERIC_DOC_ID]
 
-    return namespace, doc_type, doc_version, doc_id, meta, message.get('content')
+    return namespace, doc_type, doc_version, doc_id, meta, message.get("content")
 
 
 def transform(landfill, n_documents=1000):
-    meta_schema = StructType([StructField(k, StringType(), True) for k in META_WHITELIST])
+    meta_schema = StructType(
+        [StructField(k, StringType(), True) for k in META_WHITELIST]
+    )
 
-    schema = StructType([
-        StructField("namespace", StringType(), False),
-        StructField("doc_type", StringType(), False),
-        StructField("doc_version", StringType(), True),
-        StructField("doc_id", StringType(), True),
-        StructField("meta", meta_schema, False),
-        StructField("content", StringType(), False)
-    ])
+    schema = StructType(
+        [
+            StructField("namespace", StringType(), False),
+            StructField("doc_type", StringType(), False),
+            StructField("doc_version", StringType(), True),
+            StructField("doc_id", StringType(), True),
+            StructField("meta", meta_schema, False),
+            StructField("content", StringType(), False),
+        ]
+    )
 
     documents = (
-        landfill
-        .map(_process)
+        landfill.map(_process)
         .filter(lambda x: x[0] and x[1] and x[-2] and x[-1])
         .toDF(schema)
     )
 
-    window_spec = Window.partitionBy("namespace", "doc_type", "doc_version").orderBy("doc_id")
+    window_spec = Window.partitionBy("namespace", "doc_type", "doc_version").orderBy(
+        "doc_id"
+    )
 
     df = (
-        documents
-        .fillna("0", "doc_version")
+        documents.fillna("0", "doc_version")
         .withColumn("row_id", row_number().over(window_spec))
         .where(col("row_id") <= n_documents)
         .drop("row_id")
@@ -108,19 +121,23 @@ def transform(landfill, n_documents=1000):
 
 
 def save(submission_date, bucket, prefix, df):
-    path = "s3://{}/{}/{}/submission_date_s3={}".format(bucket, prefix, 'v3', submission_date)
+    path = "s3://{}/{}/{}/submission_date_s3={}".format(
+        bucket, prefix, "v3", submission_date
+    )
     (
-        df
-        .write.partitionBy("namespace", "doc_type", "doc_version")
-        .json(path, mode='overwrite')
+        df.write.partitionBy("namespace", "doc_type", "doc_version").json(
+            path, mode="overwrite"
+        )
     )
 
 
-@click.command('sample-landfill')
-@click.option('--bucket', type=str, default='net-mozaws-prod-us-west-2-pipeline-analysis')
-@click.option('--prefix', type=str, default='amiyaguchi/sanitized-landfill-sample')
-@click.option('--submission-date', type=str, required=True)
-@click.option('--sample', type=float, default=0.01)
+@click.command("sample-landfill")
+@click.option(
+    "--bucket", type=str, default="net-mozaws-prod-us-west-2-pipeline-analysis"
+)
+@click.option("--prefix", type=str, default="amiyaguchi/sanitized-landfill-sample")
+@click.option("--submission-date", type=str, required=True)
+@click.option("--sample", type=float, default=0.01)
 def main(bucket, prefix, submission_date, sample):
     """Sample documents from landfill."""
     spark = SparkSession.builder.getOrCreate()

--- a/mozetl/main.py
+++ b/mozetl/main.py
@@ -7,32 +7,26 @@ from pyspark import Row
 
 
 def get_data(sc):
-    pings = Dataset.from_source(
-        "telemetry"
-    ).where(
-        docType='main',
-        submissionDate=(date.today() - timedelta(1)).strftime("%Y%m%d"),
-        appUpdateChannel="nightly"
-    ).records(sc, sample=0.1)
+    pings = (
+        Dataset.from_source("telemetry")
+        .where(
+            docType="main",
+            submissionDate=(date.today() - timedelta(1)).strftime("%Y%m%d"),
+            appUpdateChannel="nightly",
+        )
+        .records(sc, sample=0.1)
+    )
 
-    return get_pings_properties(pings, ["clientId",
-                                        "environment/system/os/name"])
+    return get_pings_properties(pings, ["clientId", "environment/system/os/name"])
 
 
 def ping_to_row(ping):
-    return Row(
-        client_id=ping['clientId'],
-        os=ping['environment/system/os/name']
-    )
+    return Row(client_id=ping["clientId"], os=ping["environment/system/os/name"])
 
 
 def transform_pings(pings):
     """Take a dataframe of main pings and summarize OS share"""
-    out = pings.map(
-        ping_to_row
-    ).distinct().map(
-        lambda x: x.os
-    ).countByValue()
+    out = pings.map(ping_to_row).distinct().map(lambda x: x.os).countByValue()
     return dict(out)
 
 
@@ -44,14 +38,9 @@ def etl_job(sc, sqlContext):
     total = sum(map(operator.itemgetter(1), iter(results.items())))
     # Print the OS and client_id counts in descending order:
     sorted_results = sorted(
-        iter(results.items()),
-        key=operator.itemgetter(1),
-        reverse=True,
+        iter(results.items()), key=operator.itemgetter(1), reverse=True
     )
     for pair in sorted_results:
         print(
-            "OS: {:<10} Percent: {:0.2f}%".format(
-                pair[0],
-                float(pair[1]) / total * 100
-            )
+            "OS: {:<10} Percent: {:0.2f}%".format(pair[0], float(pair[1]) / total * 100)
         )

--- a/mozetl/schemas.py
+++ b/mozetl/schemas.py
@@ -5,8 +5,9 @@ import pkg_resources
 from pyspark.sql.types import StructType
 
 import mozetl
-SCHEMA_DIR = 'json'
-MAIN_SUMMARY_SCHEMA_BASENAME = 'main_summary.v4.schema.json'
+
+SCHEMA_DIR = "json"
+MAIN_SUMMARY_SCHEMA_BASENAME = "main_summary.v4.schema.json"
 main_summary_path = os.path.join(SCHEMA_DIR, MAIN_SUMMARY_SCHEMA_BASENAME)
 
 with pkg_resources.resource_stream(mozetl.__name__, main_summary_path) as f:

--- a/mozetl/search/aggregates.py
+++ b/mozetl/search/aggregates.py
@@ -1,4 +1,4 @@
-'''Firefox Desktop Search Count Datasets
+"""Firefox Desktop Search Count Datasets
 
 This job produces derived datasets that make it easy to explore search count
 data.
@@ -9,14 +9,26 @@ For more information, see Bug 1381140.
 The search_clients_daily job produces a dataset keyed by
 `(client_id, submission_date, search_counts.engine, search_counts.source)`.
 This allows for deeper analysis into user level search behavior.
-'''
+"""
 import click
 import logging
 import datetime
 from pyspark_hyperloglog import hll
 from pyspark.sql.functions import (
-    expr, explode, col, when, udf, sum, first, count, datediff, from_unixtime,
-    mean, size, max, lit
+    expr,
+    explode,
+    col,
+    when,
+    udf,
+    sum,
+    first,
+    count,
+    datediff,
+    from_unixtime,
+    mean,
+    size,
+    max,
+    lit,
 )
 from pyspark.sql.types import StringType
 from pyspark.sql import SparkSession
@@ -24,9 +36,9 @@ from pyspark.sql import SparkSession
 from mozetl.constants import SEARCH_SOURCE_WHITELIST
 
 
-DEFAULT_INPUT_BUCKET = 'telemetry-parquet'
-DEFAULT_INPUT_PREFIX = 'main_summary/v4'
-DEFAULT_SAVE_MODE = 'error'
+DEFAULT_INPUT_BUCKET = "telemetry-parquet"
+DEFAULT_INPUT_PREFIX = "main_summary/v4"
+DEFAULT_SAVE_MODE = "error"
 MAX_CLIENT_SEARCH_COUNT = 10000
 
 SEARCH_AGGREGATES_VERSION = 4
@@ -40,72 +52,75 @@ def agg_first(col):
 def search_clients_daily(main_summary):
     return agg_search_data(
         main_summary,
-        [
-            'client_id',
-            'submission_date',
-            'engine',
-            'source',
-        ],
-        list(map(agg_first, [
-            'country',
-            'app_version',
-            'distribution_id',
-            'locale',
-            'search_cohort',
-            'addon_version',
-            'os',
-            'channel',
-            'profile_creation_date',
-            'default_search_engine',
-            'default_search_engine_data_load_path',
-            'default_search_engine_data_submission_url',
-            'sample_id',
-        ])) + [
+        ["client_id", "submission_date", "engine", "source"],
+        list(
+            map(
+                agg_first,
+                [
+                    "country",
+                    "app_version",
+                    "distribution_id",
+                    "locale",
+                    "search_cohort",
+                    "addon_version",
+                    "os",
+                    "channel",
+                    "profile_creation_date",
+                    "default_search_engine",
+                    "default_search_engine_data_load_path",
+                    "default_search_engine_data_submission_url",
+                    "sample_id",
+                ],
+            )
+        )
+        + [
             # Count of 'first' subsessions seen for this client_day
             (
-                count(when(col('subsession_counter') == 1, 1))
-                .alias('sessions_started_on_this_day')
+                count(when(col("subsession_counter") == 1, 1)).alias(
+                    "sessions_started_on_this_day"
+                )
             ),
-            first(datediff(
-                'subsession_start_date',
-                from_unixtime(col('profile_creation_date') * 24 * 60 * 60)
-            )).alias('profile_age_in_days'),
-            sum(col('subsession_length')/3600.0).alias('subsession_hours_sum'),
-            mean(size('active_addons')).alias('active_addons_count_mean'),
+            first(
+                datediff(
+                    "subsession_start_date",
+                    from_unixtime(col("profile_creation_date") * 24 * 60 * 60),
+                )
+            ).alias("profile_age_in_days"),
+            sum(col("subsession_length") / 3600.0).alias("subsession_hours_sum"),
+            mean(size("active_addons")).alias("active_addons_count_mean"),
             (
-                max('scalar_parent_browser_engagement_max_concurrent_tab_count')
-                .alias('max_concurrent_tab_count_max')
+                max("scalar_parent_browser_engagement_max_concurrent_tab_count").alias(
+                    "max_concurrent_tab_count_max"
+                )
             ),
             (
-                sum('scalar_parent_browser_engagement_tab_open_event_count')
-                .alias('tab_open_event_count_sum')
+                sum("scalar_parent_browser_engagement_tab_open_event_count").alias(
+                    "tab_open_event_count_sum"
+                )
             ),
-            (
-                sum(col('active_ticks') * 5 / 3600.0)
-                .alias('active_hours_sum')
-            ),
-        ]
+            (sum(col("active_ticks") * 5 / 3600.0).alias("active_hours_sum")),
+        ],
     )
 
 
 def search_aggregates(main_summary):
     hll.register()
     return agg_search_data(
-        main_summary.withColumn('hll', expr('hll_create(client_id, 12)')),
+        main_summary.withColumn("hll", expr("hll_create(client_id, 12)")),
         [
-            'addon_version',
-            'app_version',
-            'country',
-            'distribution_id',
-            'engine',
-            'locale',
-            'search_cohort',
-            'source',
-            'submission_date',
-            'default_search_engine',
+            "addon_version",
+            "app_version",
+            "country",
+            "distribution_id",
+            "engine",
+            "locale",
+            "search_cohort",
+            "source",
+            "submission_date",
+            "default_search_engine",
         ],
-        [expr("hll_cardinality(hll_merge(hll)) as client_count")]
-    ).where(col('engine').isNotNull())
+        [expr("hll_cardinality(hll_merge(hll)) as client_count")],
+    ).where(col("engine").isNotNull())
 
 
 def agg_search_data(main_summary, grouping_cols, agg_functions):
@@ -128,26 +143,21 @@ def agg_search_data(main_summary, grouping_cols, agg_functions):
     augmented = add_derived_columns(exploded)
 
     # Do all aggregations
-    aggregated = (
-        augmented
-        .groupBy(grouping_cols + ['type'])
-        .agg(*(agg_functions + [sum('count').alias('count')]))
+    aggregated = augmented.groupBy(grouping_cols + ["type"]).agg(
+        *(agg_functions + [sum("count").alias("count")])
     )
 
     # Pivot on search type
     pivoted = (
-        aggregated
-        .groupBy([column for column in aggregated.columns
-                  if column not in ['type', 'count']])
-        .pivot(
-            'type',
-            ['organic', 'tagged-sap', 'tagged-follow-on', 'sap', 'unknown']
+        aggregated.groupBy(
+            [column for column in aggregated.columns if column not in ["type", "count"]]
         )
-        .sum('count')
+        .pivot("type", ["organic", "tagged-sap", "tagged-follow-on", "sap", "unknown"])
+        .sum("count")
         # Add convenience columns with underscores instead of hyphens.
         # This makes the table easier to query from Presto.
-        .withColumn('tagged_sap', col('tagged-sap'))
-        .withColumn('tagged_follow_on', col('tagged-follow-on'))
+        .withColumn("tagged_sap", col("tagged-sap"))
+        .withColumn("tagged_follow_on", col("tagged-follow-on"))
     )
 
     return pivoted
@@ -156,153 +166,160 @@ def agg_search_data(main_summary, grouping_cols, agg_functions):
 def get_search_addon_version(active_addons):
     if not active_addons:
         return None
-    return next((a[5] for a in active_addons if a[0] == "followonsearch@mozilla.com"),
-                None)
+    return next(
+        (a[5] for a in active_addons if a[0] == "followonsearch@mozilla.com"), None
+    )
 
 
 def explode_search_counts(main_summary):
-    exploded_col_name = 'single_search_count'
-    search_fields = [exploded_col_name + '.' + field
-                     for field in ['engine', 'source', 'count']]
+    exploded_col_name = "single_search_count"
+    search_fields = [
+        exploded_col_name + "." + field for field in ["engine", "source", "count"]
+    ]
 
     exploded_search_counts = (
-        main_summary
-        .withColumn(exploded_col_name, explode(col('search_counts')))
-        .select(['*'] + search_fields)
-        .filter('single_search_count.count < %s' % MAX_CLIENT_SEARCH_COUNT)
+        main_summary.withColumn(exploded_col_name, explode(col("search_counts")))
+        .select(["*"] + search_fields)
+        .filter("single_search_count.count < %s" % MAX_CLIENT_SEARCH_COUNT)
         .drop(exploded_col_name)
-        .drop('search_counts')
+        .drop("search_counts")
     )
 
     zero_search_users = (
-        main_summary
-        .where(col('search_counts').isNull())
-        .withColumn('engine', lit(None))
-        .withColumn('source', lit(None))
+        main_summary.where(col("search_counts").isNull())
+        .withColumn("engine", lit(None))
+        .withColumn("source", lit(None))
         # Using 0 instead of None for search_count makes many queries easier
         # (e.g. average searche per user)
-        .withColumn('count', lit(0))
-        .drop('search_counts')
+        .withColumn("count", lit(0))
+        .drop("search_counts")
     )
 
     return exploded_search_counts.union(zero_search_users)
 
 
 def add_derived_columns(exploded_search_counts):
-    '''Adds the following columns to the provided dataset:
+    """Adds the following columns to the provided dataset:
 
     type:           One of 'in-content-sap', 'follow-on', or 'chrome-sap'.
     addon_version:  The version of the followon-search@mozilla addon, or None
-    '''
+    """
     udf_get_search_addon_version = udf(get_search_addon_version, StringType())
 
     def _generate_when_expr(source_mappings):
         if not source_mappings:
-            return 'unknown'
+            return "unknown"
         source_mapping = source_mappings[0]
-        return when(col('source').startswith(source_mapping[0]), source_mapping[1]).otherwise(
-            _generate_when_expr(source_mappings[1:])
-        )
-    when_expr = (
-        when(col('source').isin(SEARCH_SOURCE_WHITELIST), 'sap')
-        .otherwise(
-            when(col('source').isNull(), 'sap').otherwise(
-                _generate_when_expr([('in-content:sap:', 'tagged-sap'),
-                                     ('in-content:sap-follow-on:', 'tagged-follow-on'),
-                                     ('in-content:organic:', 'organic'),
-                                     ('sap:', 'tagged-sap'),
-                                     ('follow-on:', 'tagged-follow-on')])
+        return when(
+            col("source").startswith(source_mapping[0]), source_mapping[1]
+        ).otherwise(_generate_when_expr(source_mappings[1:]))
+
+    when_expr = when(col("source").isin(SEARCH_SOURCE_WHITELIST), "sap").otherwise(
+        when(col("source").isNull(), "sap").otherwise(
+            _generate_when_expr(
+                [
+                    ("in-content:sap:", "tagged-sap"),
+                    ("in-content:sap-follow-on:", "tagged-follow-on"),
+                    ("in-content:organic:", "organic"),
+                    ("sap:", "tagged-sap"),
+                    ("follow-on:", "tagged-follow-on"),
+                ]
             )
         )
     )
 
-    return (
-        exploded_search_counts.withColumn('type', when_expr)
-        .withColumn('addon_version', udf_get_search_addon_version('active_addons'))
+    return exploded_search_counts.withColumn("type", when_expr).withColumn(
+        "addon_version", udf_get_search_addon_version("active_addons")
     )
 
 
-def generate_rollups(submission_date, output_bucket, output_prefix,
-                     output_version, transform_func,
-                     input_bucket=DEFAULT_INPUT_BUCKET,
-                     input_prefix=DEFAULT_INPUT_PREFIX,
-                     save_mode=DEFAULT_SAVE_MODE, orderBy=[]):
+def generate_rollups(
+    submission_date,
+    output_bucket,
+    output_prefix,
+    output_version,
+    transform_func,
+    input_bucket=DEFAULT_INPUT_BUCKET,
+    input_prefix=DEFAULT_INPUT_PREFIX,
+    save_mode=DEFAULT_SAVE_MODE,
+    orderBy=[],
+):
     """Load main_summary, apply transform_func, and write to S3"""
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
 
-    logger.info('Running the {0} ETL job...'.format(transform_func.__name__))
+    logger.info("Running the {0} ETL job...".format(transform_func.__name__))
     start = datetime.datetime.now()
-    spark = (
-        SparkSession
-        .builder
-        .appName('search_dashboard_etl')
-        .getOrCreate()
+    spark = SparkSession.builder.appName("search_dashboard_etl").getOrCreate()
+
+    source_path = "s3://{}/{}/submission_date_s3={}".format(
+        input_bucket, input_prefix, submission_date
+    )
+    output_path = "s3://{}/{}/v{}/submission_date_s3={}".format(
+        output_bucket, output_prefix, output_version, submission_date
     )
 
-    source_path = 's3://{}/{}/submission_date_s3={}'.format(
-        input_bucket,
-        input_prefix,
-        submission_date
-    )
-    output_path = 's3://{}/{}/v{}/submission_date_s3={}'.format(
-        output_bucket,
-        output_prefix,
-        output_version,
-        submission_date
-    )
-
-    logger.info('Loading main_summary...')
+    logger.info("Loading main_summary...")
     main_summary = spark.read.parquet(source_path)
 
-    logger.info('Applying transformation function...')
+    logger.info("Applying transformation function...")
     search_dashboard_data = transform_func(main_summary)
 
     if orderBy:
         search_dashboard_data = search_dashboard_data.orderBy(*orderBy)
 
-    logger.info('Saving rollups to: {}'.format(output_path))
-    (
-        search_dashboard_data
-        .write
-        .mode(save_mode)
-        .save(output_path)
-    )
+    logger.info("Saving rollups to: {}".format(output_path))
+    (search_dashboard_data.write.mode(save_mode).save(output_path))
 
     spark.stop()
-    logger.info('... done (took: %s)', str(datetime.datetime.now() - start))
+    logger.info("... done (took: %s)", str(datetime.datetime.now() - start))
 
 
 # Generate ETL jobs - these are useful if you want to run a job from ATMO
-def search_aggregates_etl(submission_date, bucket, prefix,
-                          **kwargs):
-    generate_rollups(submission_date, bucket, prefix,
-                     SEARCH_AGGREGATES_VERSION, search_aggregates, **kwargs)
+def search_aggregates_etl(submission_date, bucket, prefix, **kwargs):
+    generate_rollups(
+        submission_date,
+        bucket,
+        prefix,
+        SEARCH_AGGREGATES_VERSION,
+        search_aggregates,
+        **kwargs
+    )
 
 
-def search_clients_daily_etl(submission_date, bucket, prefix,
-                             **kwargs):
-    generate_rollups(submission_date, bucket, prefix,
-                     SEARCH_CLIENTS_DAILY_VERSION, search_clients_daily,
-                     orderBy=['sample_id'], **kwargs)
+def search_clients_daily_etl(submission_date, bucket, prefix, **kwargs):
+    generate_rollups(
+        submission_date,
+        bucket,
+        prefix,
+        SEARCH_CLIENTS_DAILY_VERSION,
+        search_clients_daily,
+        orderBy=["sample_id"],
+        **kwargs
+    )
 
 
 # Generate click commands - wrap ETL jobs to accept click arguements
 def gen_click_command(etl_job):
     """Wrap an ETL job with click arguements"""
+
     @click.command()
-    @click.option('--submission_date', required=True)
-    @click.option('--bucket', required=True)
-    @click.option('--prefix', required=True)
-    @click.option('--input_bucket',
-                  default=DEFAULT_INPUT_BUCKET,
-                  help='Bucket of the input dataset')
-    @click.option('--input_prefix',
-                  default=DEFAULT_INPUT_PREFIX,
-                  help='Prefix of the input dataset')
-    @click.option('--save_mode',
-                  default=DEFAULT_SAVE_MODE,
-                  help='Save mode for writing data')
+    @click.option("--submission_date", required=True)
+    @click.option("--bucket", required=True)
+    @click.option("--prefix", required=True)
+    @click.option(
+        "--input_bucket",
+        default=DEFAULT_INPUT_BUCKET,
+        help="Bucket of the input dataset",
+    )
+    @click.option(
+        "--input_prefix",
+        default=DEFAULT_INPUT_PREFIX,
+        help="Prefix of the input dataset",
+    )
+    @click.option(
+        "--save_mode", default=DEFAULT_SAVE_MODE, help="Save mode for writing data"
+    )
     def wrapper(*args, **posargs):
         return etl_job(*args, **posargs)
 

--- a/mozetl/shield/privacy_prefs.py
+++ b/mozetl/shield/privacy_prefs.py
@@ -13,7 +13,7 @@ from moztelemetry.dataset import Dataset
 from ..basic import convert_pings, DataFrameConfig
 
 
-SHIELD_ADDON_ID = '@shield-study-privacy'
+SHIELD_ADDON_ID = "@shield-study-privacy"
 
 # Note that the JSON paths in this config are unusual for Shield pings.
 # See https://bugzil.la/1387236 for more details and discussion
@@ -29,11 +29,11 @@ COMMON_COLUMN_CONFIGS = [
 ]
 
 STUDY_STATE_DATAFRAME_COLUMN_CONFIGS = COMMON_COLUMN_CONFIGS + [
-    ("study", "payload/study_name", None, StringType()),
+    ("study", "payload/study_name", None, StringType())
 ]
 
 STUDY_EVENT_DATAFRAME_COLUMN_CONFIGS = COMMON_COLUMN_CONFIGS + [
-    ("study", "payload/study", None, StringType()),
+    ("study", "payload/study", None, StringType())
 ]
 
 
@@ -41,8 +41,7 @@ def transform_state_pings(sqlContext, pings):
     return convert_pings(
         sqlContext,
         pings,
-        DataFrameConfig(STUDY_STATE_DATAFRAME_COLUMN_CONFIGS,
-                        include_state_pings)
+        DataFrameConfig(STUDY_STATE_DATAFRAME_COLUMN_CONFIGS, include_state_pings),
     )
 
 
@@ -50,31 +49,30 @@ def transform_event_pings(sqlContext, pings):
     return convert_pings(
         sqlContext,
         pings,
-        DataFrameConfig(STUDY_EVENT_DATAFRAME_COLUMN_CONFIGS,
-                        include_event_pings)
+        DataFrameConfig(STUDY_EVENT_DATAFRAME_COLUMN_CONFIGS, include_event_pings),
     )
 
 
 def include_event_pings(ping):
-    return ping['payload/study'] == SHIELD_ADDON_ID
+    return ping["payload/study"] == SHIELD_ADDON_ID
 
 
 def include_state_pings(ping):
-    return ping['payload/study_name'] == SHIELD_ADDON_ID
+    return ping["payload/study_name"] == SHIELD_ADDON_ID
 
 
 def etl_job(sc, sqlContext, submission_date=None, save=True):
-    s3_path = 's3n://telemetry-parquet/harter/privacy_prefs_shield/v2'
+    s3_path = "s3n://telemetry-parquet/harter/privacy_prefs_shield/v2"
     if submission_date is None:
         submission_date = (date.today() - timedelta(1)).strftime("%Y%m%d")
 
-    pings = Dataset.from_source(
-        "telemetry"
-    ).where(
-        docType="shield-study",
-        submissionDate=submission_date,
-        appName="Firefox",
-    ).records(sc)
+    pings = (
+        Dataset.from_source("telemetry")
+        .where(
+            docType="shield-study", submissionDate=submission_date, appName="Firefox"
+        )
+        .records(sc)
+    )
 
     transformed_event_pings = transform_event_pings(sqlContext, pings)
 
@@ -83,7 +81,7 @@ def etl_job(sc, sqlContext, submission_date=None, save=True):
     transformed_pings = transformed_event_pings.union(transformed_state_pings)
 
     if save:
-        path = s3_path + '/submission_date={}'.format(submission_date)
-        transformed_pings.repartition(1).write.mode('overwrite').parquet(path)
+        path = s3_path + "/submission_date={}".format(submission_date)
+        transformed_pings.repartition(1).write.mode("overwrite").parquet(path)
 
     return transformed_pings

--- a/mozetl/shield/utils.py
+++ b/mozetl/shield/utils.py
@@ -7,19 +7,21 @@ def shield_etl_boilerplate(transform_func, s3_path):
         if submission_date is None:
             submission_date = (date.today() - timedelta(1)).strftime("%Y%m%d")
 
-        pings = Dataset.from_source(
-            "telemetry"
-        ).where(
-            docType="shield-study",
-            submissionDate=submission_date,
-            appName="Firefox",
-        ).records(sc)
+        pings = (
+            Dataset.from_source("telemetry")
+            .where(
+                docType="shield-study",
+                submissionDate=submission_date,
+                appName="Firefox",
+            )
+            .records(sc)
+        )
 
         transformed_pings = transform_func(sqlContext, pings)
 
         if save:
-            path = s3_path + '/submission_date={}'.format(submission_date)
-            transformed_pings.repartition(1).write.mode('overwrite').parquet(path)
+            path = s3_path + "/submission_date={}".format(submission_date)
+            transformed_pings.repartition(1).write.mode("overwrite").parquet(path)
 
         return transformed_pings
 

--- a/mozetl/taar/taar_amodump.py
+++ b/mozetl/taar/taar_amodump.py
@@ -13,14 +13,14 @@ from .taar_utils import store_json_to_s3
 import requests
 from requests_toolbelt.threaded import pool
 
-AMO_DUMP_BUCKET = 'telemetry-parquet'
-AMO_DUMP_PREFIX = 'telemetry-ml/addon_recommender/'
-AMO_DUMP_FILENAME = 'extended_addons_database'
+AMO_DUMP_BUCKET = "telemetry-parquet"
+AMO_DUMP_PREFIX = "telemetry-ml/addon_recommender/"
+AMO_DUMP_FILENAME = "extended_addons_database"
 
 DEFAULT_AMO_REQUEST_URI = "https://addons.mozilla.org/api/v3/addons/search/"
 QUERY_PARAMS = "?app=firefox&sort=created&type=extension"
 
-logger = logging.getLogger('amo_database')
+logger = logging.getLogger("amo_database")
 
 
 """
@@ -53,27 +53,26 @@ class JSONSchema:
 
 
 class AMOAddonFile(JSONSchema):
-    meta = {'id': int,
-            'platform': str,
-            'status': str,
-            'is_webextension': bool}
+    meta = {"id": int, "platform": str, "status": str, "is_webextension": bool}
 
 
 class AMOAddonVersion(JSONSchema):
-    meta = {'files': typing.List[AMOAddonFile]}
+    meta = {"files": typing.List[AMOAddonFile]}
 
 
 class AMOAddonInfo(JSONSchema):
-    meta = {'guid': str,
-            'categories': typing.Dict[str, typing.List[str]],
-            'default_locale': str,
-            'description': typing.Dict[str, str],
-            'name': typing.Dict[str, str],
-            'current_version': AMOAddonVersion,
-            'ratings': typing.Dict[str, float],
-            'summary': typing.Dict[str, str],
-            'tags': typing.List[str],
-            'weekly_downloads': int}
+    meta = {
+        "guid": str,
+        "categories": typing.Dict[str, typing.List[str]],
+        "default_locale": str,
+        "description": typing.Dict[str, str],
+        "name": typing.Dict[str, str],
+        "current_version": AMOAddonVersion,
+        "ratings": typing.Dict[str, float],
+        "summary": typing.Dict[str, str],
+        "tags": typing.List[str],
+        "weekly_downloads": int,
+    }
 
 
 class AMODatabase:
@@ -85,16 +84,16 @@ class AMODatabase:
 
         uri = DEFAULT_AMO_REQUEST_URI + QUERY_PARAMS
         response = requests.get(uri)
-        jdata = json.loads(response.content.decode('utf8'))
+        jdata = json.loads(response.content.decode("utf8"))
 
-        self._page_count = jdata['page_count']
+        self._page_count = jdata["page_count"]
 
     def fetch_addons(self):
         addon_map = self._fetch_pages()
         self._fetch_versions(addon_map)
         final_result = {}
         for k, v in list(addon_map.items()):
-            if 'first_create_date' in v:
+            if "first_create_date" in v:
                 final_result[k] = v
         logger.info("Final addon set includes %d addons." % len(final_result))
         return final_result
@@ -103,7 +102,7 @@ class AMODatabase:
         addon_map = {}
 
         urls = []
-        for i in range(1, self._page_count+1):
+        for i in range(1, self._page_count + 1):
             url = "{0}{1}&page={2}".format(DEFAULT_AMO_REQUEST_URI, QUERY_PARAMS, i)
             urls.append(url)
         logger.info("Processing AMO urls")
@@ -145,9 +144,7 @@ class AMODatabase:
         total_processed_addons = 0
         for chunk in chunker(iterFactory(addon_map), 500):
             for i, url in enumerate(chunk):
-                q.put({'method': 'GET',
-                       'url': url,
-                       'timeout': 2.0})
+                q.put({"method": "GET", "url": url, "timeout": 2.0})
             logger.info("Queue setup - processing initial version page requests")
             logger.info("%d requests to process" % q.qsize())
 
@@ -159,40 +156,44 @@ class AMODatabase:
             total_processed_addons += len(last_page_urls)
 
             # Try processing the exceptions once
-            p = pool.Pool.from_exceptions(p.exceptions(), num_processes=self._max_processes)
+            p = pool.Pool.from_exceptions(
+                p.exceptions(), num_processes=self._max_processes
+            )
             p.join_all()
             last_page_urls.extend(self._handle_version_responses(p))
 
             # Now fetch the last version of each addon
             logger.info("Processing last page urls: %d" % len(last_page_urls))
-            p = pool.Pool.from_urls(last_page_urls,
-                                    num_processes=self._max_processes)
+            p = pool.Pool.from_urls(last_page_urls, num_processes=self._max_processes)
             p.join_all()
 
             self._handle_last_version_responses(p, addon_map)
 
             # Try processing exceptions once
-            p = pool.Pool.from_exceptions(p.exceptions(), num_processes=self._max_processes)
+            p = pool.Pool.from_exceptions(
+                p.exceptions(), num_processes=self._max_processes
+            )
             p.join_all()
             self._handle_last_version_responses(p, addon_map)
 
-            logger.info("Processed %d addons with version info" %
-                        total_processed_addons)
+            logger.info(
+                "Processed %d addons with version info" % total_processed_addons
+            )
 
     def _handle_last_version_responses(self, p, addon_map):
         for i, resp in enumerate(p.responses()):
             try:
                 if resp.status_code == 200:
-                    jdata = json.loads(resp.content.decode('utf8'))
-                    results = jdata['results']
+                    jdata = json.loads(resp.content.decode("utf8"))
+                    results = jdata["results"]
 
                     raw_guid = resp.url.split("addon/")[1].split("/versions")[0]
                     guid = urllib.parse.unquote(raw_guid)
-                    create_date = results[-1]['files'][0]['created']
+                    create_date = results[-1]["files"][0]["created"]
 
                     record = addon_map.get(guid, None)
                     if record is not None:
-                        record['first_create_date'] = create_date
+                        record["first_create_date"] = create_date
             except Exception as e:
                 # Skip this record
                 logger.error(e)
@@ -203,12 +204,12 @@ class AMODatabase:
         for resp in p.responses():
             try:
                 if resp.status_code == 200:
-                    jdata = json.loads(resp.content.decode('utf8'))
-                    results = jdata['results']
+                    jdata = json.loads(resp.content.decode("utf8"))
+                    results = jdata["results"]
                     for record in results:
                         if i % 500 == 0:
                             logger.info("Still parsing  addons...")
-                        guid = record['guid']
+                        guid = record["guid"]
                         addon_map[guid] = record
                     i += 1
             except Exception as e:
@@ -220,10 +221,10 @@ class AMODatabase:
         for i, resp in enumerate(p.responses()):
             try:
                 if resp.status_code == 200:
-                    jdata = json.loads(resp.content.decode('utf8'))
-                    page_count = int(jdata['page_count'])
+                    jdata = json.loads(resp.content.decode("utf8"))
+                    page_count = int(jdata["page_count"])
                     if page_count > 1:
-                        url = resp.url+"?page=%d" % page_count
+                        url = resp.url + "?page=%d" % page_count
                     else:
                         url = resp.url
                     page_urls.append(url)
@@ -238,17 +239,20 @@ class Undefined:
     This value is used to disambiguate None vs a non-existant value on
     dict.get() lookups
     """
+
     pass
 
 
 def marshal(value, name, type_def):
-    serializers = {typing.List: list,
-                   typing.Dict: dict,
-                   str: text_type,
-                   text_type: text_type,
-                   int: int,
-                   float: float,
-                   bool: bool}
+    serializers = {
+        typing.List: list,
+        typing.Dict: dict,
+        str: text_type,
+        text_type: text_type,
+        int: int,
+        float: float,
+        bool: bool,
+    }
 
     if issubclass(type_def, JSONSchema):
         obj = {}
@@ -256,9 +260,7 @@ def marshal(value, name, type_def):
             attr_value = value.get(attr_name, Undefined)
             if attr_value is not Undefined:
                 # Try marshalling the value
-                obj[attr_name] = marshal(attr_value,
-                                         attr_name,
-                                         attr_type_def)
+                obj[attr_name] = marshal(attr_value, attr_name, attr_type_def)
         return obj
     elif issubclass(type_def, typing.Container) and type_def not in [str, bytes]:
         if issubclass(type_def, typing.List):
@@ -268,9 +270,10 @@ def marshal(value, name, type_def):
             if value is None:
                 return None
             k_cast, v_cast = type_def.__args__
-            dict_vals = [(marshal(k, name, k_cast),
-                          marshal(v, name, v_cast))
-                         for k, v in list(value.items())]
+            dict_vals = [
+                (marshal(k, name, k_cast), marshal(v, name, v_cast))
+                for k, v in list(value.items())
+            ]
             return dict(dict_vals)
     else:
         return serializers[type_def](value)
@@ -287,17 +290,16 @@ def main(date, workers, s3_prefix, s3_bucket):
     addon_map = amodb.fetch_addons()
 
     try:
-        store_json_to_s3(json.dumps(addon_map),
-                         AMO_DUMP_FILENAME,
-                         date,
-                         s3_prefix,
-                         s3_bucket)
-        logger.info("Completed uploading s3://%s/%s%s.json" % (s3_bucket,
-                                                               s3_prefix,
-                                                               AMO_DUMP_FILENAME))
+        store_json_to_s3(
+            json.dumps(addon_map), AMO_DUMP_FILENAME, date, s3_prefix, s3_bucket
+        )
+        logger.info(
+            "Completed uploading s3://%s/%s%s.json"
+            % (s3_bucket, s3_prefix, AMO_DUMP_FILENAME)
+        )
     except Exception as e:
         logger.error("Error uploading data to S3", e)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/mozetl/taar/taar_lite_guidguid.py
+++ b/mozetl/taar/taar_lite_guidguid.py
@@ -16,14 +16,14 @@ import mozetl.taar.taar_utils as taar_utils
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
-OUTPUT_BUCKET = 'telemetry-parquet'
-OUTPUT_PREFIX = 'taar/lite/'
-OUTPUT_BASE_FILENAME = 'guid_coinstallation'
+OUTPUT_BUCKET = "telemetry-parquet"
+OUTPUT_PREFIX = "taar/lite/"
+OUTPUT_BASE_FILENAME = "guid_coinstallation"
 
-AMO_DUMP_BUCKET = 'telemetry-parquet'
-AMO_DUMP_KEY = 'telemetry-ml/addon_recommender/addons_database.json'
-MAIN_SUMMARY_PATH = 's3://telemetry-parquet/main_summary/v4/'
-ONE_WEEK_AGO = (dt.datetime.now() - dt.timedelta(days=7)).strftime('%Y%m%d')
+AMO_DUMP_BUCKET = "telemetry-parquet"
+AMO_DUMP_KEY = "telemetry-ml/addon_recommender/addons_database.json"
+MAIN_SUMMARY_PATH = "s3://telemetry-parquet/main_summary/v4/"
+ONE_WEEK_AGO = (dt.datetime.now() - dt.timedelta(days=7)).strftime("%Y%m%d")
 
 
 def extract_telemetry(spark):
@@ -43,12 +43,14 @@ def extract_telemetry(spark):
         """
         # Could scale this up to grab more than what is in
         # longitudinal and see how long it takes to run.
-        return (spark.table("longitudinal")  # noqa: E127,E501,E502,E999
-                .where("active_addons IS NOT null")
-                .where("size(active_addons[0]) > 1")
-                .where("normalized_channel = 'release'")
-                .where("build IS NOT NULL AND build[0].application_name = 'Firefox'")
-                .selectExpr("client_id as client_id", "active_addons[0] as active_addons"))
+        return (
+            spark.table("longitudinal")  # noqa: E127,E501,E502,E999
+            .where("active_addons IS NOT null")
+            .where("size(active_addons[0]) > 1")
+            .where("normalized_channel = 'release'")
+            .where("build IS NOT NULL AND build[0].application_name = 'Firefox'")
+            .selectExpr("client_id as client_id", "active_addons[0] as active_addons")
+        )
 
     def get_addons_per_client(users_df):
         """ Extracts a DataFrame that contains one row
@@ -60,14 +62,15 @@ def extract_telemetry(spark):
             legacy addons, disabled addons, sideloaded addons.
             """
             return not (
-                addon.is_system or
-                addon.app_disabled or
-                addon.type != "extension" or
-                addon.user_disabled or
-                addon.foreign_install or
+                addon.is_system
+                or addon.app_disabled
+                or addon.type != "extension"
+                or addon.user_disabled
+                or addon.foreign_install
+                or
                 # make sure the amo_whitelist has been broadcast to worker nodes.
-                guid not in broadcast_amo_whitelist.value or
-
+                guid not in broadcast_amo_whitelist.value
+                or
                 # Make sure that the Pioneer addon is explicitly
                 # excluded
                 guid == "pioneer-opt-in@mozilla.org"
@@ -76,13 +79,18 @@ def extract_telemetry(spark):
         # Create an add-ons dataset un-nesting the add-on map from each
         # user to a list of add-on GUIDs. Also filter undesired add-ons.
         return (
-            users_df.rdd
-                    .map(lambda p: (p["client_id"],
-                                    [guid
-                                     for guid, data in list(p["active_addons"].items())
-                                     if is_valid_addon(guid, data)]))
-                    .filter(lambda p: len(p[1]) > 1)
-                    .toDF(["client_id", "addon_ids"])
+            users_df.rdd.map(
+                lambda p: (
+                    p["client_id"],
+                    [
+                        guid
+                        for guid, data in list(p["active_addons"].items())
+                        if is_valid_addon(guid, data)
+                    ],
+                )
+            )
+            .filter(lambda p: len(p[1]) > 1)
+            .toDF(["client_id", "addon_ids"])
         )
 
     client_features_frame = get_initial_sample()
@@ -96,9 +104,11 @@ def extract_telemetry(spark):
     addons_info_frame = get_addons_per_client(client_features_frame)
     logging.info("Filtered for valid addons only.")
 
-    taar_training = addons_info_frame.join(client_features_frame, 'client_id', 'inner') \
-        .drop('active_addons') \
+    taar_training = (
+        addons_info_frame.join(client_features_frame, "client_id", "inner")
+        .drop("active_addons")
         .selectExpr("addon_ids as installed_addons")
+    )
     logging.info("JOIN completed on TAAR training data")
 
     return taar_training
@@ -116,33 +126,50 @@ def key_all(a):
 
 def transform(longitudinal_addons):
     # Only for logging, not used, but may be interesting for later analysis.
-    guid_set_unique = longitudinal_addons.withColumn("exploded",
-            F.explode(longitudinal_addons.installed_addons)).select(  # noqa: E501 - long lines
-        "exploded").rdd.flatMap(lambda x: x).distinct().collect()
-    logging.info("Number of unique guids co-installed in sample: " + str(len(guid_set_unique)))
+    guid_set_unique = (
+        longitudinal_addons.withColumn(
+            "exploded", F.explode(longitudinal_addons.installed_addons)
+        )
+        .select("exploded")  # noqa: E501 - long lines
+        .rdd.flatMap(lambda x: x)
+        .distinct()
+        .collect()
+    )
+    logging.info(
+        "Number of unique guids co-installed in sample: " + str(len(guid_set_unique))
+    )
 
-    restructured = longitudinal_addons.rdd.flatMap(lambda x: key_all(x.installed_addons)).toDF(
-        ['key_addon', "coinstalled_addons"])
+    restructured = longitudinal_addons.rdd.flatMap(
+        lambda x: key_all(x.installed_addons)
+    ).toDF(["key_addon", "coinstalled_addons"])
 
     # Explode the list of co-installs and count pair occurrences.
-    addon_co_installations = (restructured.select('key_addon',
-        F.explode('coinstalled_addons').alias('coinstalled_addon'))  # noqa: E501 - long lines
-                              .groupBy("key_addon", 'coinstalled_addon').count())
+    addon_co_installations = (
+        restructured.select(
+            "key_addon", F.explode("coinstalled_addons").alias("coinstalled_addon")
+        )  # noqa: E501 - long lines
+        .groupBy("key_addon", "coinstalled_addon")
+        .count()
+    )
 
     # Collect the set of coinstalled_addon, count pairs for each key_addon.
-    combine_and_map_cols = F.udf(lambda x, y: (x, y),
-                                 StructType([StructField('id', StringType()),
-                                             StructField('n', LongType())]))
+    combine_and_map_cols = F.udf(
+        lambda x, y: (x, y),
+        StructType([StructField("id", StringType()), StructField("n", LongType())]),
+    )
 
     # Spark functions are sometimes long and unwieldy. Tough luck.
     # Ignore E128 and E501 long line errors
-    addon_co_installations_collapsed = (addon_co_installations  # noqa: E128
-                                        .select('key_addon',
-                                            combine_and_map_cols('coinstalled_addon', 'count')  # noqa: E501
-                                        .alias('id_n'))
-                                        .groupby("key_addon")
-                                        .agg(F.collect_list('id_n')
-                                        .alias('coinstallation_counts')))
+    addon_co_installations_collapsed = (
+        addon_co_installations.select(  # noqa: E128
+            "key_addon",
+            combine_and_map_cols("coinstalled_addon", "count").alias(  # noqa: E501
+                "id_n"
+            ),
+        )
+        .groupby("key_addon")
+        .agg(F.collect_list("id_n").alias("coinstallation_counts"))
+    )
     logging.info(addon_co_installations_collapsed.printSchema())
     logging.info("Collecting final result of co-installations.")
 
@@ -161,23 +188,17 @@ def load_s3(result_df, date, prefix, bucket):
             value_json[_id] = n
         result_json[key_addon] = value_json
 
-    taar_utils.store_json_to_s3(json.dumps(result_json, indent=2),
-                                OUTPUT_BASE_FILENAME,
-                                date,
-                                prefix,
-                                bucket)
+    taar_utils.store_json_to_s3(
+        json.dumps(result_json, indent=2), OUTPUT_BASE_FILENAME, date, prefix, bucket
+    )
 
 
 @click.command()
-@click.option('--date', required=True)
-@click.option('--bucket', default=OUTPUT_BUCKET)
-@click.option('--prefix', default=OUTPUT_PREFIX)
+@click.option("--date", required=True)
+@click.option("--bucket", default=OUTPUT_BUCKET)
+@click.option("--prefix", default=OUTPUT_PREFIX)
 def main(date, bucket, prefix):
-    spark = (SparkSession
-             .builder
-             .appName("taar_lite=")
-             .enableHiveSupport()
-             .getOrCreate())
+    spark = SparkSession.builder.appName("taar_lite=").enableHiveSupport().getOrCreate()
 
     logging.info("Loading telemetry sample.")
 

--- a/mozetl/taar/taar_lite_guidranking.py
+++ b/mozetl/taar/taar_lite_guidranking.py
@@ -12,15 +12,16 @@ from pyspark.sql import SparkSession
 import mozetl.taar.taar_utils as taar_utils
 
 
-OUTPUT_BUCKET = 'telemetry-parquet'
-OUTPUT_PREFIX = 'taar/lite/'
-OUTPUT_BASE_FILENAME = 'guid_install_ranking'
+OUTPUT_BUCKET = "telemetry-parquet"
+OUTPUT_PREFIX = "taar/lite/"
+OUTPUT_BASE_FILENAME = "guid_install_ranking"
 
 
 def extract_telemetry(sparkSession):
     """ Load some training data from telemetry given a sparkContext
     """
-    frame = sparkSession.sql("""
+    frame = sparkSession.sql(
+        """
     SELECT
         addon_guid,
         count(*) as install_count
@@ -35,7 +36,8 @@ def extract_telemetry(sparkSession):
             build[0].application_name='Firefox'
         )
     GROUP BY addon_guid
-    """)
+    """
+    )
     return frame
 
 
@@ -43,29 +45,29 @@ def transform(frame):
     """ Convert the dataframe to JSON and augment each record to
     include the install count for each addon.
     """
+
     def lambda_func(x):
         return (x.addon_guid, x.install_count)
+
     return dict(frame.rdd.map(lambda_func).collect())
 
 
 def load_s3(result_data, date, prefix, bucket):
-    taar_utils.store_json_to_s3(json.dumps(result_data, indent=2),
-                                OUTPUT_BASE_FILENAME,
-                                date,
-                                prefix,
-                                bucket)
+    taar_utils.store_json_to_s3(
+        json.dumps(result_data, indent=2), OUTPUT_BASE_FILENAME, date, prefix, bucket
+    )
 
 
 @click.command()
-@click.option('--date', required=True)
-@click.option('--bucket', default=OUTPUT_BUCKET)
-@click.option('--prefix', default=OUTPUT_PREFIX)
+@click.option("--date", required=True)
+@click.option("--bucket", default=OUTPUT_BUCKET)
+@click.option("--prefix", default=OUTPUT_PREFIX)
 def main(date, bucket, prefix):
-    spark = (SparkSession
-             .builder
-             .appName("taar_lite_ranking")
-             .enableHiveSupport()
-             .getOrCreate())
+    spark = (
+        SparkSession.builder.appName("taar_lite_ranking")
+        .enableHiveSupport()
+        .getOrCreate()
+    )
 
     logging.info("Processing GUID install rankings")
 
@@ -74,5 +76,5 @@ def main(date, bucket, prefix):
     load_s3(result_data, date, prefix, bucket)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/mozetl/taar/taar_locale.py
+++ b/mozetl/taar/taar_locale.py
@@ -21,7 +21,7 @@ from .taar_utils import load_amo_curated_whitelist
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-LOCALE_FILE_NAME = 'top10_dict'
+LOCALE_FILE_NAME = "top10_dict"
 
 
 def get_addons(spark):
@@ -36,7 +36,8 @@ def get_addons(spark):
     telemetry client ID so we do not need to post-process the data in the
     get_addons function.
     """
-    return spark.sql("""
+    return spark.sql(
+        """
        WITH sample AS
        (
           SELECT
@@ -79,23 +80,21 @@ def get_addons(spark):
         FROM
             country_addon_pairs
         ORDER BY locality, pair_cnts DESC
-    """)
+    """
+    )
 
 
 def compute_threshold(addon_df):
     """ Get a threshold to remove locales with a small
     number of addons installations.
     """
-    addon_install_counts = (
-        addon_df
-        .groupBy('locality')
-        .agg({'pair_cnts': 'sum'})
-    )
+    addon_install_counts = addon_df.groupBy("locality").agg({"pair_cnts": "sum"})
 
     # Compute a threshold at the 25th percentile to remove locales with a
     # small number of addons installations.
-    locale_pop_threshold =\
-        addon_install_counts.approxQuantile('sum(pair_cnts)', [0.25], 0.2)[0]
+    locale_pop_threshold = addon_install_counts.approxQuantile(
+        "sum(pair_cnts)", [0.25], 0.2
+    )[0]
 
     # Safety net in case the distribution gets really skewed, we should
     # require 2000 addon installation instances to make recommendations.
@@ -105,10 +104,9 @@ def compute_threshold(addon_df):
     # Filter the list to only include locales including a sufficient
     # number of addon installations. Include number of addons in locales
     # that satisfy the threshold condition.
-    addon_locale_counts = (
-        addon_install_counts
-        .filter((col('sum(pair_cnts)') >= locale_pop_threshold))
-        )
+    addon_locale_counts = addon_install_counts.filter(
+        (col("sum(pair_cnts)") >= locale_pop_threshold)
+    )
 
     return addon_locale_counts
 
@@ -124,7 +122,7 @@ def transform(addon_df, addon_locale_counts_df, num_addons):
 
     # Helper function to normalize addon installations in a lambda.
     def normalize_cnts(p):
-        loc_norm = float(p['pair_cnts'])/float(p['sum(pair_cnts)'])
+        loc_norm = float(p["pair_cnts"]) / float(p["sum(pair_cnts)"])
         return loc_norm
 
     # Instantiate an empty dict.
@@ -136,53 +134,42 @@ def transform(addon_df, addon_locale_counts_df, num_addons):
     df1 = addon_locale_counts_df.alias("df1")
     df2 = addon_df.alias("df2")
 
-    combined_df = (
-        addon_df
-        .join(df1, df2.locality == df1.locality)
-        .drop(df1.locality)
-    )
+    combined_df = addon_df.join(df1, df2.locality == df1.locality).drop(df1.locality)
 
     # Normalize installation rate per locale.
     normalized_installs = combined_df.rdd.map(
         lambda p: Row(
-            addon_key=p['addon_key'],
-            locality=p['locality'],
-            loc_norm=normalize_cnts(p))
-        ).toDF()
+            addon_key=p["addon_key"], locality=p["locality"], loc_norm=normalize_cnts(p)
+        )
+    ).toDF()
 
     # Groupby locale and sort by normalized install rate
-    window = Window\
-        .partitionBy(normalized_installs['locality'])\
-        .orderBy(desc('loc_norm'))
+    window = Window.partitionBy(normalized_installs["locality"]).orderBy(
+        desc("loc_norm")
+    )
 
     # Truncate reults exceeding required number of addons.
     truncated_df = (
-        normalized_installs
-        .select(
-            '*', rank()
-            .over(window)
-            .alias('rank')
-            )
-        .filter(col('rank') <= num_addons)
-        .drop(col('rank'))
-        )
+        normalized_installs.select("*", rank().over(window).alias("rank"))
+        .filter(col("rank") <= num_addons)
+        .drop(col("rank"))
+    )
 
     list_of_locales = [
-        x[0] for x in truncated_df
-        .select(truncated_df.locality)
-        .distinct()
-        .collect()
-        ]
+        x[0] for x in truncated_df.select(truncated_df.locality).distinct().collect()
+    ]
 
     # There is probably a *much* smarter way fo doing this...
     # but alas, I am le tired.
     for specific_locale in list_of_locales:
         # Most popular addons per locale sorted by normalized
         # number of installs.
-        top10_per[specific_locale] =\
-            [[x['addon_key'], x['loc_norm']] for x in truncated_df
-                .filter(truncated_df.locality == specific_locale)
-                .collect()]
+        top10_per[specific_locale] = [
+            [x["addon_key"], x["loc_norm"]]
+            for x in truncated_df.filter(
+                truncated_df.locality == specific_locale
+            ).collect()
+        ]
     return top10_per
 
 
@@ -205,20 +192,19 @@ def generate_dictionary(spark, num_addons):
 
 
 @click.command()
-@click.option('--date', required=True)
-@click.option('--bucket', default='telemetry-private-analysis-2')
-@click.option('--prefix', default='taar/locale/')
-@click.option('--num_addons', default=10)
+@click.option("--date", required=True)
+@click.option("--bucket", default="telemetry-private-analysis-2")
+@click.option("--prefix", default="taar/locale/")
+@click.option("--num_addons", default=10)
 def main(date, bucket, prefix, num_addons):
-    spark = (SparkSession
-             .builder
-             .appName("taar_locale")
-             .enableHiveSupport()
-             .getOrCreate())
+    spark = (
+        SparkSession.builder.appName("taar_locale").enableHiveSupport().getOrCreate()
+    )
 
     logger.info("Processing top N addons per locale")
     locale_dict = generate_dictionary(spark, num_addons)
-    store_json_to_s3(json.dumps(locale_dict, indent=2), LOCALE_FILE_NAME,
-                     date, prefix, bucket)
+    store_json_to_s3(
+        json.dumps(locale_dict, indent=2), LOCALE_FILE_NAME, date, prefix, bucket
+    )
 
     spark.stop()

--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -177,7 +177,9 @@ def get_donor_pools(users_df, clusters_df, num_donors, random_seed=None):
     return clusters, donor_pool_df
 
 
-def get_donors(spark, num_clusters, num_donors, addon_whitelist, date_from, random_seed=None):
+def get_donors(
+    spark, num_clusters, num_donors, addon_whitelist, date_from, random_seed=None
+):
     # Get the data for the potential add-on donors.
     users_sample = get_samples(spark, date_from)
     # Get add-ons from selected users and make sure they are
@@ -315,7 +317,9 @@ def get_lr_curves(
 
     # Determine a range of observed similarity values linearly spaced.
     all_scores_rdd = same_cluster_scores_rdd.union(different_clusters_scores_rdd)
-    stats = all_scores_rdd.aggregate(StatCounter(), StatCounter.merge, StatCounter.mergeStats)
+    stats = all_scores_rdd.aggregate(
+        StatCounter(), StatCounter.merge, StatCounter.mergeStats
+    )
     min_similarity = stats.minValue
     max_similarity = stats.maxValue
     lr_index = np.arange(
@@ -353,8 +357,16 @@ def today_minus_90_days():
 @click.option("--kernel_bandwidth", default=0.35)
 @click.option("--num_pdf_points", default=1000)
 @click.option("--clients_sample_date_from", default=today_minus_90_days())
-def main(date, bucket, prefix, num_clusters, num_donors, kernel_bandwidth, num_pdf_points,
-         clients_sample_date_from):
+def main(
+    date,
+    bucket,
+    prefix,
+    num_clusters,
+    num_donors,
+    kernel_bandwidth,
+    num_pdf_points,
+    clients_sample_date_from,
+):
     logger.info("Sampling clients since {}".format(clients_sample_date_from))
 
     spark = (
@@ -375,8 +387,9 @@ def main(date, bucket, prefix, num_clusters, num_donors, kernel_bandwidth, num_p
     logger.info("Computing the list of donors...")
 
     # Compute the donors clusters and the LR curves.
-    cluster_ids, donors_df = get_donors(spark, num_clusters, num_donors, whitelist,
-                                        clients_sample_date_from)
+    cluster_ids, donors_df = get_donors(
+        spark, num_clusters, num_donors, whitelist, clients_sample_date_from
+    )
     donors_df.cache()
     lr_curves = get_lr_curves(
         spark, donors_df, cluster_ids, kernel_bandwidth, num_pdf_points

--- a/mozetl/taar/taar_utils.py
+++ b/mozetl/taar/taar_utils.py
@@ -16,11 +16,11 @@ from botocore.exceptions import ClientError
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-AMO_DUMP_BUCKET = 'telemetry-parquet'
-AMO_DUMP_KEY = 'telemetry-ml/addon_recommender/addons_database.json'
+AMO_DUMP_BUCKET = "telemetry-parquet"
+AMO_DUMP_KEY = "telemetry-ml/addon_recommender/addons_database.json"
 
-AMO_WHITELIST_KEY = 'telemetry-ml/addon_recommender/whitelist_addons_database.json'
-AMO_CURATED_WHITELIST_KEY = 'telemetry-ml/addon_recommender/only_guids_top_200.json'
+AMO_WHITELIST_KEY = "telemetry-ml/addon_recommender/whitelist_addons_database.json"
+AMO_CURATED_WHITELIST_KEY = "telemetry-ml/addon_recommender/only_guids_top_200.json"
 
 
 @contextlib.contextmanager
@@ -34,14 +34,10 @@ def read_from_s3(s3_dest_file_name, s3_prefix, bucket):
     Read JSON from an S3 bucket and return the decoded JSON blob
     """
 
-    full_s3_name = '{}{}'.format(s3_prefix, s3_dest_file_name)
-    conn = boto3.resource('s3', region_name='us-west-2')
+    full_s3_name = "{}{}".format(s3_prefix, s3_dest_file_name)
+    conn = boto3.resource("s3", region_name="us-west-2")
     stored_data = json.loads(
-        conn
-        .Object(bucket, full_s3_name)
-        .get()['Body']
-        .read()
-        .decode('utf-8')
+        conn.Object(bucket, full_s3_name).get()["Body"].read().decode("utf-8")
     )
     return stored_data
 
@@ -54,7 +50,7 @@ def write_to_s3(source_file_name, s3_dest_file_name, s3_prefix, bucket):
     :param s3_prefix: The S3 prefix in the bucket.
     :param bucket: The S3 bucket.
     """
-    client = boto3.client('s3', 'us-west-2')
+    client = boto3.client("s3", "us-west-2")
     transfer = boto3.s3.transfer.S3Transfer(client)
 
     # Update the state in the analysis bucket.
@@ -84,8 +80,7 @@ def store_json_to_s3(json_data, base_filename, date, prefix, bucket):
         with open(FULL_FILENAME, "w+") as json_file:
             json_file.write(json_data)
 
-        archived_file_copy =\
-            "{}{}.json".format(base_filename, date)
+        archived_file_copy = "{}{}.json".format(base_filename, date)
 
         # Store a copy of the current JSON with datestamp.
         write_to_s3(FULL_FILENAME, archived_file_copy, prefix, bucket)
@@ -102,20 +97,21 @@ def load_amo_external_whitelist():
     amo_dump = {}
     try:
         # Load the most current AMO dump JSON resource.
-        s3 = boto3.client('s3')
+        s3 = boto3.client("s3")
         s3_contents = s3.get_object(Bucket=AMO_DUMP_BUCKET, Key=AMO_WHITELIST_KEY)
-        amo_dump = json.loads(s3_contents['Body'].read().decode('utf-8'))
+        amo_dump = json.loads(s3_contents["Body"].read().decode("utf-8"))
     except ClientError:
-        logger.exception("Failed to download from S3", extra={
-            "bucket": AMO_DUMP_BUCKET,
-            "key": AMO_DUMP_KEY})
+        logger.exception(
+            "Failed to download from S3",
+            extra={"bucket": AMO_DUMP_BUCKET, "key": AMO_DUMP_KEY},
+        )
 
     # If the load fails, we will have an empty whitelist, this may be problematic.
     for key, value in list(amo_dump.items()):
-        addon_files = value.get('current_version', {}).get('files', {})
+        addon_files = value.get("current_version", {}).get("files", {})
         # If any of the addon files are web_extensions compatible, it can be recommended.
         if any([f.get("is_webextension", False) for f in addon_files]):
-            final_whitelist.append(value['guid'])
+            final_whitelist.append(value["guid"])
 
     if len(final_whitelist) == 0:
         raise RuntimeError("Empty AMO whitelist detected")
@@ -127,9 +123,11 @@ def load_amo_curated_whitelist():
     """
     Return the curated whitelist of addon GUIDs
     """
-    whitelist = read_from_s3('only_guids_top_200.json',
-                             'telemetry-ml/addon_recommender/',
-                             'telemetry-parquet')
+    whitelist = read_from_s3(
+        "only_guids_top_200.json",
+        "telemetry-ml/addon_recommender/",
+        "telemetry-parquet",
+    )
     return list(whitelist)
 
 
@@ -139,4 +137,4 @@ def hash_telemetry_id(telemetry_id):
             https://phabricator.services.mozilla.com/D8311
 
     """
-    return hashlib.sha256(telemetry_id.encode('utf8')).hexdigest()
+    return hashlib.sha256(telemetry_id.encode("utf8")).hexdigest()

--- a/mozetl/tab_spinner/generate_counts.py
+++ b/mozetl/tab_spinner/generate_counts.py
@@ -16,9 +16,8 @@ def run_spinner_etl(sc):
     end_date = datetime.today().strftime("%Y%m%d")
 
     def appBuildId_filter(b):
-        return (
-            (b.startswith(start_date) or b > start_date) and
-            (b.startswith(end_date) or b < end_date)
+        return (b.startswith(start_date) or b > start_date) and (
+            b.startswith(end_date) or b < end_date
         )
 
     print("Start Date: {}, End Date: {}".format(start_date, end_date))
@@ -28,33 +27,39 @@ def run_spinner_etl(sc):
     for build_type in nightly_build_channels:
         # Bug 1341340 - if we're looking for pings from before 20161012, we need to query
         # old infra.
-        old_infra_pings = Dataset.from_source("telemetry-oldinfra") \
-            .where(docType='main') \
-            .where(submissionDate=lambda b: b < "20161201") \
-            .where(appBuildId=appBuildId_filter) \
-            .where(appUpdateChannel=build_type) \
+        old_infra_pings = (
+            Dataset.from_source("telemetry-oldinfra")
+            .where(docType="main")
+            .where(submissionDate=lambda b: b < "20161201")
+            .where(appBuildId=appBuildId_filter)
+            .where(appUpdateChannel=build_type)
             .records(sc, sample=sample_size)
+        )
 
-        new_infra_pings = Dataset.from_source("telemetry") \
-            .where(docType='main') \
-            .where(submissionDate=lambda b: (b.startswith("20161201") or b > "20161201")) \
-            .where(appBuildId=appBuildId_filter) \
-            .where(appUpdateChannel=build_type) \
+        new_infra_pings = (
+            Dataset.from_source("telemetry")
+            .where(docType="main")
+            .where(
+                submissionDate=lambda b: (b.startswith("20161201") or b > "20161201")
+            )
+            .where(appBuildId=appBuildId_filter)
+            .where(appUpdateChannel=build_type)
             .records(sc, sample=sample_size)
+        )
 
         pings = old_infra_pings.union(new_infra_pings)
         build_results[build_type] = get_short_and_long_spinners(pings)
 
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client("s3")
     for result_key, results in build_results.items():
         filename = "severities_by_build_id_%s.json" % result_key
         results_json = json.dumps(results, ensure_ascii=False)
 
-        with open(filename, 'w') as f:
+        with open(filename, "w") as f:
             f.write(results_json)
 
         s3_client.upload_file(
             filename,
-            'telemetry-public-analysis-2',
-            'spinner-severity-generator/data/{}'.format(filename)
+            "telemetry-public-analysis-2",
+            "spinner-severity-generator/data/{}".format(filename),
         )

--- a/mozetl/testpilot/containers.py
+++ b/mozetl/testpilot/containers.py
@@ -9,17 +9,34 @@ SHIELD_ADDON_ID = "@shield-study-containers"
 DATAFRAME_COLUMN_CONFIGS = [
     ("uuid", "payload/payload/uuid", None, StringType()),
     ("userContextId", "payload/payload/userContextId", None, StringType()),
-    ("clickedContainerTabCount",
-     "payload/payload/clickedContainerTabCount", None, LongType()),
+    (
+        "clickedContainerTabCount",
+        "payload/payload/clickedContainerTabCount",
+        None,
+        LongType(),
+    ),
     ("eventSource", "payload/payload/eventSource", None, StringType()),
     ("event", "payload/payload/event", None, StringType()),
-    ("hiddenContainersCount", "payload/payload/hiddenContainersCount", None, LongType()),
+    (
+        "hiddenContainersCount",
+        "payload/payload/hiddenContainersCount",
+        None,
+        LongType(),
+    ),
     ("shownContainersCount", "payload/payload/shownContainersCount", None, LongType()),
     ("totalContainersCount", "payload/payload/totalContainersCount", None, LongType()),
-    ("totalContainerTabsCount",
-     "payload/payload/totalContainerTabsCount", None, LongType()),
-    ("totalNonContainerTabsCount",
-     "payload/payload/totalNonContainerTabsCount", None, LongType()),
+    (
+        "totalContainerTabsCount",
+        "payload/payload/totalContainerTabsCount",
+        None,
+        LongType(),
+    ),
+    (
+        "totalNonContainerTabsCount",
+        "payload/payload/totalNonContainerTabsCount",
+        None,
+        LongType(),
+    ),
     ("pageRequestCount", "payload/payload/pageRequestCount", None, LongType()),
     ("test", "payload/test", None, StringType()),
 ]
@@ -29,7 +46,7 @@ def transform_testpilot_pings(sqlContext, pings):
     return convert_pings(
         sqlContext,
         pings,
-        DataFrameConfig(DATAFRAME_COLUMN_CONFIGS, include_testpilot_pings)
+        DataFrameConfig(DATAFRAME_COLUMN_CONFIGS, include_testpilot_pings),
     )
 
 
@@ -37,26 +54,25 @@ def transform_shield_pings(sqlContext, pings):
     return convert_pings(
         sqlContext,
         pings,
-        DataFrameConfig(DATAFRAME_COLUMN_CONFIGS, include_testpilot_and_shield_pings)
+        DataFrameConfig(DATAFRAME_COLUMN_CONFIGS, include_testpilot_and_shield_pings),
     )
 
 
 def include_testpilot_pings(ping):
-    return ping['payload/test'] == TESTPILOT_ADDON_ID
+    return ping["payload/test"] == TESTPILOT_ADDON_ID
 
 
 def include_testpilot_and_shield_pings(ping):
-    return ping['payload/test'] in [TESTPILOT_ADDON_ID, SHIELD_ADDON_ID]
+    return ping["payload/test"] in [TESTPILOT_ADDON_ID, SHIELD_ADDON_ID]
 
 
 testpilot_etl_job = testpilot_etl_boilerplate(
     transform_testpilot_pings,
-    's3n://telemetry-parquet/harter/containers_testpilottest/v2'
+    "s3n://telemetry-parquet/harter/containers_testpilottest/v2",
 )
 
 shield_etl_job = testpilot_etl_boilerplate(
-    transform_shield_pings,
-    's3n://telemetry-parquet/harter/containers_shield/v1'
+    transform_shield_pings, "s3n://telemetry-parquet/harter/containers_shield/v1"
 )
 
 

--- a/mozetl/testpilot/pulse.py
+++ b/mozetl/testpilot/pulse.py
@@ -1,7 +1,15 @@
 import dateutil.parser
-from pyspark.sql.types import (LongType, DoubleType, BooleanType, StringType,
-                               TimestampType, ArrayType, MapType, StructType,
-                               StructField)
+from pyspark.sql.types import (
+    LongType,
+    DoubleType,
+    BooleanType,
+    StringType,
+    TimestampType,
+    ArrayType,
+    MapType,
+    StructType,
+    StructField,
+)
 from pyspark.sql import Row
 
 from ..basic import DataFrameConfig, convert_pings
@@ -17,10 +25,10 @@ class Request(object):
     float_type = (_option_or_none(float), DoubleType())
 
     field_types = {
-        'num': int_type,
-        'cached': float_type,
-        'cdn': float_type,
-        'time': int_type,
+        "num": int_type,
+        "cached": float_type,
+        "cdn": float_type,
+        "time": int_type,
     }
 
     # python3 work-around to keep field_types in scope since class variables
@@ -28,7 +36,9 @@ class Request(object):
     _keys = sorted(field_types.keys())
     _dtypes = map(field_types.get, _keys)
 
-    StructType = StructType([StructField(x[0], x[1][1], True) for x in zip(_keys, _dtypes)])
+    StructType = StructType(
+        [StructField(x[0], x[1][1], True) for x in zip(_keys, _dtypes)]
+    )
 
     def __init__(self, request_dict):
         args = {
@@ -50,48 +60,95 @@ def transform_pings(sqlContext, pings):
     return convert_pings(
         sqlContext,
         pings,
-        DataFrameConfig([
-            ("method", "payload/payload/method", None, StringType()),
-            ("id", "payload/payload/id", None, StringType()),
-            ("type", "payload/payload/type", None, StringType()),
-            ("object", "payload/payload/object", None, StringType()),
-            ("category", "payload/payload/category", None, StringType()),
-            ("variant", "payload/payload/variant", None, StringType()),
-            ("details", "payload/payload/details", None, StringType()),
-            ("sentiment", "payload/payload/sentiment", None, LongType()),
-            ("reason", "payload/payload/reason", None, StringType()),
-            ("adBlocker", "payload/payload/adBlocker", None, BooleanType()),
-            ("addons", "payload/payload/addons", None, ArrayType(StringType())),
-            ("channel", "payload/payload/channel", None, StringType()),
-            ("hostname", "payload/payload/hostname", None, StringType()),
-            ("language", "payload/payload/language", None, StringType()),
-            ("openTabs", "payload/payload/openTabs", None, LongType()),
-            ("openWindows", "payload/payload/openWindows", None, LongType()),
-            ("platform", "payload/payload/platform", None, StringType()),
-            ("protocol", "payload/payload/protocol", None, StringType()),
-            ("telemetryId", "payload/payload/telemetryId", None, StringType()),
-            ("timerContentLoaded", "payload/payload/timerContentLoaded", None, LongType()),
-            ("timerFirstInteraction", "payload/payload/timerFirstInteraction", None, LongType()),
-            ("timerFirstPaint", "payload/payload/timerFirstPaint", None, LongType()),
-            ("timerWindowLoad", "payload/payload/timerWindowLoad", None, LongType()),
-            ("inner_timestamp", "payload/payload/timestamp", None, LongType()),
-            ("fx_version", "payload/payload/fx_version", None, StringType()),
-            ("creation_date", "creationDate", dateutil.parser.parse, TimestampType()),
-            ("test", "payload/test", None, StringType()),
-            ("variants", "payload/variants", None, StringType()),
-            ("timestamp", "payload/timestamp", None, LongType()),
-            ("version", "payload/version", None, StringType()),
-            ("requests", "payload/payload/requests", _requests_to_rows, RequestsType),
-            ("disconnectRequests", "payload/payload/disconnectRequests", None, LongType()),
-            ("consoleErrors", "payload/payload/consoleErrors", None, LongType()),
-            ("e10sStatus", "payload/payload/e10sStatus", None, LongType()),
-            ("e10sProcessCount", "payload/payload/e10sProcessCount", None, LongType()),
-            ("trackingProtection", "payload/payload/trackingProtection", None, BooleanType())
-        ], lambda ping: ping['payload/test'] == 'pulse@mozilla.com')
+        DataFrameConfig(
+            [
+                ("method", "payload/payload/method", None, StringType()),
+                ("id", "payload/payload/id", None, StringType()),
+                ("type", "payload/payload/type", None, StringType()),
+                ("object", "payload/payload/object", None, StringType()),
+                ("category", "payload/payload/category", None, StringType()),
+                ("variant", "payload/payload/variant", None, StringType()),
+                ("details", "payload/payload/details", None, StringType()),
+                ("sentiment", "payload/payload/sentiment", None, LongType()),
+                ("reason", "payload/payload/reason", None, StringType()),
+                ("adBlocker", "payload/payload/adBlocker", None, BooleanType()),
+                ("addons", "payload/payload/addons", None, ArrayType(StringType())),
+                ("channel", "payload/payload/channel", None, StringType()),
+                ("hostname", "payload/payload/hostname", None, StringType()),
+                ("language", "payload/payload/language", None, StringType()),
+                ("openTabs", "payload/payload/openTabs", None, LongType()),
+                ("openWindows", "payload/payload/openWindows", None, LongType()),
+                ("platform", "payload/payload/platform", None, StringType()),
+                ("protocol", "payload/payload/protocol", None, StringType()),
+                ("telemetryId", "payload/payload/telemetryId", None, StringType()),
+                (
+                    "timerContentLoaded",
+                    "payload/payload/timerContentLoaded",
+                    None,
+                    LongType(),
+                ),
+                (
+                    "timerFirstInteraction",
+                    "payload/payload/timerFirstInteraction",
+                    None,
+                    LongType(),
+                ),
+                (
+                    "timerFirstPaint",
+                    "payload/payload/timerFirstPaint",
+                    None,
+                    LongType(),
+                ),
+                (
+                    "timerWindowLoad",
+                    "payload/payload/timerWindowLoad",
+                    None,
+                    LongType(),
+                ),
+                ("inner_timestamp", "payload/payload/timestamp", None, LongType()),
+                ("fx_version", "payload/payload/fx_version", None, StringType()),
+                (
+                    "creation_date",
+                    "creationDate",
+                    dateutil.parser.parse,
+                    TimestampType(),
+                ),
+                ("test", "payload/test", None, StringType()),
+                ("variants", "payload/variants", None, StringType()),
+                ("timestamp", "payload/timestamp", None, LongType()),
+                ("version", "payload/version", None, StringType()),
+                (
+                    "requests",
+                    "payload/payload/requests",
+                    _requests_to_rows,
+                    RequestsType,
+                ),
+                (
+                    "disconnectRequests",
+                    "payload/payload/disconnectRequests",
+                    None,
+                    LongType(),
+                ),
+                ("consoleErrors", "payload/payload/consoleErrors", None, LongType()),
+                ("e10sStatus", "payload/payload/e10sStatus", None, LongType()),
+                (
+                    "e10sProcessCount",
+                    "payload/payload/e10sProcessCount",
+                    None,
+                    LongType(),
+                ),
+                (
+                    "trackingProtection",
+                    "payload/payload/trackingProtection",
+                    None,
+                    BooleanType(),
+                ),
+            ],
+            lambda ping: ping["payload/test"] == "pulse@mozilla.com",
+        ),
     )
 
 
 etl_job = testpilot_etl_boilerplate(
-    transform_pings,
-    's3://telemetry-parquet/testpilot/txp_pulse/v1'
+    transform_pings, "s3://telemetry-parquet/testpilot/txp_pulse/v1"
 )

--- a/mozetl/testpilot/txp_mau_dau.py
+++ b/mozetl/testpilot/txp_mau_dau.py
@@ -5,8 +5,8 @@ import requests
 from pyspark.sql.functions import col, countDistinct, lit
 from pyspark.sql import SparkSession
 
-SCHEMA_VERSION = 'v3'
-TESTPILOT_EXPERIMENT_ENDPOINT = 'https://testpilot.firefox.com/api/experiments.json'
+SCHEMA_VERSION = "v3"
+TESTPILOT_EXPERIMENT_ENDPOINT = "https://testpilot.firefox.com/api/experiments.json"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -28,63 +28,84 @@ def get_experiments():
     # If we end up having a lot of retired tests and the job gets slow we could filter by dates
     r = requests.get(TESTPILOT_EXPERIMENT_ENDPOINT)
     r.raise_for_status()
-    return [el['addon_id'] for el in r.json()['results'] if 'addon_id' in el]
+    return [el["addon_id"] for el in r.json()["results"] if "addon_id" in el]
 
 
 def get_active_users(dataset, addon_ids):
-    tp_installed = dataset \
-        .filter(dataset.addon_id == "@testpilot-addon") \
-        .select("client_id") \
+    tp_installed = (
+        dataset.filter(dataset.addon_id == "@testpilot-addon")
+        .select("client_id")
         .distinct()
+    )
 
-    test_installed = dataset \
-        .where(col("addon_id").isin(addon_ids)) \
-        .select("client_id", "addon_id", "submission_date_s3") \
+    test_installed = (
+        dataset.where(col("addon_id").isin(addon_ids))
+        .select("client_id", "addon_id", "submission_date_s3")
         .distinct()
+    )
 
-    return tp_installed \
-        .join(test_installed, test_installed.client_id == tp_installed.client_id) \
-        .select(test_installed.client_id.alias("client_id"), "addon_id", "submission_date_s3")
+    return tp_installed.join(
+        test_installed, test_installed.client_id == tp_installed.client_id
+    ).select(
+        test_installed.client_id.alias("client_id"), "addon_id", "submission_date_s3"
+    )
 
 
 def get_mau_dau(df, run_date_string):
-    all_dau = df.filter(df.submission_date_s3 == run_date_string) \
-        .agg(countDistinct(df.client_id).alias("dau")) \
+    all_dau = (
+        df.filter(df.submission_date_s3 == run_date_string)
+        .agg(countDistinct(df.client_id).alias("dau"))
         .select(lit("testpilot").alias("addon_id"), "dau")
-    dau = df.filter(df.submission_date_s3 == run_date_string) \
-        .groupBy("addon_id") \
-        .agg(countDistinct("client_id").alias("dau")) \
+    )
+    dau = (
+        df.filter(df.submission_date_s3 == run_date_string)
+        .groupBy("addon_id")
+        .agg(countDistinct("client_id").alias("dau"))
         .union(all_dau)
-    all_mau = df.agg(countDistinct(df.client_id).alias("mau")) \
-        .select(lit("testpilot").alias("addon_id"), "mau")
-    mau = df.groupBy(df.addon_id) \
-        .agg(countDistinct(df.client_id).alias("mau")) \
+    )
+    all_mau = df.agg(countDistinct(df.client_id).alias("mau")).select(
+        lit("testpilot").alias("addon_id"), "mau"
+    )
+    mau = (
+        df.groupBy(df.addon_id)
+        .agg(countDistinct(df.client_id).alias("mau"))
         .union(all_mau)
-    return dau.join(mau, dau.addon_id == mau.addon_id) \
-        .select(mau.addon_id.alias("test"), dau.dau.alias("dau"), mau.mau.alias("mau"))
+    )
+    return dau.join(mau, dau.addon_id == mau.addon_id).select(
+        mau.addon_id.alias("test"), dau.dau.alias("dau"), mau.mau.alias("mau")
+    )
 
 
 def get_spark_session(app_name):
     # TODO: move this into a general library with more default configs?
-    return SparkSession.builder \
-            .appName(app_name) \
-            .getOrCreate()
+    return SparkSession.builder.appName(app_name).getOrCreate()
 
 
-def main(bucket, prefix, input_bucket, input_prefix, run_date_string,
-         sample_id=None, spark_session=None):
+def main(
+    bucket,
+    prefix,
+    input_bucket,
+    input_prefix,
+    run_date_string,
+    sample_id=None,
+    spark_session=None,
+):
     run_date_dt = parse(run_date_string)
     input_location = "s3://{}/{}".format(input_bucket, input_prefix)
     addon_ids = get_experiments()
 
-    logger.info("Calculating mau/dau for date {} and tests {}".format(run_date_dt, addon_ids))
+    logger.info(
+        "Calculating mau/dau for date {} and tests {}".format(run_date_dt, addon_ids)
+    )
 
     if spark_session is None:
         spark_session = get_spark_session("txp_mau_dau")
     try:
-        dataset = spark_session.read.parquet(input_location) \
-            .filter(col("submission_date_s3") >= fmt(run_date_dt - timedelta(28))) \
+        dataset = (
+            spark_session.read.parquet(input_location)
+            .filter(col("submission_date_s3") >= fmt(run_date_dt - timedelta(28)))
             .filter(col("submission_date_s3") <= run_date_string)
+        )
         if sample_id:
             dataset = dataset.filter(col("sample_id") == sample_id)
         active_users = get_active_users(dataset, addon_ids)
@@ -96,7 +117,9 @@ def main(bucket, prefix, input_bucket, input_prefix, run_date_string,
         output_location = "s3n://{}/{}/{}/submission_date_s3={}".format(
             bucket, prefix, SCHEMA_VERSION, run_date_string
         )
-        mau_dau.repartition(1).write.format("parquet").mode("overwrite").save(output_location)
+        mau_dau.repartition(1).write.format("parquet").mode("overwrite").save(
+            output_location
+        )
         logger.info("Successfully wrote txp mau dau to {}".format(output_location))
     finally:
         if spark_session is None:
@@ -104,11 +127,11 @@ def main(bucket, prefix, input_bucket, input_prefix, run_date_string,
 
 
 if __name__ == "__main__":
-    bucket = environ['bucket']
-    prefix = environ['prefix']
-    input_bucket = environ['inbucket']
-    input_prefix = environ['inprefix']
-    run_date = environ.get('date', fmt(date.today() - timedelta(1)))
-    sample_id = environ.get('sampleid', None)
+    bucket = environ["bucket"]
+    prefix = environ["prefix"]
+    input_bucket = environ["inbucket"]
+    input_prefix = environ["inprefix"]
+    run_date = environ.get("date", fmt(date.today() - timedelta(1)))
+    sample_id = environ.get("sampleid", None)
 
     main(bucket, prefix, input_bucket, input_prefix, run_date, sample_id=sample_id)

--- a/mozetl/testpilot/utils.py
+++ b/mozetl/testpilot/utils.py
@@ -7,20 +7,22 @@ def testpilot_etl_boilerplate(transform_func, s3_path):
         if submission_date is None:
             submission_date = (date.today() - timedelta(1)).strftime("%Y%m%d")
 
-        pings = Dataset.from_source(
-            "telemetry"
-        ).where(
-            docType="testpilottest",
-            submissionDate=submission_date,
-            appName="Firefox",
-        ).records(sc)
+        pings = (
+            Dataset.from_source("telemetry")
+            .where(
+                docType="testpilottest",
+                submissionDate=submission_date,
+                appName="Firefox",
+            )
+            .records(sc)
+        )
 
         transformed_pings = transform_func(sqlContext, pings)
 
         if save:
             # path = 's3://telemetry-parquet/testpilot/txp_pulse/v1/submission_date={}'
-            path = s3_path + '/submission_date={}'.format(submission_date)
-            transformed_pings.repartition(1).write.mode('overwrite').parquet(path)
+            path = s3_path + "/submission_date={}".format(submission_date)
+            transformed_pings.repartition(1).write.mode("overwrite").parquet(path)
 
         return transformed_pings
 

--- a/mozetl/topline/schema.py
+++ b/mozetl/topline/schema.py
@@ -25,5 +25,5 @@ def schema_from_json(path):
 
 
 # Generate module level schemas
-historical_schema = schema_from_json('historical_schema.json')
-topline_schema = schema_from_json('topline_schema.json')
+historical_schema = schema_from_json("historical_schema.json")
+topline_schema = schema_from_json("topline_schema.json")

--- a/mozetl/topline/topline_summary.py
+++ b/mozetl/topline/topline_summary.py
@@ -14,6 +14,7 @@ from functools import reduce
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# fmt: off
 countries = {
     "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR", "AS",
     "AT", "AU", "AW", "AX", "AZ", "BA", "BB", "BD", "BE", "BF", "BG",
@@ -39,6 +40,7 @@ countries = {
     "UM", "US", "UY", "UZ", "VA", "VC", "VE", "VG", "VI", "VN", "VU",
     "WF", "WS", "YE", "YT", "ZA", "ZM", "ZW"
 }
+# fmt: on
 
 seconds_per_hour = 60 * 60
 seconds_per_day = seconds_per_hour * 24

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,7 @@ import json
 @pytest.fixture(scope="session")
 def spark():
     spark = (
-        SparkSession
-        .builder
-        .master("local")
-        .appName("python_mozetl_test")
-        .getOrCreate()
+        SparkSession.builder.master("local").appName("python_mozetl_test").getOrCreate()
     )
     # Set server timezone at UTC+0
     spark.conf.set("spark.sql.session.timeZone", "UTC")
@@ -26,8 +22,10 @@ def spark_context(spark):
 @pytest.fixture(autouse=True)
 def no_spark_stop(monkeypatch):
     """ Disable stopping the shared spark session during tests """
+
     def nop(*args, **kwargs):
         print("Disabled spark.stop for testing")
+
     monkeypatch.setattr("pyspark.sql.SparkSession.stop", nop)
 
 
@@ -84,8 +82,11 @@ class DataFrameFactory:
         # if no schema is provided, the schema will be inferred
         return self.spark.createDataFrame(samples, schema)
 
-    def create_dataframe_with_key(self, snippets, base, key, key_func=None, schema=None):
+    def create_dataframe_with_key(
+        self, snippets, base, key, key_func=None, schema=None
+    ):
         """Generate dataframe with autoincrementing key function"""
+
         def generate_keys():
             num = 0
             while True:

--- a/tests/engagement/conftest.py
+++ b/tests/engagement/conftest.py
@@ -11,7 +11,7 @@ def generate_main_summary_data(dataframe_factory):
     return functools.partial(
         dataframe_factory.create_dataframe,
         base=data.main_summary_sample,
-        schema=data.main_summary_schema
+        schema=data.main_summary_schema,
     )
 
 
@@ -20,21 +20,19 @@ def generate_new_profile_data(dataframe_factory):
     return functools.partial(
         dataframe_factory.create_dataframe,
         base=data.new_profile_sample,
-        schema=data.new_profile_schema
+        schema=data.new_profile_schema,
     )
 
 
 @pytest.fixture()
 def release_info():
     return {
-        "major": {
-            "52.0": "2017-03-07"
-        },
+        "major": {"52.0": "2017-03-07"},
         "minor": {
             "51.0.1": "2017-01-26",
             "52.0.1": "2017-03-17",
-            "52.0.2": "2017-03-29"
-        }
+            "52.0.2": "2017-03-29",
+        },
     }
 
 
@@ -44,10 +42,11 @@ def no_get_release_info(release_info, monkeypatch):
 
     def mock_get_release_info():
         return release_info
-    monkeypatch.setattr(release, 'get_release_info', mock_get_release_info)
+
+    monkeypatch.setattr(release, "get_release_info", mock_get_release_info)
 
     # disable fetch_json to cover all the bases
-    monkeypatch.delattr(release, 'fetch_json')
+    monkeypatch.delattr(release, "fetch_json")
 
 
 @pytest.fixture()

--- a/tests/engagement/data.py
+++ b/tests/engagement/data.py
@@ -1,8 +1,12 @@
 import arrow
 
 from pyspark.sql.types import (
-    StructField, StructType, StringType,
-    LongType, IntegerType, BooleanType
+    StructField,
+    StructType,
+    StringType,
+    LongType,
+    IntegerType,
+    BooleanType,
 )
 
 """
@@ -24,67 +28,114 @@ SECONDS_PER_DAY = 60 * 60 * 24
 
 # Generate the datasets
 # Sunday, also the first day in this collection period.
-SUBSESSION_START = arrow.get(2017, 1, 15).replace(tzinfo='utc')
+SUBSESSION_START = arrow.get(2017, 1, 15).replace(tzinfo="utc")
 WEEK_START_DS = SUBSESSION_START.format("YYYYMMDD")
 
 
-main_summary_schema = StructType([
-    StructField("app_version", StringType(), True),
-    StructField("attribution", StructType([
-        StructField("source", StringType(), True),
-        StructField("medium", StringType(), True),
-        StructField("campaign", StringType(), True),
-        StructField("content", StringType(), True)]), True),
-    StructField("channel", StringType(), True),
-    StructField("client_id", StringType(), True),
-    StructField("country", StringType(), True),
-    StructField("default_search_engine", StringType(), True),
-    StructField("distribution_id", StringType(), True),
-    StructField("locale", StringType(), True),
-    StructField("normalized_channel", StringType(), True),
-    StructField("profile_creation_date", LongType(), True),
-    StructField("submission_date_s3", StringType(), False),
-    StructField("subsession_length", LongType(), True),
-    StructField("subsession_start_date", StringType(), True),
-    StructField("sync_configured", BooleanType(), True),
-    StructField("sync_count_desktop", IntegerType(), True),
-    StructField("sync_count_mobile", IntegerType(), True),
-    StructField("timestamp", LongType(), True),
-    StructField(SPBE + "total_uri_count", IntegerType(), True),
-    StructField(SPBE + "unique_domains_count", IntegerType(), True)])
-
-
-new_profile_schema = StructType([
-    StructField("submission", StringType(), True),
-    StructField("environment", StructType([
-        StructField("profile", StructType([
-            StructField("creation_date", LongType(), True),
-        ]), True),
-        StructField("build", StructType([
-            StructField("version", StringType(), True),
-        ]), True),
-        StructField("partner", StructType([
-            StructField("distribution_id", StringType(), True),
-        ]), True),
-        StructField("settings", StructType([
-            StructField("locale", StringType(), True),
-            StructField("is_default_browser", StringType(), True),
-            StructField("default_search_engine", StringType(), True),
-            StructField("attribution", StructType([
-                StructField("source", StringType(), True),
-                StructField("medium", StringType(), True),
-                StructField("campaign", StringType(), True),
-                StructField("content", StringType(), True)]), True),
-        ]), True),
-    ]), True),
-    StructField("client_id", StringType(), True),
-    StructField("metadata", StructType([
-        StructField("geo_country", StringType(), True),
-        StructField("timestamp", LongType(), True),
+main_summary_schema = StructType(
+    [
+        StructField("app_version", StringType(), True),
+        StructField(
+            "attribution",
+            StructType(
+                [
+                    StructField("source", StringType(), True),
+                    StructField("medium", StringType(), True),
+                    StructField("campaign", StringType(), True),
+                    StructField("content", StringType(), True),
+                ]
+            ),
+            True,
+        ),
+        StructField("channel", StringType(), True),
+        StructField("client_id", StringType(), True),
+        StructField("country", StringType(), True),
+        StructField("default_search_engine", StringType(), True),
+        StructField("distribution_id", StringType(), True),
+        StructField("locale", StringType(), True),
         StructField("normalized_channel", StringType(), True),
-        StructField("creation_timestamp", LongType(), True),
-    ]), True)
-])
+        StructField("profile_creation_date", LongType(), True),
+        StructField("submission_date_s3", StringType(), False),
+        StructField("subsession_length", LongType(), True),
+        StructField("subsession_start_date", StringType(), True),
+        StructField("sync_configured", BooleanType(), True),
+        StructField("sync_count_desktop", IntegerType(), True),
+        StructField("sync_count_mobile", IntegerType(), True),
+        StructField("timestamp", LongType(), True),
+        StructField(SPBE + "total_uri_count", IntegerType(), True),
+        StructField(SPBE + "unique_domains_count", IntegerType(), True),
+    ]
+)
+
+
+new_profile_schema = StructType(
+    [
+        StructField("submission", StringType(), True),
+        StructField(
+            "environment",
+            StructType(
+                [
+                    StructField(
+                        "profile",
+                        StructType([StructField("creation_date", LongType(), True)]),
+                        True,
+                    ),
+                    StructField(
+                        "build",
+                        StructType([StructField("version", StringType(), True)]),
+                        True,
+                    ),
+                    StructField(
+                        "partner",
+                        StructType(
+                            [StructField("distribution_id", StringType(), True)]
+                        ),
+                        True,
+                    ),
+                    StructField(
+                        "settings",
+                        StructType(
+                            [
+                                StructField("locale", StringType(), True),
+                                StructField("is_default_browser", StringType(), True),
+                                StructField(
+                                    "default_search_engine", StringType(), True
+                                ),
+                                StructField(
+                                    "attribution",
+                                    StructType(
+                                        [
+                                            StructField("source", StringType(), True),
+                                            StructField("medium", StringType(), True),
+                                            StructField("campaign", StringType(), True),
+                                            StructField("content", StringType(), True),
+                                        ]
+                                    ),
+                                    True,
+                                ),
+                            ]
+                        ),
+                        True,
+                    ),
+                ]
+            ),
+            True,
+        ),
+        StructField("client_id", StringType(), True),
+        StructField(
+            "metadata",
+            StructType(
+                [
+                    StructField("geo_country", StringType(), True),
+                    StructField("timestamp", LongType(), True),
+                    StructField("normalized_channel", StringType(), True),
+                    StructField("creation_timestamp", LongType(), True),
+                ]
+            ),
+            True,
+        ),
+    ]
+)
 
 main_summary_sample = {
     "app_version": "57.0.0",
@@ -92,7 +143,7 @@ main_summary_sample = {
         "source": "source-value",
         "medium": "medium-value",
         "campaign": "campaign-value",
-        "content": "content-value"
+        "content": "content-value",
     },
     "channel": "release",
     "client_id": "client-id",
@@ -110,22 +161,16 @@ main_summary_sample = {
     "sync_count_mobile": 1,
     "timestamp": SUBSESSION_START.timestamp * 10 ** 9,  # nanoseconds
     SPBE + "total_uri_count": 20,
-    SPBE + "unique_domains_count": 3
+    SPBE + "unique_domains_count": 3,
 }
 
 
 new_profile_sample = {
     "submission": SUBSESSION_START.format("YYYYMMDD"),
     "environment": {
-        "profile": {
-            "creation_date": int(SUBSESSION_START.timestamp / SECONDS_PER_DAY)
-        },
-        "build": {
-            "version": "57.0.0",
-        },
-        "partner": {
-            "distribution_id": "mozilla57"
-        },
+        "profile": {"creation_date": int(SUBSESSION_START.timestamp / SECONDS_PER_DAY)},
+        "build": {"version": "57.0.0"},
+        "partner": {"distribution_id": "mozilla57"},
         "settings": {
             "locale": "en-US",
             "is_default_browser": True,
@@ -134,23 +179,23 @@ new_profile_sample = {
                 "source": "source-value",
                 "medium": "medium-value",
                 "campaign": "campaign-value",
-                "content": "content-value"
+                "content": "content-value",
             },
-        }
+        },
     },
     "client_id": "new-profile",
     "metadata": {
         "geo_country": "US",
         "timestamp": (SUBSESSION_START.timestamp + 3600) * 10 ** 9,
         "normalized_channel": "release",
-        "creation_timestamp": SUBSESSION_START.timestamp * 10 ** 9
-    }
+        "creation_timestamp": SUBSESSION_START.timestamp * 10 ** 9,
+    },
 }
 
 
 def format_ssd(arrow_date):
     """Format an arrow date into the submission_start_date"""
-    return str(arrow_date.replace(tzinfo='utc'))
+    return str(arrow_date.replace(tzinfo="utc"))
 
 
 def format_pcd(arrow_date):
@@ -174,7 +219,7 @@ def generate_dates(subsession_date, submission_offset=0, creation_offset=0):
         "subsession_start_date": format_ssd(subsession_date),
         "submission_date_s3": submission_date.format("YYYYMMDD"),
         "profile_creation_date": format_pcd(profile_creation_date),
-        "timestamp": submission_date.timestamp * 10 ** 9
+        "timestamp": submission_date.timestamp * 10 ** 9,
     }
 
     return date_snippet

--- a/tests/engagement/test_churn.py
+++ b/tests/engagement/test_churn.py
@@ -14,7 +14,8 @@ SPBE = "scalar_parent_browser_engagement_"
 @pytest.fixture
 def single_profile_df(generate_main_summary_data):
     recent_ping = data.generate_dates(
-        SUBSESSION_START.replace(days=3), creation_offset=3)
+        SUBSESSION_START.replace(days=3), creation_offset=3
+    )
 
     # create a duplicate ping for this user, earlier than the previous
     old_ping = data.generate_dates(SUBSESSION_START)
@@ -38,28 +39,34 @@ def multi_profile_df(generate_main_summary_data):
     seconds_in_hour = 60 * 60
 
     user_0 = cohort_0.copy()
-    user_0.update({
-        "client_id": "user_0",
-        "country": "US",
-        "normalized_channel": "release",
-        "subsession_length": seconds_in_hour * 2
-    })
+    user_0.update(
+        {
+            "client_id": "user_0",
+            "country": "US",
+            "normalized_channel": "release",
+            "subsession_length": seconds_in_hour * 2,
+        }
+    )
 
     user_1 = cohort_1.copy()
-    user_1.update({
-        "client_id": "user_1",
-        "country": "US",
-        "normalized_channel": "release",
-        "subsession_length": seconds_in_hour * 2
-    })
+    user_1.update(
+        {
+            "client_id": "user_1",
+            "country": "US",
+            "normalized_channel": "release",
+            "subsession_length": seconds_in_hour * 2,
+        }
+    )
 
     user_2 = cohort_2.copy()
-    user_2.update({
-        "client_id": "user_2",
-        "country": "CA",
-        "normalized_channel": "beta",
-        "subsession_length": seconds_in_hour
-    })
+    user_2.update(
+        {
+            "client_id": "user_2",
+            "country": "CA",
+            "normalized_channel": "beta",
+            "subsession_length": seconds_in_hour,
+        }
+    )
 
     snippets = [user_0, user_1, user_2]
     return generate_main_summary_data(snippets)
@@ -69,16 +76,19 @@ def test_extract_main_summary(spark, generate_main_summary_data):
     df = job.extract(
         generate_main_summary_data(None),
         spark.createDataFrame([], data.new_profile_schema),
-        WEEK_START_DS, 1, 0, False
+        WEEK_START_DS,
+        1,
+        0,
+        False,
     )
     assert df.count() == 1
 
 
 def test_clean_new_profile_sample_id(generate_new_profile_data):
     df = job.clean_new_profile(
-        generate_new_profile_data([{
-            "client_id": "c4582ba1-79fc-1f47-ae2a-671118dccd8b"
-        }])
+        generate_new_profile_data(
+            [{"client_id": "c4582ba1-79fc-1f47-ae2a-671118dccd8b"}]
+        )
     )
     expect = "4"
 
@@ -89,15 +99,20 @@ def test_extract_new_profile(spark, generate_new_profile_data):
     df = job.extract(
         spark.createDataFrame([], data.main_summary_schema),
         generate_new_profile_data([dict()]),
-        WEEK_START_DS, 1, 0, False
+        WEEK_START_DS,
+        1,
+        0,
+        False,
     )
     assert df.count() == 1
 
     row = df.first()
-    assert row['subsession_length'] is None
-    assert (row['profile_creation_date'] ==
-            data.new_profile_sample['environment']['profile']['creation_date'])
-    assert row['scalar_parent_browser_engagement_total_uri_count'] is None
+    assert row["subsession_length"] is None
+    assert (
+        row["profile_creation_date"]
+        == data.new_profile_sample["environment"]["profile"]["creation_date"]
+    )
+    assert row["scalar_parent_browser_engagement_total_uri_count"] is None
 
 
 def test_ignored_submissions_outside_of_period(spark, generate_main_summary_data):
@@ -106,42 +121,38 @@ def test_ignored_submissions_outside_of_period(spark, generate_main_summary_data
     # are used for computation. Generate pings for this case.
     late_submission = data.generate_dates(SUBSESSION_START, submission_offset=18)
     early_subsession = data.generate_dates(SUBSESSION_START.replace(days=-7))
-    late_submissions_df = generate_main_summary_data([late_submission, early_subsession])
+    late_submissions_df = generate_main_summary_data(
+        [late_submission, early_subsession]
+    )
 
     df = job.extract(
         late_submissions_df,
         spark.createDataFrame([], data.new_profile_schema),
-        WEEK_START_DS, 7, 10, False
+        WEEK_START_DS,
+        7,
+        10,
+        False,
     )
     assert df.count() == 0
 
 
-def test_multiple_sources_transform(effective_version,
-                                    generate_main_summary_data,
-                                    generate_new_profile_data):
-    main_summary = generate_main_summary_data([
-        {"client_id": "1"},
-        {"client_id": "3"},
-    ])
-    new_profile = generate_new_profile_data([
-        {"client_id": "1"},
-        {"client_id": "2"},
-        {"client_id": "2"},
-    ])
+def test_multiple_sources_transform(
+    effective_version, generate_main_summary_data, generate_new_profile_data
+):
+    main_summary = generate_main_summary_data([{"client_id": "1"}, {"client_id": "3"}])
+    new_profile = generate_new_profile_data(
+        [{"client_id": "1"}, {"client_id": "2"}, {"client_id": "2"}]
+    )
     sources = job.extract(main_summary, new_profile, WEEK_START_DS, 1, 0, False)
     df = job.transform(sources, effective_version, WEEK_START_DS)
 
     # There are two different channels
     assert df.count() == 2
 
-    assert (
-        df.select(F.sum("n_profiles").alias("n_profiles"))
-        .first().n_profiles
-    ) == 3
+    assert (df.select(F.sum("n_profiles").alias("n_profiles")).first().n_profiles) == 3
 
 
-def test_latest_submission_from_client_exists(single_profile_df,
-                                              effective_version):
+def test_latest_submission_from_client_exists(single_profile_df, effective_version):
     df = job.transform(single_profile_df, effective_version, WEEK_START_DS)
     assert df.count() == 1
 
@@ -166,7 +177,7 @@ def test_current_cohort_week_is_zero(single_profile_df, effective_version):
 
 def test_multiple_cohort_weeks_exist(multi_profile_df, effective_version):
     df = job.transform(multi_profile_df, effective_version, WEEK_START_DS)
-    rows = df.select('current_week').collect()
+    rows = df.select("current_week").collect()
 
     actual = set([row.current_week for row in rows])
     expect = set([0, 1, 2])
@@ -176,7 +187,7 @@ def test_multiple_cohort_weeks_exist(multi_profile_df, effective_version):
 
 def test_cohort_by_channel_count(multi_profile_df, effective_version):
     df = job.transform(multi_profile_df, effective_version, WEEK_START_DS)
-    rows = df.where(df.channel == 'release-cck-mozilla42').collect()
+    rows = df.where(df.channel == "release-cck-mozilla42").collect()
 
     assert len(rows) == 2
 
@@ -184,11 +195,12 @@ def test_cohort_by_channel_count(multi_profile_df, effective_version):
 def test_cohort_by_channel_aggregates(multi_profile_df, effective_version):
     df = job.transform(multi_profile_df, effective_version, WEEK_START_DS)
     rows = (
-        df
-        .groupBy(df.channel)
-        .agg(F.sum('n_profiles').alias('n_profiles'),
-             F.sum('usage_hours').alias('usage_hours'))
-        .where(df.channel == 'release-cck-mozilla42')
+        df.groupBy(df.channel)
+        .agg(
+            F.sum("n_profiles").alias("n_profiles"),
+            F.sum("usage_hours").alias("usage_hours"),
+        )
+        .where(df.channel == "release-cck-mozilla42")
         .collect()
     )
     assert rows[0].n_profiles == 2
@@ -199,9 +211,7 @@ def test_cohort_by_channel_aggregates(multi_profile_df, effective_version):
 def test_transform(generate_main_summary_data, effective_version):
     def _test_transform(snippets, week_start=WEEK_START_DS):
         return job.transform(
-            generate_main_summary_data(snippets),
-            effective_version,
-            week_start
+            generate_main_summary_data(snippets), effective_version, week_start
         )
 
     return _test_transform
@@ -211,98 +221,79 @@ def test_transform_adheres_to_schema(test_transform):
     df = test_transform(None)
 
     def column_types(schema):
-        return {
-            col.name: col.dataType.typeName()
-            for col in schema.fields
-        }
+        return {col.name: col.dataType.typeName() for col in schema.fields}
 
     assert column_types(df.schema) == column_types(schema.churn_schema)
 
 
 def test_nulled_stub_attribution(test_transform):
-    df = test_transform([
-        {
-            'client_id': 'partial',
-            'attribution': {
-                'content': 'content'
-            }
-        },
-        {
-            'client_id': 'nulled',
-            'attribution': None,
-        }
-    ])
-
-    rows = (
-        df
-        .select('content', 'medium')
-        .distinct()
-        .collect()
+    df = test_transform(
+        [
+            {"client_id": "partial", "attribution": {"content": "content"}},
+            {"client_id": "nulled", "attribution": None},
+        ]
     )
+
+    rows = df.select("content", "medium").distinct().collect()
     actual = set([r.content for r in rows])
-    expect = set(['content', 'unknown'])
+    expect = set(["content", "unknown"])
     assert actual == expect
 
     actual = set([r.medium for r in rows])
-    expect = set(['unknown'])
+    expect = set(["unknown"])
     assert actual == expect
 
 
 def test_simple_string_dimensions(test_transform):
-    df = test_transform([
-        {
-            'distribution_id': None,
-            'default_search_engine': None,
-            'locale': None
-        }
-    ])
+    df = test_transform(
+        [{"distribution_id": None, "default_search_engine": None, "locale": None}]
+    )
     rows = df.collect()
 
-    assert rows[0].distribution_id == 'unknown'
-    assert rows[0].default_search_engine == 'unknown'
-    assert rows[0].locale == 'unknown'
+    assert rows[0].distribution_id == "unknown"
+    assert rows[0].default_search_engine == "unknown"
+    assert rows[0].locale == "unknown"
 
 
 def test_empty_session_length(test_transform):
-    df = test_transform([
-        {'client_id': '1', 'subsession_length': None},
-        {'client_id': '2', 'subsession_length': 3600},
-        {'client_id': '3', 'subsession_length': None},
-        {'client_id': '3', 'subsession_length': 3600},
-    ])
+    df = test_transform(
+        [
+            {"client_id": "1", "subsession_length": None},
+            {"client_id": "2", "subsession_length": 3600},
+            {"client_id": "3", "subsession_length": None},
+            {"client_id": "3", "subsession_length": 3600},
+        ]
+    )
     row = df.first()
 
     assert row.usage_hours == 2
 
 
 def test_empty_total_uri_count(test_transform):
-    df = test_transform([
-        {SPBE + 'total_uri_count': None}
-    ])
+    df = test_transform([{SPBE + "total_uri_count": None}])
     rows = df.collect()
 
     assert rows[0].total_uri_count == 0
 
 
 def test_total_uri_count_per_client(test_transform):
-    df = test_transform([
-        {SPBE + 'total_uri_count': 1},
-        {SPBE + 'total_uri_count': 2}
-    ])
+    df = test_transform([{SPBE + "total_uri_count": 1}, {SPBE + "total_uri_count": 2}])
     rows = df.collect()
 
     assert rows[0].total_uri_count == 3
 
 
 def test_average_unique_domains_count(test_transform):
-    df = test_transform([
-        # averages to 4
-        {'client_id': '1', SPBE + 'unique_domains_count': 6},
-        {'client_id': '1', SPBE + 'unique_domains_count': 2},
-        # averages to 8
-        {'client_id': '2', SPBE + 'unique_domains_count': 12},
-        {'client_id': '2', SPBE + 'unique_domains_count': 4}
-    ])
+    df = test_transform(
+        [
+            # averages to 4
+            {"client_id": "1", SPBE + "unique_domains_count": 6},
+            {"client_id": "1", SPBE + "unique_domains_count": 2},
+            # averages to 8
+            {"client_id": "2", SPBE + "unique_domains_count": 12},
+            {"client_id": "2", SPBE + "unique_domains_count": 4},
+        ]
+    )
     rows = df.collect()
 
     # (4 + 8) / 2 == 6
@@ -310,19 +301,20 @@ def test_average_unique_domains_count(test_transform):
 
 
 def test_top_countries(test_transform):
-    df = test_transform([
-        {"client_id": "1", "country": "US"},
-        {"client_id": "2", "country": "HK"},
-        {"client_id": "3", "country": "MR"},
-        {"client_id": "4", "country": "??"},
-        {"client_id": "5", "country": "Random"},
-        {"client_id": "6", "country": "None"},
-    ])
+    df = test_transform(
+        [
+            {"client_id": "1", "country": "US"},
+            {"client_id": "2", "country": "HK"},
+            {"client_id": "3", "country": "MR"},
+            {"client_id": "4", "country": "??"},
+            {"client_id": "5", "country": "Random"},
+            {"client_id": "6", "country": "None"},
+        ]
+    )
 
     def country_count(geo):
         return (
-            df
-            .where(F.col("geo") == geo)
+            df.where(F.col("geo") == geo)
             .groupBy("geo")
             .agg(F.sum("n_profiles").alias("n_profiles"))
             .first()
@@ -339,12 +331,7 @@ def test_sync_usage(test_transform):
     # the transformation, and then run the test function on each
     # case afterwards.
     def test_case(df, uid=None, expect=None):
-        actual = (
-            df
-            .where(F.col("distribution_id") == uid)
-            .first()
-            .sync_usage
-        )
+        actual = df.where(F.col("distribution_id") == uid).first().sync_usage
         assert actual == expect, "failed on {}".format(uid)
 
     def case(name, expect, desktop, mobile, configured):
@@ -359,26 +346,30 @@ def test_sync_usage(test_transform):
         test_func = functools.partial(test_case, uid=uid, expect=expect)
         return snippet, test_func
 
-    snippets, test_func = list(zip(*[
-        # unobservable
-        case("1", "unknown", None, None, None),
-        # no reported devices, and not configured
-        case("2", "no", 0, 0, False),
-        # no reported devices, but sync is configured
-        case("3", "single", 0, 0, True),
-        # has a single device, and is configured
-        case("4", "single", 1, 0, True),
-        # a single device is reported, but everything else is unobserved
-        case("5", "single", 1, None, None),
-        # sync is somehow disabled, but reporting a single device
-        case("6", "single", None, 1, False),
-        # same as case #5, but with multiple devices
-        case("7", "multiple", 2, None, None),
-        # multiple desktop devices, but sync is not configured
-        case("8", "multiple", 0, 2, False),
-        # a mobile and desktop device, but not configured
-        case("9", "multiple", 1, 1, False),
-    ]))
+    snippets, test_func = list(
+        zip(
+            *[
+                # unobservable
+                case("1", "unknown", None, None, None),
+                # no reported devices, and not configured
+                case("2", "no", 0, 0, False),
+                # no reported devices, but sync is configured
+                case("3", "single", 0, 0, True),
+                # has a single device, and is configured
+                case("4", "single", 1, 0, True),
+                # a single device is reported, but everything else is unobserved
+                case("5", "single", 1, None, None),
+                # sync is somehow disabled, but reporting a single device
+                case("6", "single", None, 1, False),
+                # same as case #5, but with multiple devices
+                case("7", "multiple", 2, None, None),
+                # multiple desktop devices, but sync is not configured
+                case("8", "multiple", 0, 2, False),
+                # a mobile and desktop device, but not configured
+                case("9", "multiple", 1, 1, False),
+            ]
+        )
+    )
 
     df = test_transform(list(snippets))
 
@@ -386,57 +377,67 @@ def test_sync_usage(test_transform):
         test(df)
 
 
-def test_attribution_from_new_profile(effective_version,
-                                      generate_main_summary_data,
-                                      generate_new_profile_data):
-    main_summary = generate_main_summary_data([
-        {'client_id': '1', 'attribution': {'source': 'mozilla.org'}},
-        {'client_id': '3', 'attribution': None},
-        {'client_id': '4', 'attribution': None},
-        {
-            'client_id': '5',
-            'attribution': {'source': 'mozilla.org'},
-            'timestamp': SUBSESSION_START.shift(days=1).timestamp * 10 ** 9,
-        },
-        {
-            'client_id': '6',
-            'attribution': {'source': 'mozilla.org'},
-            'timestamp': SUBSESSION_START.shift(days=1).timestamp * 10 ** 9,
-        },
-        {'client_id': '7', 'attribution': {'source': 'mozilla.org'}},
-    ])
+def test_attribution_from_new_profile(
+    effective_version, generate_main_summary_data, generate_new_profile_data
+):
+    main_summary = generate_main_summary_data(
+        [
+            {"client_id": "1", "attribution": {"source": "mozilla.org"}},
+            {"client_id": "3", "attribution": None},
+            {"client_id": "4", "attribution": None},
+            {
+                "client_id": "5",
+                "attribution": {"source": "mozilla.org"},
+                "timestamp": SUBSESSION_START.shift(days=1).timestamp * 10 ** 9,
+            },
+            {
+                "client_id": "6",
+                "attribution": {"source": "mozilla.org"},
+                "timestamp": SUBSESSION_START.shift(days=1).timestamp * 10 ** 9,
+            },
+            {"client_id": "7", "attribution": {"source": "mozilla.org"}},
+        ]
+    )
 
     def update_attribution(attribution):
         # only updates the attribution section in the environment
-        env = copy.deepcopy(data.new_profile_sample['environment'])
-        env['settings']['attribution'] = attribution
+        env = copy.deepcopy(data.new_profile_sample["environment"])
+        env["settings"]["attribution"] = attribution
         return env
 
-    new_profile = generate_new_profile_data([
-        # new profile without a main summary companion
-        {'client_id': '2', 'environment': update_attribution({'source': 'mozilla.org'})},
-        # recover null attribution
-        {'client_id': '3', 'environment': update_attribution({'source': 'mozilla.org'})},
-        # new-profile ping used to recover attribution, but outside of the
-        # the current retention period
-        {
-            'client_id': '4',
-            'environment': update_attribution({'source': 'mozilla.org'}),
-            'submission': SUBSESSION_START.shift(days=-7).format("YYYYMMDD"),
-        },
-        # avoid accidentally overwriting an existing value with an empty structure
-        {'client_id': '5', 'environment': update_attribution({})},
-        # main-pings have higher latency than new-profile pings, so the main
-        # ping attribution state will be set correctly
-        {'client': '6', 'environment': update_attribution(None)},
-        # new-profile timestamp is newer than main-ping, so attribution for the
-        # client is unset
-        {
-            'client_id': '7',
-            'environment': update_attribution(None),
-            'timestamp': SUBSESSION_START.shift(days=1).timestamp * 10 ** 9,
-        },
-    ])
+    new_profile = generate_new_profile_data(
+        [
+            # new profile without a main summary companion
+            {
+                "client_id": "2",
+                "environment": update_attribution({"source": "mozilla.org"}),
+            },
+            # recover null attribution
+            {
+                "client_id": "3",
+                "environment": update_attribution({"source": "mozilla.org"}),
+            },
+            # new-profile ping used to recover attribution, but outside of the
+            # the current retention period
+            {
+                "client_id": "4",
+                "environment": update_attribution({"source": "mozilla.org"}),
+                "submission": SUBSESSION_START.shift(days=-7).format("YYYYMMDD"),
+            },
+            # avoid accidentally overwriting an existing value with an empty structure
+            {"client_id": "5", "environment": update_attribution({})},
+            # main-pings have higher latency than new-profile pings, so the main
+            # ping attribution state will be set correctly
+            {"client": "6", "environment": update_attribution(None)},
+            # new-profile timestamp is newer than main-ping, so attribution for the
+            # client is unset
+            {
+                "client_id": "7",
+                "environment": update_attribution(None),
+                "timestamp": SUBSESSION_START.shift(days=1).timestamp * 10 ** 9,
+            },
+        ]
+    )
     sources = job.extract(main_summary, new_profile, WEEK_START_DS, 2, 0, False)
     df = job.transform(sources, effective_version, WEEK_START_DS)
 
@@ -444,21 +445,24 @@ def test_attribution_from_new_profile(effective_version,
 
 
 def test_invalid_profile_creation_date(test_transform):
-    df = test_transform([
-        {
-            "client_id": "created when?",
-            "profile_creation_date": None
-        },
-        {
-            "client_id": "older than firefox",
-            "profile_creation_date": data.format_pcd(data.SUBSESSION_START.shift(years=-50))
-        },
-        {
-            "client_id": "created in the future",
-            "profile_creation_date": data.format_pcd(data.SUBSESSION_START.shift(days=+10))
-        },
-        {"client_id": "sanity"},
-    ])
+    df = test_transform(
+        [
+            {"client_id": "created when?", "profile_creation_date": None},
+            {
+                "client_id": "older than firefox",
+                "profile_creation_date": data.format_pcd(
+                    data.SUBSESSION_START.shift(years=-50)
+                ),
+            },
+            {
+                "client_id": "created in the future",
+                "profile_creation_date": data.format_pcd(
+                    data.SUBSESSION_START.shift(days=+10)
+                ),
+            },
+            {"client_id": "sanity"},
+        ]
+    )
 
     # null and the single sane row
     assert df.count() == 2

--- a/tests/engagement/test_churn_release.py
+++ b/tests/engagement/test_churn_release.py
@@ -24,14 +24,12 @@ For reference:
 def test_date_to_version_range(release_info):
     result = release.create_date_to_version(release_info)
 
-    start = datetime.strptime(
-        release_info['minor']['51.0.1'], '%Y-%m-%d')
-    end = datetime.strptime(
-        release_info['minor']['52.0.2'], '%Y-%m-%d')
+    start = datetime.strptime(release_info["minor"]["51.0.1"], "%Y-%m-%d")
+    end = datetime.strptime(release_info["minor"]["52.0.2"], "%Y-%m-%d")
 
     assert len(result) == (end - start).days + 1
-    assert result['2017-03-08'] == '52.0'
-    assert result['2017-03-17'] == '52.0.1'
+    assert result["2017-03-08"] == "52.0"
+    assert result["2017-03-17"] == "52.0.1"
 
 
 @pytest.fixture()
@@ -44,15 +42,12 @@ def usage_dates(dataframe_factory):
         {"uid": 4, "date": "2017-03-08"},
         {"uid": 5, "date": "2017-03-07", "channel": "beta"},
         {"uid": 6, "date": "2017-03-07", "channel": None},
-
     ]
     return dataframe_factory.create_dataframe(snippets, sample)
 
 
 def test_with_effective_version(usage_dates, effective_version):
-    result = (
-        release.with_effective_version(usage_dates, effective_version, "date")
-    )
+    result = release.with_effective_version(usage_dates, effective_version, "date")
 
     def get_case(uid):
         return result.where(F.col("uid") == uid).collect()[0].start_version

--- a/tests/engagement/test_churn_utils.py
+++ b/tests/engagement/test_churn_utils.py
@@ -5,10 +5,10 @@ from mozetl.engagement.churn import utils
 
 
 def test_to_datetime(spark):
-    df = spark.createDataFrame([{'date': '20000101'}])
-    expect = '2000-01-01 00:00:00'
+    df = spark.createDataFrame([{"date": "20000101"}])
+    expect = "2000-01-01 00:00:00"
 
-    expr = utils.to_datetime('date', 'yyyyMMdd')
+    expr = utils.to_datetime("date", "yyyyMMdd")
     actual = df.select(expr).collect()[0][0]
 
     assert actual == expect
@@ -17,45 +17,35 @@ def test_to_datetime(spark):
 @pytest.fixture()
 def test_df(dataframe_factory):
     return dataframe_factory.create_dataframe(
-        [None] * 2,
-        {"alpha": "hello", "omega": "world", "delta": "!"}
+        [None] * 2, {"alpha": "hello", "omega": "world", "delta": "!"}
     )
 
 
 @pytest.fixture()
 def select_expr_dict():
     return {
-        "alpha": None,            # key is the column name
-        "beta":  "omega",         # reference to another column
+        "alpha": None,  # key is the column name
+        "beta": "omega",  # reference to another column
         "gamma": "upper(alpha)",  # string expression
-        "delta": F.col("delta")   # column expression
+        "delta": F.col("delta"),  # column expression
     }
 
 
 def test_preprocess_col_expr(select_expr_dict, test_df, row_to_dict):
-    expect = {
-        "alpha": "hello",
-        "beta": "world",
-        "gamma": "HELLO",
-        "delta": "!",
-    }
+    expect = {"alpha": "hello", "beta": "world", "gamma": "HELLO", "delta": "!"}
 
     actual = utils.preprocess_col_expr(select_expr_dict)
 
-    assert row_to_dict(
-        test_df
-        .select([v.alias(k) for k, v in list(actual.items())])
-        .first()
-    ) == expect
+    assert (
+        row_to_dict(
+            test_df.select([v.alias(k) for k, v in list(actual.items())]).first()
+        )
+        == expect
+    )
 
 
 def test_build_col_expr(select_expr_dict, test_df, row_to_dict):
-    expect = {
-        "alpha": "hello",
-        "beta": "world",
-        "gamma": "HELLO",
-        "delta": "!",
-    }
+    expect = {"alpha": "hello", "beta": "world", "gamma": "HELLO", "delta": "!"}
 
     actual = utils.build_col_expr(select_expr_dict)
 

--- a/tests/engagement/test_daily_retention.py
+++ b/tests/engagement/test_daily_retention.py
@@ -10,10 +10,7 @@ from .data import WEEK_START_DS, SUBSESSION_START
 @pytest.fixture()
 def test_transform(generate_main_summary_data):
     def _test_transform(snippets, week_start=WEEK_START_DS):
-        return job.transform(
-            generate_main_summary_data(snippets),
-            week_start
-        )
+        return job.transform(generate_main_summary_data(snippets), week_start)
 
     return _test_transform
 
@@ -22,64 +19,55 @@ def test_transform_adheres_to_schema(test_transform):
     df = test_transform(None)
 
     def column_types(schema):
-        return {
-            col.name: col.dataType.typeName()
-            for col in schema.fields
-        }
+        return {col.name: col.dataType.typeName() for col in schema.fields}
 
     assert column_types(df.schema) == column_types(schema.retention_schema)
 
 
 def test_transform_valid_profile_creation(test_transform):
-    ssd = 'subsession_start_date'
-    pcd = 'profile_creation_date'
+    ssd = "subsession_start_date"
+    pcd = "profile_creation_date"
 
-    df = test_transform([
-        {
-            'client_id': '1',
-            ssd: data.format_ssd(arrow.get(1999, 1, 1))
-        },
-        {
-            'client_id': '2',
-            pcd: None
-        },
-        {
-            'client_id': '3',
-            ssd: data.format_ssd(SUBSESSION_START),
-            pcd: data.format_pcd(SUBSESSION_START.shift(days=3))
-        },
-        {
-            'client_id': '4',
-            ssd: data.format_ssd(SUBSESSION_START),
-            pcd: data.format_pcd(SUBSESSION_START.shift(days=-3))
-        }
-    ])
+    df = test_transform(
+        [
+            {"client_id": "1", ssd: data.format_ssd(arrow.get(1999, 1, 1))},
+            {"client_id": "2", pcd: None},
+            {
+                "client_id": "3",
+                ssd: data.format_ssd(SUBSESSION_START),
+                pcd: data.format_pcd(SUBSESSION_START.shift(days=3)),
+            },
+            {
+                "client_id": "4",
+                ssd: data.format_ssd(SUBSESSION_START),
+                pcd: data.format_pcd(SUBSESSION_START.shift(days=-3)),
+            },
+        ]
+    )
 
     assert df.count() == 4
-    assert (
-        df
-        .where(F.col("profile_creation") == F.lit(job.DEFAULT_DATE))
-        .count()
-    ) == 3
-    assert (
-        df.where(df.client_id == '4').first().profile_creation
-    ) == '2017-01-12'
+    assert (df.where(F.col("profile_creation") == F.lit(job.DEFAULT_DATE)).count()) == 3
+    assert (df.where(df.client_id == "4").first().profile_creation) == "2017-01-12"
 
 
 def test_transform_valid_app_version(spark, test_transform, df_equals):
 
-    expect = spark.createDataFrame([
-        {'client_id': '1', 'app_version': '55'},
-        {'client_id': '2', 'app_version': '57.0.1'},
-        {'client_id': '3', 'app_version': 'unknown'},
-        {'client_id': '4', 'app_version': 'older'},
-    ])
+    expect = spark.createDataFrame(
+        [
+            {"client_id": "1", "app_version": "55"},
+            {"client_id": "2", "app_version": "57.0.1"},
+            {"client_id": "3", "app_version": "unknown"},
+            {"client_id": "4", "app_version": "older"},
+        ]
+    )
 
-    actual = test_transform([
-        {'client_id': '1', 'app_version': '55'},
-        {'client_id': '2', 'app_version': '57.0.1'},
-        {'client_id': '3', 'app_version': None},
-        {'client_id': '4', 'app_version': '54.0'},
-    ]).select("client_id", "app_version")
+    actual = test_transform(
+        [
+            {"client_id": "1", "app_version": "55"},
+            {"client_id": "2", "app_version": "57.0.1"},
+            {"client_id": "3", "app_version": None},
+            {"client_id": "4", "app_version": "54.0"},
+        ]
+    ).select("client_id", "app_version")
 
     assert df_equals(actual, expect)

--- a/tests/hardware_report/test_check_output.py
+++ b/tests/hardware_report/test_check_output.py
@@ -5,49 +5,42 @@ import os
 from mozetl.hardware_report.check_output import (
     _check_most_recent_change as check_most_recent_change,
     _get_data as get_data,
-    _make_report as make_report)
+    _make_report as make_report,
+)
 
 
 def test_check_most_recent_change_min_change():
     test_data = {
-        20170701: {
-            "nochange": 1.0,
-            "somechange": 1.0,
-            "bigchange": 1.0
-        },
-        20170702: {
-            "nochange": 1.0,
-            "somechange": 1.1,
-            "bigchange": 1.4
-        }
+        20170701: {"nochange": 1.0, "somechange": 1.0, "bigchange": 1.0},
+        20170702: {"nochange": 1.0, "somechange": 1.1, "bigchange": 1.4},
     }
 
-    assert set(check_most_recent_change(test_data, min_change=0.5).keys())\
-        == set()
-    assert set(check_most_recent_change(test_data, min_change=0.3).keys())\
-        == {"bigchange"}
-    assert set(check_most_recent_change(test_data, min_change=0.05).keys())\
-        == {"bigchange", "somechange"}
+    assert set(check_most_recent_change(test_data, min_change=0.5).keys()) == set()
+    assert set(check_most_recent_change(test_data, min_change=0.3).keys()) == {
+        "bigchange"
+    }
+    assert set(check_most_recent_change(test_data, min_change=0.05).keys()) == {
+        "bigchange",
+        "somechange",
+    }
 
 
 def test_check_most_recent_change_min_value():
     test_data = {
-        20170701: {
-            "somechange1": 1.5,
-            "somechange2": 0.5
-        },
-        20170702: {
-            "somechange1": 1.0,
-            "somechange2": 0.0
-        }
+        20170701: {"somechange1": 1.5, "somechange2": 0.5},
+        20170702: {"somechange1": 1.0, "somechange2": 0.0},
     }
 
-    assert set(check_most_recent_change(test_data, min_change=0.1, min_value=2.0).keys())\
+    assert (
+        set(check_most_recent_change(test_data, min_change=0.1, min_value=2.0).keys())
         == set()
-    assert set(check_most_recent_change(test_data, min_change=0.1, min_value=1.0).keys())\
-        == {"somechange1"}
-    assert set(check_most_recent_change(test_data, min_change=0.1, min_value=0.0).keys())\
-        == {"somechange1", "somechange2"}
+    )
+    assert set(
+        check_most_recent_change(test_data, min_change=0.1, min_value=1.0).keys()
+    ) == {"somechange1"}
+    assert set(
+        check_most_recent_change(test_data, min_change=0.1, min_value=0.0).keys()
+    ) == {"somechange1", "somechange2"}
 
 
 def test_check_most_recent_change_missing_val():
@@ -75,47 +68,26 @@ def test_check_most_recent_change_missing_val():
 
 def test_get_data():
     test_data = [
-        {
-            "date": "20170701",
-            "nochange": 0.5,
-            "somechange": 0.5,
-            "bigchange": 0.5
-        },
-        {
-            "date": "20170702",
-            "nochange": 0.5,
-            "somechange": 0.4,
-            "bigchange": 0.1
-        }
+        {"date": "20170701", "nochange": 0.5, "somechange": 0.5, "bigchange": 0.5},
+        {"date": "20170702", "nochange": 0.5, "somechange": 0.4, "bigchange": 0.1},
     ]
 
-    with open('hwsurvey-weekly.json', 'w') as f:
+    with open("hwsurvey-weekly.json", "w") as f:
         f.write(ujson.dumps(test_data))
 
     expected = {
-        20170701: {
-            "nochange": 0.5,
-            "somechange": 0.5,
-            "bigchange": 0.5
-        },
-        20170702: {
-            "nochange": 0.5,
-            "somechange": 0.4,
-            "bigchange": 0.1
-        }
+        20170701: {"nochange": 0.5, "somechange": 0.5, "bigchange": 0.5},
+        20170702: {"nochange": 0.5, "somechange": 0.4, "bigchange": 0.1},
     }
 
     assert get_data() == expected
-    os.remove('hwsurvey-weekly.json')
+    os.remove("hwsurvey-weekly.json")
 
 
 def test_report_missing_data():
-    test_data = {
-        20170701: {
-            "change": 0.5,
-        },
-        20170702: {}
-    }
+    test_data = {20170701: {"change": 0.5}, 20170702: {}}
 
-    changes = check_most_recent_change(test_data, min_change=0.1, min_value=0.0, missing_val=1.0)
+    changes = check_most_recent_change(
+        test_data, min_change=0.1, min_value=0.0, missing_val=1.0
+    )
     assert make_report(changes) == "change: Last week = 50.00%, This week = 100.00%"

--- a/tests/hardware_report/test_summarize_json.py
+++ b/tests/hardware_report/test_summarize_json.py
@@ -8,159 +8,187 @@ import mozetl.hardware_report.summarize_json as summarize_json
 def test_run_tests():
     """Test if helper functions work as expected."""
     # Does |get_OS_arch| work as expected?
-    assert summarize_json.get_OS_arch("x86", "Windows_NT", False) == "x86", (
-           "get_OS_arch should report an 'x86' for an x86 browser with no is_wow64.")
-    assert summarize_json.get_OS_arch("x86", "Windows_NT", True) == "x86-64", (
-           "get_OS_arch should report an 'x86-64' for an x86 browser, on Windows, using Wow64.")
-    assert summarize_json.get_OS_arch("x86", "Darwin", True) == "x86", (
-           "get_OS_arch should report an 'x86' for an x86 browser on non Windows platforms.")
-    assert summarize_json.get_OS_arch("x86-64", "Darwin", True) == "x86-64", (
-           "get_OS_arch should report an 'x86-64' for an x86-64 browser on non Windows platforms.")
-    assert summarize_json.get_OS_arch("x86-64", "Windows_NT", False) == "x86-64", (
-           "get_OS_arch should report an 'x86-64' for an x86-64 browser on Windows platforms.")
+    assert (
+        summarize_json.get_OS_arch("x86", "Windows_NT", False) == "x86"
+    ), "get_OS_arch should report an 'x86' for an x86 browser with no is_wow64."
+    assert (
+        summarize_json.get_OS_arch("x86", "Windows_NT", True) == "x86-64"
+    ), "get_OS_arch should report an 'x86-64' for an x86 browser, on Windows, using Wow64."
+    assert (
+        summarize_json.get_OS_arch("x86", "Darwin", True) == "x86"
+    ), "get_OS_arch should report an 'x86' for an x86 browser on non Windows platforms."
+    assert (
+        summarize_json.get_OS_arch("x86-64", "Darwin", True) == "x86-64"
+    ), "get_OS_arch should report an 'x86-64' for an x86-64 browser on non Windows platforms."
+    assert (
+        summarize_json.get_OS_arch("x86-64", "Windows_NT", False) == "x86-64"
+    ), "get_OS_arch should report an 'x86-64' for an x86-64 browser on Windows platforms."
 
     # Does |vendor_name_from_id| behave correctly?
-    assert summarize_json.vendor_name_from_id("0x1013") == "Cirrus Logic", (
-           "vendor_name_from_id must report the correct vendor name for a known vendor id.")
-    assert summarize_json.vendor_name_from_id("0xfeee") == "Other", (
-           "vendor_name_from_id must report 'Other' for an unknown vendor id.")
+    assert (
+        summarize_json.vendor_name_from_id("0x1013") == "Cirrus Logic"
+    ), "vendor_name_from_id must report the correct vendor name for a known vendor id."
+    assert (
+        summarize_json.vendor_name_from_id("0xfeee") == "Other"
+    ), "vendor_name_from_id must report 'Other' for an unknown vendor id."
 
     # Make sure |invert_device_map| works as expected.
     device_data = {"feee": {"family": {"chipset": ["d1d1", "d2d2"]}}}
     inverted_device_data = summarize_json.invert_device_map(device_data)
-    assert "0xfeee" in inverted_device_data, (
-           "The vendor id must be prefixed with '0x' and be at the root of the map.")
-    assert len(list(inverted_device_data["0xfeee"].keys())) == 2, (
-           "There must be two devices for the '0xfeee' vendor.")
-    assert all(device_id in inverted_device_data["0xfeee"] for device_id in ("0xd1d1", "0xd2d2")), (
-           "The '0xfeee' vendor must contain the expected devices.")
-    assert all(d in inverted_device_data["0xfeee"]["0xd1d1"] for d in ("family", "chipset")), (
-           "The family and chipset data must be reported in the device section.")
+    assert (
+        "0xfeee" in inverted_device_data
+    ), "The vendor id must be prefixed with '0x' and be at the root of the map."
+    assert (
+        len(list(inverted_device_data["0xfeee"].keys())) == 2
+    ), "There must be two devices for the '0xfeee' vendor."
+    assert all(
+        device_id in inverted_device_data["0xfeee"]
+        for device_id in ("0xd1d1", "0xd2d2")
+    ), "The '0xfeee' vendor must contain the expected devices."
+    assert all(
+        d in inverted_device_data["0xfeee"]["0xd1d1"] for d in ("family", "chipset")
+    ), "The family and chipset data must be reported in the device section."
 
     # Let's test |get_device_family_chipset|.
     global device_map
     device_map = inverted_device_data
-    assert summarize_json.get_device_family_chipset(
-           "0xfeee", "0xd1d1", device_map) == "family-chipset", (
-           "The family and chipset info must be returned as '<family>-<chipset>' ",
-           "for known devices.")
-    assert summarize_json.get_device_family_chipset("0xfeee", "0xdeee", device_map) == "Unknown", (
-           "Unknown devices must be reported as 'Unknown'.")
-    assert summarize_json.get_device_family_chipset("0xfeeb", "0xdeee", device_map) == "Unknown", (
-           "Unknown families must be reported as 'Unknown'.")
+    assert (
+        summarize_json.get_device_family_chipset("0xfeee", "0xd1d1", device_map)
+        == "family-chipset"
+    ), (
+        "The family and chipset info must be returned as '<family>-<chipset>' ",
+        "for known devices.",
+    )
+    assert (
+        summarize_json.get_device_family_chipset("0xfeee", "0xdeee", device_map)
+        == "Unknown"
+    ), "Unknown devices must be reported as 'Unknown'."
+    assert (
+        summarize_json.get_device_family_chipset("0xfeeb", "0xdeee", device_map)
+        == "Unknown"
+    ), "Unknown families must be reported as 'Unknown'."
 
 
 def test_prepare_data():
     """Test prepare_data function on sample data."""
     data = {
-        'browser_arch': 'x86',
-        'os_name': 'Windows_NT',
-        'os_version': '6.1',
-        'memory_mb': 4286,
-        'is_wow64': False,
-        'gfx0_vendor_id': '0xfeee',
-        'gfx0_device_id': '0xd1d1',
-        'screen_width': 1280,
-        'screen_height': 1024,
-        'cpu_cores': 2,
-        'cpu_vendor': 'SomeCpuVendor',
-        'cpu_speed': 3261,
-        'has_flash': True
+        "browser_arch": "x86",
+        "os_name": "Windows_NT",
+        "os_version": "6.1",
+        "memory_mb": 4286,
+        "is_wow64": False,
+        "gfx0_vendor_id": "0xfeee",
+        "gfx0_device_id": "0xd1d1",
+        "screen_width": 1280,
+        "screen_height": 1024,
+        "cpu_cores": 2,
+        "cpu_vendor": "SomeCpuVendor",
+        "cpu_speed": 3261,
+        "has_flash": True,
     }
 
     prepared_data = summarize_json.prepare_data(data, device_map)
-    assert prepared_data["browser_arch"] == "x86", (
-               "The browser architecture must be correct.")
-    assert prepared_data["cpu_cores"] == 2, (
-               "The number of CPU cores must be correct.")
-    assert prepared_data["cpu_speed"] == 3.3, (
-               "The CPU speed must be in GHz and correctly rounded to 1 decimal.")
-    assert prepared_data["cpu_vendor"] == "SomeCpuVendor", (
-               "The CPU vendor must be correct.")
-    assert prepared_data["cpu_cores_speed"] == "2_3.3", (
-               "The CPU cores and speed must be correctly merged together.")
-    assert prepared_data["gfx0_vendor_name"] == "Other", (
-               "The GPU vendor name must be correctly converted from the vendor id.")
-    assert prepared_data["gfx0_model"] == "family-chipset", (
-               "The GPU family and chipset must be correctly derived from vendor and device ids.")
-    assert prepared_data["resolution"] == "1280x1024", (
-               "The screen resolution must be correctly concatenated.")
-    assert prepared_data["memory_gb"] == 4, (
-               "The RAM memory must be converted to GB.")
-    assert prepared_data["os"] == "Windows_NT-6.1", (
-               "The OS string must contain the OS name and version.")
-    assert prepared_data["os_arch"] == "x86", (
-               "The OS architecture must be correctly inferred.")
-    assert prepared_data["has_flash"] is True, (
-               "The flash plugin must be correctly reported.")
+    assert (
+        prepared_data["browser_arch"] == "x86"
+    ), "The browser architecture must be correct."
+    assert prepared_data["cpu_cores"] == 2, "The number of CPU cores must be correct."
+    assert (
+        prepared_data["cpu_speed"] == 3.3
+    ), "The CPU speed must be in GHz and correctly rounded to 1 decimal."
+    assert (
+        prepared_data["cpu_vendor"] == "SomeCpuVendor"
+    ), "The CPU vendor must be correct."
+    assert (
+        prepared_data["cpu_cores_speed"] == "2_3.3"
+    ), "The CPU cores and speed must be correctly merged together."
+    assert (
+        prepared_data["gfx0_vendor_name"] == "Other"
+    ), "The GPU vendor name must be correctly converted from the vendor id."
+    assert (
+        prepared_data["gfx0_model"] == "family-chipset"
+    ), "The GPU family and chipset must be correctly derived from vendor and device ids."
+    assert (
+        prepared_data["resolution"] == "1280x1024"
+    ), "The screen resolution must be correctly concatenated."
+    assert prepared_data["memory_gb"] == 4, "The RAM memory must be converted to GB."
+    assert (
+        prepared_data["os"] == "Windows_NT-6.1"
+    ), "The OS string must contain the OS name and version."
+    assert (
+        prepared_data["os_arch"] == "x86"
+    ), "The OS architecture must be correctly inferred."
+    assert (
+        prepared_data["has_flash"] is True
+    ), "The flash plugin must be correctly reported."
 
 
 def test_aggregate_data():
     """Test aggregate_data function on sample data."""
     raw_data = [
         {
-            'browser_arch': 'x86',
-            'os_name': 'Windows_NT',
-            'os_version': '6.1',
-            'memory_mb': 4286,
-            'is_wow64': False,
-            'gfx0_vendor_id': '0xfeee',
-            'gfx0_device_id': '0xd1d1',
-            'screen_width': 1280,
-            'screen_height': 1024,
-            'cpu_cores': 2,
-            'cpu_vendor': 'SomeCpuVendor',
-            'cpu_speed': 3261,
-            'has_flash': True
+            "browser_arch": "x86",
+            "os_name": "Windows_NT",
+            "os_version": "6.1",
+            "memory_mb": 4286,
+            "is_wow64": False,
+            "gfx0_vendor_id": "0xfeee",
+            "gfx0_device_id": "0xd1d1",
+            "screen_width": 1280,
+            "screen_height": 1024,
+            "cpu_cores": 2,
+            "cpu_vendor": "SomeCpuVendor",
+            "cpu_speed": 3261,
+            "has_flash": True,
         },
         {
-            'browser_arch': 'x86',
-            'os_name': 'Windows_NT',
-            'os_version': '6.1',
-            'memory_mb': 4286,
-            'is_wow64': False,
-            'gfx0_vendor_id': '0xfeee',
-            'gfx0_device_id': '0xd1d1',
-            'screen_width': 1280,
-            'screen_height': 1024,
-            'cpu_cores': 2,
-            'cpu_vendor': 'SomeCpuVendor',
-            'cpu_speed': 3261,
-            'has_flash': True
+            "browser_arch": "x86",
+            "os_name": "Windows_NT",
+            "os_version": "6.1",
+            "memory_mb": 4286,
+            "is_wow64": False,
+            "gfx0_vendor_id": "0xfeee",
+            "gfx0_device_id": "0xd1d1",
+            "screen_width": 1280,
+            "screen_height": 1024,
+            "cpu_cores": 2,
+            "cpu_vendor": "SomeCpuVendor",
+            "cpu_speed": 3261,
+            "has_flash": True,
         },
         {
-            'browser_arch': 'x86-64',
-            'os_name': 'Darwin',
-            'os_version': '15.3',
-            'memory_mb': 8322,
-            'is_wow64': False,
-            'gfx0_vendor_id': '0xfeee',
-            'gfx0_device_id': '0xd1d2',
-            'screen_width': 1320,
-            'screen_height': 798,
-            'cpu_cores': 4,
-            'cpu_vendor': 'SomeCpuVendor',
-            'cpu_speed': 4211,
-            'has_flash': True
+            "browser_arch": "x86-64",
+            "os_name": "Darwin",
+            "os_version": "15.3",
+            "memory_mb": 8322,
+            "is_wow64": False,
+            "gfx0_vendor_id": "0xfeee",
+            "gfx0_device_id": "0xd1d2",
+            "screen_width": 1320,
+            "screen_height": 798,
+            "cpu_cores": 4,
+            "cpu_vendor": "SomeCpuVendor",
+            "cpu_speed": 4211,
+            "has_flash": True,
         },
     ]
 
-    spark = (SparkSession
-             .builder
-             .appName("hardware_report_dashboard")
-             .getOrCreate())
+    spark = SparkSession.builder.appName("hardware_report_dashboard").getOrCreate()
 
     # Create an rdd with the pepared data, then aggregate.
     data_rdd = spark.sparkContext.parallelize(
-               [summarize_json.prepare_data(d, device_map) for d in raw_data])
+        [summarize_json.prepare_data(d, device_map) for d in raw_data]
+    )
     agg_data = summarize_json.aggregate_data(data_rdd)
 
-    assert agg_data[('os_arch', 'x86')] == 2, (
-               "Two 'x86' OS architectures must be reported.")
-    assert agg_data[('os_arch', 'x86-64')] == 1, (
-               "One 'x86-64' OS architecture must be reported.")
-    assert agg_data[('has_flash', True)] == 3, (
-               "All the entries had the flash plugin, so this must be 3.")
+    assert (
+        agg_data[("os_arch", "x86")] == 2
+    ), "Two 'x86' OS architectures must be reported."
+    assert (
+        agg_data[("os_arch", "x86-64")] == 1
+    ), "One 'x86-64' OS architecture must be reported."
+    assert (
+        agg_data[("has_flash", True)] == 3
+    ), "All the entries had the flash plugin, so this must be 3."
 
 
 def test_collapse_buckets():
@@ -186,114 +214,139 @@ def test_collapse_buckets():
     collapsed_data = summarize_json.collapse_buckets(agg_data, threshold)
 
     # Test that keys with values above the threshold are kept.
-    assert ("os", "Darwin-11.0") in collapsed_data, (
-               "Keys with enough elements must not be collapsed.")
-    assert ("has_flash", True) in collapsed_data, (
-               "Keys with enough elements must not be collapsed.")
-    assert ("resolution", "1280x1024") in collapsed_data, (
-               "Keys with enough elements must not be collapsed.")
-    assert ("os", "Windows_NT-6.11") in collapsed_data, (
-               "Keys with enough elements must not be collapsed.")
+    assert (
+        "os",
+        "Darwin-11.0",
+    ) in collapsed_data, "Keys with enough elements must not be collapsed."
+    assert (
+        "has_flash",
+        True,
+    ) in collapsed_data, "Keys with enough elements must not be collapsed."
+    assert (
+        "resolution",
+        "1280x1024",
+    ) in collapsed_data, "Keys with enough elements must not be collapsed."
+    assert (
+        "os",
+        "Windows_NT-6.11",
+    ) in collapsed_data, "Keys with enough elements must not be collapsed."
 
     # Test resolution collapsing.
-    assert ("resolution", "~2600x1400") in collapsed_data, (
-               "Collapsed resolutions with enough elements must be reported, prefixed with ~.")
-    assert ("resolution", "Other") in collapsed_data, (
-               "Collapsed resolutions with not enough elements must be reported as 'Other'.")
-    assert collapsed_data[("resolution", "Other")] == 23, (
-               "The 640x* and the 0x0 resolution must be reported in the 'Other' bucket.")
+    assert (
+        "resolution",
+        "~2600x1400",
+    ) in collapsed_data, (
+        "Collapsed resolutions with enough elements must be reported, prefixed with ~."
+    )
+    assert (
+        "resolution",
+        "Other",
+    ) in collapsed_data, (
+        "Collapsed resolutions with not enough elements must be reported as 'Other'."
+    )
+    assert (
+        collapsed_data[("resolution", "Other")] == 23
+    ), "The 640x* and the 0x0 resolution must be reported in the 'Other' bucket."
 
     # Test that whitelisted keys are not collapsed.
-    assert ("has_flash", False) in collapsed_data, (
-           "Whitelisted keys must not be collapsed.")
+    assert (
+        "has_flash",
+        False,
+    ) in collapsed_data, "Whitelisted keys must not be collapsed."
 
 
 def test_finalize_data():
     """Test finalize_data function on sample data."""
     collapsed_data = {
-        ('os', 'Darwin-11.0'): 22,
-        ('resolution', '1280x1024'): 50,
-        ('os', 'Windows_NT-6.11'): 34,
-        ('resolution', '~2600x1400'): 16,
-        ('os', 'Other'): 2,
-        ('has_flash', True): 72,
-        ('os', 'Windows_NT-Other'): 16,
-        ('has_flash', False): 2,
-        ('resolution', 'Other'): 8
+        ("os", "Darwin-11.0"): 22,
+        ("resolution", "1280x1024"): 50,
+        ("os", "Windows_NT-6.11"): 34,
+        ("resolution", "~2600x1400"): 16,
+        ("os", "Other"): 2,
+        ("has_flash", True): 72,
+        ("os", "Windows_NT-Other"): 16,
+        ("has_flash", False): 2,
+        ("resolution", "Other"): 8,
     }
 
     finalized_data = summarize_json.finalize_data(
-                     collapsed_data, 74, 0.1, 0.2, datetime.strptime('20160703', '%Y%m%d'))
+        collapsed_data, 74, 0.1, 0.2, datetime.strptime("20160703", "%Y%m%d")
+    )
 
     # Check that the basic fields are in the finalized data.
-    assert finalized_data['broken'] == 0.1, (
-           "The ratio of broken data must be correctly reported.")
-    assert finalized_data['inactive'] == 0.2, (
-           "The ratio of inactive clients must be correctly reported.")
-    assert finalized_data['date'] == "2016-07-03", (
-           "The first day of the reporting period must be reported.")
+    assert (
+        finalized_data["broken"] == 0.1
+    ), "The ratio of broken data must be correctly reported."
+    assert (
+        finalized_data["inactive"] == 0.2
+    ), "The ratio of inactive clients must be correctly reported."
+    assert (
+        finalized_data["date"] == "2016-07-03"
+    ), "The first day of the reporting period must be reported."
 
     # Make sure that all the reported numbers are ratios.
-    all_ratios = [(v >= 0.0 and v <= 1.0) for (k, v) in finalized_data.items() if k != 'date']
+    all_ratios = [
+        (v >= 0.0 and v <= 1.0) for (k, v) in finalized_data.items() if k != "date"
+    ]
     assert all(all_ratios), "All the reported entries must be ratios."
 
 
 def test_validate_finalized_data():
     """Test valiate_finalized_data on sample data."""
-    MISSING_KEYS = {
-        'browserArch_x86': 1.0,
-        'cpuCores_2': 1.0
-    }
+    MISSING_KEYS = {"browserArch_x86": 1.0, "cpuCores_2": 1.0}
 
-    assert summarize_json.validate_finalized_data(MISSING_KEYS) is False, (
-           "The validator must fail when expected keys are missing")
+    assert (
+        summarize_json.validate_finalized_data(MISSING_KEYS) is False
+    ), "The validator must fail when expected keys are missing"
 
     KEYS_NOT_ADDING_UP = {
-        'browserArch_x86': 0.5,
-        'browserArch_x64': 0.4,
-        'cpuCores_1': 1.0,
-        'cpuCoresSpeed_2_2.2': 1.0,
-        'cpuVendor_Vendor1': 1.0,
-        'cpuSpeed_2.2': 1.0,
-        'gpuVendor_Vendor3': 1.0,
-        'gpuModel_Model1': 1.0,
-        'resolution_800x600': 1.0,
-        'ram_2': 1.0,
-        'osName_SomeOS': 1.0,
-        'osArch_x64': 1.0,
-        'hasFlash_True': 1.0
+        "browserArch_x86": 0.5,
+        "browserArch_x64": 0.4,
+        "cpuCores_1": 1.0,
+        "cpuCoresSpeed_2_2.2": 1.0,
+        "cpuVendor_Vendor1": 1.0,
+        "cpuSpeed_2.2": 1.0,
+        "gpuVendor_Vendor3": 1.0,
+        "gpuModel_Model1": 1.0,
+        "resolution_800x600": 1.0,
+        "ram_2": 1.0,
+        "osName_SomeOS": 1.0,
+        "osArch_x64": 1.0,
+        "hasFlash_True": 1.0,
     }
 
-    assert summarize_json.validate_finalized_data(KEYS_NOT_ADDING_UP) is False, (
-           "The validator must fail when the reported values don't add up to 1.0")
+    assert (
+        summarize_json.validate_finalized_data(KEYS_NOT_ADDING_UP) is False
+    ), "The validator must fail when the reported values don't add up to 1.0"
 
     WORKING_DATA = {
-        'browserArch_x86': 0.7,
-        'browserArch_x64': 0.29,
-        'cpuCores_1': 0.5,
-        'cpuCores_2': 0.5,
-        'cpuCoresSpeed_2_2.2': 0.1,
-        'cpuCoresSpeed_2_2.4': 0.9,
-        'cpuVendor_Vendor1': 0.725,
-        'cpuVendor_Vendor2': 0.275,
-        'cpuSpeed_2.2': 0.1,
-        'cpuSpeed_2.4': 0.9,
-        'gpuVendor_Vendor3': 0.9,
-        'gpuVendor_Vendor4': 0.1,
-        'gpuModel_Model1': 0.00001,
-        'gpuModel_Model2': 0.99999,
-        'resolution_800x600': 1.0,
-        'ram_2': 1.0,
-        'osName_SomeOS': 1.0,
-        'osArch_x64': 1.0,
-        'hasFlash_True': 1.0,
-        'broken': 0.1,
-        'inactive': 0.1,
-        'date': '2017-03-26'
+        "browserArch_x86": 0.7,
+        "browserArch_x64": 0.29,
+        "cpuCores_1": 0.5,
+        "cpuCores_2": 0.5,
+        "cpuCoresSpeed_2_2.2": 0.1,
+        "cpuCoresSpeed_2_2.4": 0.9,
+        "cpuVendor_Vendor1": 0.725,
+        "cpuVendor_Vendor2": 0.275,
+        "cpuSpeed_2.2": 0.1,
+        "cpuSpeed_2.4": 0.9,
+        "gpuVendor_Vendor3": 0.9,
+        "gpuVendor_Vendor4": 0.1,
+        "gpuModel_Model1": 0.00001,
+        "gpuModel_Model2": 0.99999,
+        "resolution_800x600": 1.0,
+        "ram_2": 1.0,
+        "osName_SomeOS": 1.0,
+        "osArch_x64": 1.0,
+        "hasFlash_True": 1.0,
+        "broken": 0.1,
+        "inactive": 0.1,
+        "date": "2017-03-26",
     }
 
-    assert summarize_json.validate_finalized_data(WORKING_DATA), (
-           "The validator must not fail when the reported data is correct")
+    assert summarize_json.validate_finalized_data(
+        WORKING_DATA
+    ), "The validator must not fail when the reported data is correct"
 
 
 def test_get_longitudinal_version_weekday():
@@ -313,13 +366,10 @@ def test_get_longitudinal_version_saturday():
 
 def test_generate_report():
     """Test generate_report function on sample data."""
-    spark = (SparkSession
-             .builder
-             .appName("hardware_report_dashboard")
-             .getOrCreate())
+    spark = SparkSession.builder.appName("hardware_report_dashboard").getOrCreate()
 
-    df = spark.read.json('tests/longitudinal_schema.json')
-    df.createOrReplaceTempView('longitudinal_v20160709')
+    df = spark.read.json("tests/longitudinal_schema.json")
+    df.createOrReplaceTempView("longitudinal_v20160709")
 
     expected = {
         "cpuCores_4": 1.0,
@@ -336,10 +386,14 @@ def test_generate_report():
         "date": "2016-07-03",
         "cpuCoresSpeed_4_4.0": 1.0,
         "hasFlash_False": 1.0,
-        "resolution_1920x1200": 1.0
+        "resolution_1920x1200": 1.0,
     }
 
-    assert summarize_json.generate_report(
-           datetime.strptime('20160703', '%Y%m%d'),
-           datetime.strptime('20160710', '%Y%m%d'),
-           spark)['hwsurvey-weekly-20160307-20160907.json'] == expected
+    assert (
+        summarize_json.generate_report(
+            datetime.strptime("20160703", "%Y%m%d"),
+            datetime.strptime("20160710", "%Y%m%d"),
+            spark,
+        )["hwsurvey-weekly-20160307-20160907.json"]
+        == expected
+    )

--- a/tests/test_addon_aggregates.py
+++ b/tests/test_addon_aggregates.py
@@ -5,10 +5,10 @@ import pytest
 
 @pytest.fixture
 def load_data(spark):
-    '''
+    """
     Create synthetic main_summary dataframe
     with only relevant fields
-    '''
+    """
     return spark.read.json("./tests/ms-test-data.json")
 
 
@@ -31,17 +31,17 @@ def aggregate_data(add_columns):
 
 
 def test_get_dest():
-    '''
+    """
     Ensure proper contruction of input/output s3 paths
-    '''
-    s1 = 's3://bucket/prefix/version/'
-    s2 = s1 + 'submission_date_s3=20170101/'
-    s3 = s2 + 'sample_id=42/'
+    """
+    s1 = "s3://bucket/prefix/version/"
+    s2 = s1 + "submission_date_s3=20170101/"
+    s3 = s2 + "sample_id=42/"
 
     gd = addon_aggregates.get_dest
-    assert gd('bucket', 'prefix', 'version') == s1
-    assert gd('bucket', 'prefix', 'version', '20170101') == s2
-    assert gd('bucket', 'prefix', 'version', '20170101', '42') == s3
+    assert gd("bucket", "prefix", "version") == s1
+    assert gd("bucket", "prefix", "version", "20170101") == s2
+    assert gd("bucket", "prefix", "version", "20170101", "42") == s3
 
 
 # tests for pyspark functions ###
@@ -52,73 +52,78 @@ def test_explode_data(explode_data):
 
 
 def test_add_columns(add_columns):
-    columns = ['addon_id',
-               'app_version',
-               'client_id',
-               'foreign_install',
-               'install_day',
-               'is_foreign_install',
-               'is_self_install',
-               'is_shield_addon',
-               'is_system',
-               'is_web_extension',
-               'locale',
-               'normalized_channel',
-               'profile_creation_date',
-               'sample_id']
+    columns = [
+        "addon_id",
+        "app_version",
+        "client_id",
+        "foreign_install",
+        "install_day",
+        "is_foreign_install",
+        "is_self_install",
+        "is_shield_addon",
+        "is_system",
+        "is_web_extension",
+        "locale",
+        "normalized_channel",
+        "profile_creation_date",
+        "sample_id",
+    ]
 
     # ensure proper schema
     assert sorted(add_columns.columns) == columns
 
     # ensure addon_ids equal to None register no
     # non-zero values in the added columns
-    none_addon_id = (
-      add_columns
-      .filter('addon_id is null')
-      .collect()[0])
+    none_addon_id = add_columns.filter("addon_id is null").collect()[0]
 
     # ensure null addon_ids
     # have no non-zero values
     # in the additional columns
     assert (
-      none_addon_id.is_system ==
-      none_addon_id.is_web_extension ==
-      none_addon_id.is_shield_addon ==
-      none_addon_id.is_foreign_install ==
-      none_addon_id.is_self_install == 0)
+        none_addon_id.is_system
+        == none_addon_id.is_web_extension
+        == none_addon_id.is_shield_addon
+        == none_addon_id.is_foreign_install
+        == none_addon_id.is_self_install
+        == 0
+    )
 
 
 def test_addon_counts(aggregate_data):
-    '''
+    """
     Test the aggregation across add-on types
-    '''
+    """
 
     # true values as defined in ms-test-data.json
     true_client_counts = {
-        1: {'n_self_installed_addons': 1,
-            'n_foreign_installed_addons': 1,
-            'n_web_extensions': 1,
-            'n_system_addons': 1,
-            'n_shield_addons': 0
-            },
-        2: {'n_self_installed_addons': 0,
-            'n_foreign_installed_addons': 0,
-            'n_web_extensions': 0,
-            'n_system_addons': 0,
-            'n_shield_addons': 1
-            },
-        3: {'n_self_installed_addons': 1,
-            'n_foreign_installed_addons': 0,
-            'n_web_extensions': 1,
-            'n_system_addons': 0,
-            'n_shield_addons': 0
-            },
-        4: {'n_self_installed_addons': 0,
-            'n_foreign_installed_addons': 0,
-            'n_web_extensions': 0,
-            'n_system_addons': 2,
-            'n_shield_addons': 1
-            }
+        1: {
+            "n_self_installed_addons": 1,
+            "n_foreign_installed_addons": 1,
+            "n_web_extensions": 1,
+            "n_system_addons": 1,
+            "n_shield_addons": 0,
+        },
+        2: {
+            "n_self_installed_addons": 0,
+            "n_foreign_installed_addons": 0,
+            "n_web_extensions": 0,
+            "n_system_addons": 0,
+            "n_shield_addons": 1,
+        },
+        3: {
+            "n_self_installed_addons": 1,
+            "n_foreign_installed_addons": 0,
+            "n_web_extensions": 1,
+            "n_system_addons": 0,
+            "n_shield_addons": 0,
+        },
+        4: {
+            "n_self_installed_addons": 0,
+            "n_foreign_installed_addons": 0,
+            "n_web_extensions": 0,
+            "n_system_addons": 2,
+            "n_shield_addons": 1,
+        },
     }
 
     for client_id in true_client_counts:
@@ -128,20 +133,19 @@ def test_addon_counts(aggregate_data):
 
 
 def test_unix_dates(aggregate_data):
-    '''
+    """
     Test profile_creation_date and install_date
     are properly reformatted relative to their
     previous values
-    '''
+    """
 
     # true values as defined in ms-test-data.json
     # min install_day - pcd
     true_client_days_to_install = {
-        1: {'min_install_day': 16890 - 15000},
-        2: {'min_install_day': None},
-        3: {'min_install_day': 16800 - 15002},
-        4: {'min_install_day': None}
-
+        1: {"min_install_day": 16890 - 15000},
+        2: {"min_install_day": None},
+        3: {"min_install_day": 16800 - 15002},
+        4: {"min_install_day": None},
     }
 
     for client_id, value in true_client_days_to_install.items():
@@ -149,42 +153,34 @@ def test_unix_dates(aggregate_data):
         first_install = data.first_addon_install_date
         pcd = data.profile_creation_date
         print(first_install, pcd)
-        fmt = '%Y%m%d'
+        fmt = "%Y%m%d"
         days_to_install = (
-            dt.datetime.strptime(first_install, fmt) - dt.datetime.strptime(pcd, fmt)
-        ).days if first_install is not None else None
+            (
+                dt.datetime.strptime(first_install, fmt)
+                - dt.datetime.strptime(pcd, fmt)
+            ).days
+            if first_install is not None
+            else None
+        )
 
-        assert true_client_days_to_install[client_id]['min_install_day'] == days_to_install
+        assert (
+            true_client_days_to_install[client_id]["min_install_day"] == days_to_install
+        )
 
 
 def test_agg_by_channel_locale_and_version(aggregate_data):
-    '''
+    """
     Test the aggregation by channel, locale and app_version.
-    '''
+    """
 
     # true values as defined in ms-test-data.json
     true_values = {
-      'normalized_channel':
-      {
-           'release': 1,
-           'beta': 2,
-           'nightly': 1
-      },
-      'locale':
-      {
-           'en-US': 2,
-           'de': 1,
-           'ru': 1
-      },
-      'app_version':
-      {
-           '57': 2,
-           '56': 1,
-           '58': 1
-      }
+        "normalized_channel": {"release": 1, "beta": 2, "nightly": 1},
+        "locale": {"en-US": 2, "de": 1, "ru": 1},
+        "app_version": {"57": 2, "56": 1, "58": 1},
     }
 
-    for grouping_field in ('normalized_channel', 'locale', 'app_version'):
+    for grouping_field in ("normalized_channel", "locale", "app_version"):
         counts = aggregate_data.groupBy(grouping_field).count().collect()
         for i in counts:
-            assert true_values[grouping_field][i[grouping_field]] == i['count']
+            assert true_values[grouping_field][i[grouping_field]] == i["count"]

--- a/tests/test_clientsdaily.py
+++ b/tests/test_clientsdaily.py
@@ -5,21 +5,22 @@ from mozetl.clientsdaily import rollup as cd
 
 
 EXPECTED_INTEGER_VALUES = {
-    'active_addons_count_mean': 3613,
-    'crashes_detected_content_sum': 9,
-    'first_paint_mean': 12802105,
-    'pings_aggregated_by_this_row': 1122,
-    'search_count_all_sum': 1043,
-    'scalar_parent_browser_engagement_unique_domains_count_max': 3160,
-    'scalar_parent_browser_engagement_unique_domains_count_mean': 2628
+    "active_addons_count_mean": 3613,
+    "crashes_detected_content_sum": 9,
+    "first_paint_mean": 12802105,
+    "pings_aggregated_by_this_row": 1122,
+    "search_count_all_sum": 1043,
+    "scalar_parent_browser_engagement_unique_domains_count_max": 3160,
+    "scalar_parent_browser_engagement_unique_domains_count_mean": 2628,
 }
 
 
 @pytest.fixture
 def main_summary(spark):
     root = os.path.dirname(__file__)
-    path = os.path.join(root, 'resources',
-                        'main_summary-late-may-1123-rows-anonymized.json')
+    path = os.path.join(
+        root, "resources", "main_summary-late-may-1123-rows-anonymized.json"
+    )
     frame = spark.read.json(path, MAIN_SUMMARY_SCHEMA)
     return frame
 
@@ -35,14 +36,14 @@ def clients_daily(main_summary_with_search):
 
 
 def test_extract_search_counts(main_summary_with_search):
-    row = main_summary_with_search.agg({'search_count_all': 'sum'}).collect()[0]
+    row = main_summary_with_search.agg({"search_count_all": "sum"}).collect()[0]
     total = list(row.asDict().values())[0]
-    assert total == EXPECTED_INTEGER_VALUES['search_count_all_sum']
+    assert total == EXPECTED_INTEGER_VALUES["search_count_all_sum"]
 
 
 def test_domains_count(main_summary_with_search):
-    unique_domains = 'scalar_parent_browser_engagement_unique_domains_count'
-    row = main_summary_with_search.agg({unique_domains: 'sum'}).collect()[0]
+    unique_domains = "scalar_parent_browser_engagement_unique_domains_count"
+    row = main_summary_with_search.agg({unique_domains: "sum"}).collect()[0]
     total = list(row.asDict().values())[0]
     assert total == 4402
 
@@ -50,11 +51,11 @@ def test_domains_count(main_summary_with_search):
 def test_to_profile_day_aggregates(clients_daily):
     # Sum up the means and sums as calculated over 1123 rows,
     # one of which is a duplicate.
-    aggd = dict([(k, 'sum') for k in EXPECTED_INTEGER_VALUES])
+    aggd = dict([(k, "sum") for k in EXPECTED_INTEGER_VALUES])
     result = clients_daily.agg(aggd).collect()[0]
 
     for k, expected in list(EXPECTED_INTEGER_VALUES.items()):
-        actual = int(result['sum({})'.format(k)])
+        actual = int(result["sum({})".format(k)])
         assert actual == expected
 
 
@@ -63,40 +64,55 @@ def test_profile_creation_date_fields(clients_daily):
     # See https://issues.apache.org/jira/browse/SPARK-17971
     # There are therefore three possible expected results, depending on
     # the TZ setting of the system on which the tests run.
-    expected_back = set([
-        u'2014-12-16', u'2016-09-07',
-        u'2016-05-12', u'2017-02-16',
-        u'2012-11-17', u'2013-09-08',
-        u'2017-02-12', u'2016-04-04',
-        u'2017-04-25', u'2015-06-17'
-    ])
-    expected_utc = set([
-        u'2014-12-17', u'2016-09-08',
-        u'2016-05-13', u'2017-02-17',
-        u'2012-11-18', u'2013-09-09',
-        u'2017-02-13', u'2016-04-05',
-        u'2017-04-26', u'2015-06-18'
-    ])
-    expected_forward = set([
-        u'2014-12-18', u'2016-09-09',
-        u'2016-05-14', u'2017-02-18',
-        u'2012-11-19', u'2013-09-10',
-        u'2017-02-14', u'2016-04-06',
-        u'2017-04-27', u'2015-06-19'
-    ])
+    expected_back = set(
+        [
+            u"2014-12-16",
+            u"2016-09-07",
+            u"2016-05-12",
+            u"2017-02-16",
+            u"2012-11-17",
+            u"2013-09-08",
+            u"2017-02-12",
+            u"2016-04-04",
+            u"2017-04-25",
+            u"2015-06-17",
+        ]
+    )
+    expected_utc = set(
+        [
+            u"2014-12-17",
+            u"2016-09-08",
+            u"2016-05-13",
+            u"2017-02-17",
+            u"2012-11-18",
+            u"2013-09-09",
+            u"2017-02-13",
+            u"2016-04-05",
+            u"2017-04-26",
+            u"2015-06-18",
+        ]
+    )
+    expected_forward = set(
+        [
+            u"2014-12-18",
+            u"2016-09-09",
+            u"2016-05-14",
+            u"2017-02-18",
+            u"2012-11-19",
+            u"2013-09-10",
+            u"2017-02-14",
+            u"2016-04-06",
+            u"2017-04-27",
+            u"2015-06-19",
+        ]
+    )
     ten_pcds = clients_daily.select("profile_creation_date").take(10)
     actual1 = set([list(r.asDict().values())[0][:10] for r in ten_pcds])
     assert actual1 in (expected_back, expected_utc, expected_forward)
 
-    expected2_back = [
-        378, 894, 261, 1361, 101, 1656, 415, 29, 703, 102
-    ]
-    expected2_utc = [
-        377, 893, 260, 1360, 100, 1655, 414, 28, 702, 101
-    ]
-    expected2_forward = [
-        376, 892, 259, 1359, 99, 1654, 413, 27, 701, 100
-    ]
+    expected2_back = [378, 894, 261, 1361, 101, 1656, 415, 29, 703, 102]
+    expected2_utc = [377, 893, 260, 1360, 100, 1655, 414, 28, 702, 101]
+    expected2_forward = [376, 892, 259, 1359, 99, 1654, 413, 27, 701, 100]
     ten_pdas = clients_daily.select("profile_age_in_days").take(10)
     actual2 = [list(r.asDict().values())[0] for r in ten_pdas]
     assert actual2 in (expected2_back, expected2_utc, expected2_forward)
@@ -122,8 +138,8 @@ def test_sessions_started_on_this_day_sorted(clients_daily):
 # Ensure that "first" aggregations skip null values
 def test_first_skips_nulls(clients_daily):
     filter_template = "client_id = '{}' and activity_date = '{}'"
-    client = '0c495fce-5fbf-4f4a-ac03-2dedcef0a8d0'
-    day = '2017-05-25'
+    client = "0c495fce-5fbf-4f4a-ac03-2dedcef0a8d0"
+    day = "2017-05-25"
     filter_clause = filter_template.format(client, day)
     null_to_false = clients_daily.where(filter_clause).select("sync_configured").first()
     expected = False

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -3,55 +3,64 @@ from mozetl.testpilot.containers import transform_testpilot_pings
 
 
 def create_ping_rdd(sc, payload):
-    return sc.parallelize([
-        {'payload': {
-            'test': '@testpilot-containers',
-            'other-ignored-field': 'who cares',
-            'payload': payload
-        }}
-    ])
+    return sc.parallelize(
+        [
+            {
+                "payload": {
+                    "test": "@testpilot-containers",
+                    "other-ignored-field": "who cares",
+                    "payload": payload,
+                }
+            }
+        ]
+    )
 
 
 def create_row(overrides):
-    keys = ["uuid", "userContextId", "clickedContainerTabCount", "eventSource",
-            "event", "hiddenContainersCount", "shownContainersCount",
-            "totalContainersCount", "totalContainerTabsCount",
-            "totalNonContainerTabsCount", "pageRequestCount", "test"]
+    keys = [
+        "uuid",
+        "userContextId",
+        "clickedContainerTabCount",
+        "eventSource",
+        "event",
+        "hiddenContainersCount",
+        "shownContainersCount",
+        "totalContainersCount",
+        "totalContainerTabsCount",
+        "totalNonContainerTabsCount",
+        "pageRequestCount",
+        "test",
+    ]
 
-    overrides['test'] = '@testpilot-containers'
+    overrides["test"] = "@testpilot-containers"
 
     return {key: overrides.get(key, None) for key in keys}
 
 
 def test_open_container_ping(row_to_dict, spark_context):
     input_payload = {
-        'uuid': 'a',
-        'userContextId': 10,
-        'clickedContainerTabCount': 20,
-        'event': 'open-tab',
-        'eventSource': 'tab-bar'
+        "uuid": "a",
+        "userContextId": 10,
+        "clickedContainerTabCount": 20,
+        "event": "open-tab",
+        "eventSource": "tab-bar",
     }
 
     result_payload = input_payload
-    result_payload['userContextId'] = '10'
+    result_payload["userContextId"] = "10"
 
     actual = transform_testpilot_pings(
-        SQLContext(spark_context),
-        create_ping_rdd(spark_context, input_payload)
+        SQLContext(spark_context), create_ping_rdd(spark_context, input_payload)
     ).take(1)[0]
 
     assert row_to_dict(actual) == create_row(result_payload)
 
 
 def test_edit_container_ping(row_to_dict, spark_context):
-    input_payload = {
-        'uuid': 'b',
-        'event': 'edit-containers'
-    }
+    input_payload = {"uuid": "b", "event": "edit-containers"}
 
     actual = transform_testpilot_pings(
-        SQLContext(spark_context),
-        create_ping_rdd(spark_context, input_payload)
+        SQLContext(spark_context), create_ping_rdd(spark_context, input_payload)
     ).take(1)[0]
 
     assert row_to_dict(actual) == create_row(input_payload)
@@ -59,18 +68,17 @@ def test_edit_container_ping(row_to_dict, spark_context):
 
 def test_hide_container_ping(row_to_dict, spark_context):
     input_payload = {
-        'uuid': 'a',
-        'userContextId': 'firefox-default',
-        'clickedContainerTabCount': 5,
-        'event': "hide-tabs",
-        'hiddenContainersCount': 2,
-        'shownContainersCount': 3,
-        'totalContainersCount': 5,
+        "uuid": "a",
+        "userContextId": "firefox-default",
+        "clickedContainerTabCount": 5,
+        "event": "hide-tabs",
+        "hiddenContainersCount": 2,
+        "shownContainersCount": 3,
+        "totalContainersCount": 5,
     }
 
     actual = transform_testpilot_pings(
-        SQLContext(spark_context),
-        create_ping_rdd(spark_context, input_payload)
+        SQLContext(spark_context), create_ping_rdd(spark_context, input_payload)
     ).take(1)[0]
 
     assert row_to_dict(actual) == create_row(input_payload)
@@ -78,15 +86,14 @@ def test_hide_container_ping(row_to_dict, spark_context):
 
 def test_close_container_tab_ping(row_to_dict, spark_context):
     input_payload = {
-        "uuid": 'a',
-        "userContextId": 'firefox-default',
+        "uuid": "a",
+        "userContextId": "firefox-default",
         "event": "page-requests-completed-per-tab",
         "pageRequestCount": 2,
     }
 
     actual = transform_testpilot_pings(
-        SQLContext(spark_context),
-        create_ping_rdd(spark_context, input_payload)
+        SQLContext(spark_context), create_ping_rdd(spark_context, input_payload)
     ).take(1)[0]
 
     assert row_to_dict(actual) == create_row(input_payload)

--- a/tests/test_experimentsdaily.py
+++ b/tests/test_experimentsdaily.py
@@ -5,24 +5,22 @@ from pyspark.sql.types import StructType
 
 
 EXPECTED_INTEGER_VALUES = {
-    'active_addons_count_mean': 1227,
-    'crashes_detected_content_sum': 7,
-    'first_paint_mean': 816743,
-    'pings_aggregated_by_this_row': 98,
-    'search_count_all_sum': 49
+    "active_addons_count_mean": 1227,
+    "crashes_detected_content_sum": 7,
+    "first_paint_mean": 816743,
+    "pings_aggregated_by_this_row": 98,
+    "search_count_all_sum": 49,
 }
 
 
 @pytest.fixture
 def sample_data(spark):
     root = os.path.dirname(__file__)
-    schema_path = os.path.join(root, 'resources',
-                               'experiments-summary.schema.json')
+    schema_path = os.path.join(root, "resources", "experiments-summary.schema.json")
     with open(schema_path) as f:
         d = json.load(f)
         schema = StructType.fromJson(d)
-    rows_path = os.path.join(root, 'resources',
-                             'experiments-summary-190-rows.json')
+    rows_path = os.path.join(root, "resources", "experiments-summary-190-rows.json")
     # FAILFAST causes us to abort early if the data doesn't match
     # the given schema. Without this there was as very annoying
     # problem where dataframe.collect() would return an empty set.
@@ -33,6 +31,7 @@ def sample_data(spark):
 def test_rollup(sample_data):
     from mozetl.experimentsdaily import rollup
     from mozetl.clientsdaily.rollup import extract_search_counts
+
     assert sample_data.count() == 100
 
     client_id_count = sample_data.where("client_id is not null").count()
@@ -48,10 +47,12 @@ def test_rollup(sample_data):
     #  1a3c4318-a5d9-42a4-9cae-7a68eec6e1eb
     assert searches_frame.count() == 98
 
-    filtered = searches_frame.where("subsession_start_date LIKE '2017-09-08%'") \
-                             .where("experiment_id = 'pref-flip-searchcomp1-pref3-1390584'") \
-                             .where("search_count_all > 0") \
-                             .orderBy("client_id")
+    filtered = (
+        searches_frame.where("subsession_start_date LIKE '2017-09-08%'")
+        .where("experiment_id = 'pref-flip-searchcomp1-pref3-1390584'")
+        .where("search_count_all > 0")
+        .orderBy("client_id")
+    )
 
     assert filtered.count() == 4
     f_collected = filtered.collect()

--- a/tests/test_landfill_sampler.py
+++ b/tests/test_landfill_sampler.py
@@ -9,28 +9,29 @@ from mozetl.landfill import sampler
 @pytest.fixture
 def sample_document():
     return {
-        'content': {"payload": {"foo": "bar"}},
-        'meta': {
-            u'Content-Length': u'7094',
-            u'Date': u'Sun, 19 Aug 2018 15:08:00 GMT',
-            u'Host': u'incoming.telemetry.mozilla.org',
-            'Hostname': u'ip-1.1.1.1',
-            'Timestamp': 1534691279765301222,
-            'Type': u'telemetry-raw',
-            u'User-Agent': u'pingsender/1.0',
-            u'X-Forwarded-For': u'127.0.0.1',
-            u'X-PingSender-Version': u'1.0',
-            u'args': u'v=4',
-            u'protocol': u'HTTP/1.1',
-            u'remote_addr': u'1.1.1.1',
-            u'uri': u'/submit/telemetry/doc-id/main/Firefox/61.0.2/release/20180807170231'
-        }
+        "content": {"payload": {"foo": "bar"}},
+        "meta": {
+            u"Content-Length": u"7094",
+            u"Date": u"Sun, 19 Aug 2018 15:08:00 GMT",
+            u"Host": u"incoming.telemetry.mozilla.org",
+            "Hostname": u"ip-1.1.1.1",
+            "Timestamp": 1534691279765301222,
+            "Type": u"telemetry-raw",
+            u"User-Agent": u"pingsender/1.0",
+            u"X-Forwarded-For": u"127.0.0.1",
+            u"X-PingSender-Version": u"1.0",
+            u"args": u"v=4",
+            u"protocol": u"HTTP/1.1",
+            u"remote_addr": u"1.1.1.1",
+            u"uri": u"/submit/telemetry/doc-id/main/Firefox/61.0.2/release/20180807170231",
+        },
     }
 
 
 @pytest.fixture
 def generate_data(spark, sample_document):
     """Update the meta-field using provided snippets."""
+
     def _update_meta(snippet):
         doc = deepcopy(sample_document)
         doc["meta"].update(snippet)
@@ -73,9 +74,9 @@ def test_transform_contains_at_most_n_documents(generate_data):
     n = 3
     params = [
         # (namespace, doc_type, doc_version, n_documents)
-        ("custom", "main", 4, n+1),
-        ("custom", "main", 3, n-1),
-        ("custom", "crash", 4, n)
+        ("custom", "main", 4, n + 1),
+        ("custom", "main", 3, n - 1),
+        ("custom", "crash", 4, n),
     ]
     snippets = []
     for ns, dt, dv, n in params:
@@ -86,8 +87,7 @@ def test_transform_contains_at_most_n_documents(generate_data):
 
     # assert there are at most n documents
     res = (
-        df
-        .groupBy("namespace", "doc_type", "doc_version")
+        df.groupBy("namespace", "doc_type", "doc_version")
         .agg(F.count("*").alias("n_documents"))
         .withColumn("at_most_n", F.col("n_documents") <= n)
         .collect()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,14 +4,11 @@ from mozetl import transform_pings
 
 # Generate some data
 def create_row(client_id, os):
-    return {'clientId': client_id, 'environment/system/os/name': os}
+    return {"clientId": client_id, "environment/system/os/name": os}
 
 
 def simple_data():
-    raw_data = [('a', 'windows'),
-                ('b', 'darwin'),
-                ('c', 'linux'),
-                ('d', 'windows')]
+    raw_data = [("a", "windows"), ("b", "darwin"), ("c", "linux"), ("d", "windows")]
 
     return [create_row(*raw) for raw in raw_data]
 
@@ -29,18 +26,19 @@ def simple_rdd(spark_context):
 def duplicate_rdd(spark_context):
     return spark_context.parallelize(duplicate_data())
 
+
 # Tests
 
 
 def test_simple_transform(simple_rdd):
     actual = transform_pings(simple_rdd)
-    expected = {'windows': 2, 'darwin': 1, 'linux': 1}
+    expected = {"windows": 2, "darwin": 1, "linux": 1}
 
     assert actual == expected
 
 
 def test_duplicate_transform(duplicate_rdd):
     actual = transform_pings(duplicate_rdd)
-    expected = {'windows': 2, 'darwin': 1, 'linux': 1}
+    expected = {"windows": 2, "darwin": 1, "linux": 1}
 
     assert actual == expected

--- a/tests/test_maudau.py
+++ b/tests/test_maudau.py
@@ -6,41 +6,42 @@ from pyspark.sql.types import StructField, StructType, StringType
 from mozetl.maudau import maudau as M
 from mozetl.utils import format_as_submission_date
 
-NARROW_SCHEMA = StructType([
-    StructField("client_id",             StringType(),  True),
-    StructField("submission_date_s3",    StringType(),  False),
-    StructField("subsession_start_date", StringType(), True)])
+NARROW_SCHEMA = StructType(
+    [
+        StructField("client_id", StringType(), True),
+        StructField("submission_date_s3", StringType(), False),
+        StructField("subsession_start_date", StringType(), True),
+    ]
+)
 
 generated = format_as_submission_date(DT.date.today())
 
 
 @pytest.fixture
 def make_frame(spark):
-    cols = ['client_id', 'subsession_start_date', 'submission_date_s3']
+    cols = ["client_id", "subsession_start_date", "submission_date_s3"]
     values = [
-        ('a', '2017-05-01', '20170508'),
-        ('b', '2017-05-01', '20170501'),
-        ('c', '2017-05-01', '20170510'),
-        ('a', '2017-05-02', '20170503'),
-        ('b', '2017-05-03', '20170503'),
-        ('b', '2017-05-04', '20170511'),
-        ('a', '2017-05-05', '20170507'),
+        ("a", "2017-05-01", "20170508"),
+        ("b", "2017-05-01", "20170501"),
+        ("c", "2017-05-01", "20170510"),
+        ("a", "2017-05-02", "20170503"),
+        ("b", "2017-05-03", "20170503"),
+        ("b", "2017-05-04", "20170511"),
+        ("a", "2017-05-05", "20170507"),
     ]
     return spark.createDataFrame(
-        [dict(list(zip(cols, tup))) for tup in values],
-        schema=NARROW_SCHEMA)
+        [dict(list(zip(cols, tup))) for tup in values], schema=NARROW_SCHEMA
+    )
 
 
 def test_generate_counts(spark):
     frame = make_frame(spark)
     since = DT.date(2017, 5, 1)
     counts = M.generate_counts(frame, since, DT.date(2017, 5, 6))
-    expected = {'day': '20170505', 'dau': 1, 'mau': 3,
-                'generated_on': generated}
+    expected = {"day": "20170505", "dau": 1, "mau": 3, "generated_on": generated}
     assert counts[-1] == expected, str(counts[-1])
     counts2 = M.generate_counts(frame, since, DT.date(2017, 5, 4))
-    expected2 = {'day': '20170503', 'dau': 1, 'mau': 3,
-                 'generated_on': generated}
+    expected2 = {"day": "20170503", "dau": 1, "mau": 3, "generated_on": generated}
     assert counts2[-1] == expected2, str(counts2[-1])
 
 
@@ -49,20 +50,21 @@ def test_parse_last_rollup():
     cwd = os.getcwd()
     basename = "engagement_ratio.csv"
     # Block1: test that we keep data > 10 days but regenerate newer data.
-    data = '\r\n'.join([
-        "day,dau,mau,generated_on",
-        "20170503,1,3,20170620",
-        "20170504,1,3,20170620",
-        ""
-        ])
+    data = "\r\n".join(
+        [
+            "day,dau,mau,generated_on",
+            "20170503,1,3,20170620",
+            "20170504,1,3,20170620",
+            "",
+        ]
+    )
     expected = (
         DT.date(2017, 5, 4),
-        [{'dau': '1', 'mau': '3', 'day': '20170503',
-          'generated_on': '20170620'}]
+        [{"dau": "1", "mau": "3", "day": "20170503", "generated_on": "20170620"}],
     )
     try:
         os.chdir(tempdir)
-        with open(basename, 'w') as f:
+        with open(basename, "w") as f:
             f.write(data)
         actual = M.parse_last_rollup(basename, DT.date(2017, 5, 14))
         assert actual == expected
@@ -70,21 +72,22 @@ def test_parse_last_rollup():
         os.chdir(cwd)
     # Block2: test that we regenerate old data if we hit a gap.
     # Here, 2017-05-02 is missing.
-    data2 = '\r\n'.join([
-        "day,dau,mau,generated_on",
-        "20170501,1,3,20170620",
-        "20170503,1,3,20170620",
-        "20170504,1,3,20170620",
-        ""
-        ])
+    data2 = "\r\n".join(
+        [
+            "day,dau,mau,generated_on",
+            "20170501,1,3,20170620",
+            "20170503,1,3,20170620",
+            "20170504,1,3,20170620",
+            "",
+        ]
+    )
     expected2 = (
         DT.date(2017, 5, 2),
-        [{'dau': '1', 'mau': '3', 'day': '20170501',
-          'generated_on': '20170620'}]
+        [{"dau": "1", "mau": "3", "day": "20170501", "generated_on": "20170620"}],
     )
     try:
         os.chdir(tempdir)
-        with open(basename, 'w') as f:
+        with open(basename, "w") as f:
             f.write(data2)
         actual2 = M.parse_last_rollup(basename, DT.date(2017, 5, 14))
         assert actual2 == expected2
@@ -96,17 +99,17 @@ def test_write_locally():
     tempdir = tempfile.mkdtemp()
     cwd = os.getcwd()
     results = [
-        {'day': '20170503', 'dau': 1, 'mau': 3,
-         'generated_on': generated},
-        {'day': '20170504', 'dau': 1, 'mau': 3,
-         'generated_on': generated}
+        {"day": "20170503", "dau": 1, "mau": 3, "generated_on": generated},
+        {"day": "20170504", "dau": 1, "mau": 3, "generated_on": generated},
     ]
-    expected = '\r\n'.join([
-        "day,dau,mau,generated_on",
-        "20170503,1,3,{}".format(generated),
-        "20170504,1,3,{}".format(generated),
-        ""
-        ])
+    expected = "\r\n".join(
+        [
+            "day,dau,mau,generated_on",
+            "20170503,1,3,{}".format(generated),
+            "20170504,1,3,{}".format(generated),
+            "",
+        ]
+    )
     basename = "engagement_ratio.{}.csv".format(generated)
     try:
         os.chdir(tempdir)

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -6,7 +6,7 @@ from mozetl.testpilot.pulse import transform_pings
 
 
 def create_row():
-    with open('tests/pulse_ping.json') as infile:
+    with open("tests/pulse_ping.json") as infile:
         return json.load(infile)
 
 
@@ -18,67 +18,78 @@ def simple_rdd(spark_context):
 def test_simple_transform(row_to_dict, simple_rdd, spark_context):
     actual = transform_pings(SQLContext(spark_context), simple_rdd).take(1)[0]
 
-    empty_request_keys = ["sub_frame", "stylesheet", "script", "image",
-                          "object", "xmlhttprequest", "xbl", "xslt", "ping",
-                          "beacon", "xml_dtd", "font", "media", "websocket",
-                          "csp_report", "imageset", "web_manifest", "other"]
+    empty_request_keys = [
+        "sub_frame",
+        "stylesheet",
+        "script",
+        "image",
+        "object",
+        "xmlhttprequest",
+        "xbl",
+        "xslt",
+        "ping",
+        "beacon",
+        "xml_dtd",
+        "font",
+        "media",
+        "websocket",
+        "csp_report",
+        "imageset",
+        "web_manifest",
+        "other",
+    ]
     empty_request = Row(cached=None, cdn=None, num=None, time=None)
 
     requests = dict(
-        [(key, empty_request) for key in empty_request_keys] + [
-            ("all", Row(
-                num=12,
-                time=4978,
-                cached=0.08333333333333333,
-                cdn=0
-            )),
-            ("main_frame", Row(
-                num=1,
-                time=726,
-                cached=0,
-                cdn=0
-            ))
+        [(key, empty_request) for key in empty_request_keys]
+        + [
+            ("all", Row(num=12, time=4978, cached=0.08333333333333333, cdn=0)),
+            ("main_frame", Row(num=1, time=726, cached=0, cdn=0)),
         ]
     )
 
     expected = {
-        'method': None,
-        'id': u'19e0cf07-8145-4666-938d-811397db85dc',
-        'type': None,
-        'object': None,
-        'category': None,
-        'variant': None,
-        'details': u'test',
-        'sentiment': 5,
-        'reason': u'like',
-        'adBlocker': True,
-        'addons': [u'pulse@mozilla.com', u'inspector@mozilla.org',
-                   u'DevPrefs@jetpack', u'@min-vid'],
-        'channel': u'developer',
-        'hostname': u'github.com',
-        'language': u'en-US',
-        'openTabs': 7,
-        'openWindows': 2,
-        'platform': u'darwin',
-        'protocol': u'https:',
-        'telemetryId': u'549a6456-32c2-e048-8310-d22ccfa9fee1',
-        'timerContentLoaded': 589,
-        'timerFirstInteraction': None,
-        'timerFirstPaint': 41,
-        'timerWindowLoad': 1005,
-        'inner_timestamp': 1487862372503,
-        'fx_version': None,
-        'creation_date': None,
-        'test': u'pulse@mozilla.com',
-        'variants': None,
-        'timestamp': 76543,
-        'version': u'1.0.2',
-        'requests': requests,
-        'disconnectRequests': 1,
-        'consoleErrors': 0,
-        'e10sStatus': 1,
-        'e10sProcessCount': 4,
-        'trackingProtection': False,
+        "method": None,
+        "id": u"19e0cf07-8145-4666-938d-811397db85dc",
+        "type": None,
+        "object": None,
+        "category": None,
+        "variant": None,
+        "details": u"test",
+        "sentiment": 5,
+        "reason": u"like",
+        "adBlocker": True,
+        "addons": [
+            u"pulse@mozilla.com",
+            u"inspector@mozilla.org",
+            u"DevPrefs@jetpack",
+            u"@min-vid",
+        ],
+        "channel": u"developer",
+        "hostname": u"github.com",
+        "language": u"en-US",
+        "openTabs": 7,
+        "openWindows": 2,
+        "platform": u"darwin",
+        "protocol": u"https:",
+        "telemetryId": u"549a6456-32c2-e048-8310-d22ccfa9fee1",
+        "timerContentLoaded": 589,
+        "timerFirstInteraction": None,
+        "timerFirstPaint": 41,
+        "timerWindowLoad": 1005,
+        "inner_timestamp": 1487862372503,
+        "fx_version": None,
+        "creation_date": None,
+        "test": u"pulse@mozilla.com",
+        "variants": None,
+        "timestamp": 76543,
+        "version": u"1.0.2",
+        "requests": requests,
+        "disconnectRequests": 1,
+        "consoleErrors": 0,
+        "e10sStatus": 1,
+        "e10sProcessCount": 4,
+        "trackingProtection": False,
     }
 
     assert row_to_dict(actual, recursive=False) == expected

--- a/tests/test_search_aggregates.py
+++ b/tests/test_search_aggregates.py
@@ -2,23 +2,29 @@ import functools
 import pytest
 from collections import namedtuple
 from pyspark.sql.types import (
-    StructField, ArrayType, BooleanType, StringType, LongType, StructType, DoubleType
+    StructField,
+    ArrayType,
+    BooleanType,
+    StringType,
+    LongType,
+    StructType,
+    DoubleType,
 )
 from mozetl.search.aggregates import (
-    search_aggregates, search_clients_daily,
-    explode_search_counts, add_derived_columns, MAX_CLIENT_SEARCH_COUNT
+    search_aggregates,
+    search_clients_daily,
+    explode_search_counts,
+    add_derived_columns,
+    MAX_CLIENT_SEARCH_COUNT,
 )
 
 
 # Some boilerplate to help define example dataframes for testing
 
 # A helper class for declaratively creating dataframe factories
-dataframe_field = namedtuple('dataframe_field', [
-    'name',
-    'default_value',
-    'type',
-    'nullable',
-])
+dataframe_field = namedtuple(
+    "dataframe_field", ["name", "default_value", "type", "nullable"]
+)
 
 
 def to_field(field_tuple):
@@ -28,10 +34,9 @@ def to_field(field_tuple):
 
 def get_dataframe_factory_config(fields):
     """Parse a list of dataframe_fields to a schema and set of default values"""
-    schema = StructType([
-        StructField(field.name, field.type, field.nullable)
-        for field in fields
-    ])
+    schema = StructType(
+        [StructField(field.name, field.type, field.nullable) for field in fields]
+    )
     default_sample = {field.name: field.default_value for field in fields}
 
     return schema, default_sample
@@ -43,125 +48,109 @@ def define_dataframe_factory(dataframe_factory):
         """Create a dataframe_factory from a set of field configs"""
         schema, default_sample = get_dataframe_factory_config(fields)
         return functools.partial(
-            dataframe_factory.create_dataframe,
-            base=default_sample,
-            schema=schema
+            dataframe_factory.create_dataframe, base=default_sample, schema=schema
         )
 
     return partial
 
 
 # Boilerplate for generating example main_summary tables
-def generate_search_count(engine='google', source='urlbar', count=4):
-    return {
-        'engine': engine,
-        'source': source,
-        'count':  count,
-    }
+def generate_search_count(engine="google", source="urlbar", count=4):
+    return {"engine": engine, "source": source, "count": count}
 
 
-addons_type = ArrayType(StructType([
-    StructField('addon_id', StringType(), False),
-    StructField('blocklisted', BooleanType(), True),
-    StructField('name', StringType(), True),
-    StructField('user_disabled', BooleanType(), True),
-    StructField('app_disabled', BooleanType(), True),
-    StructField('version', StringType(), True),
-    StructField('scope', LongType(), True),
-    StructField('type', StringType(), True),
-    StructField('foreign_install', BooleanType(), True),
-    StructField('has_binary_components', BooleanType(), True),
-    StructField('install_day', LongType(), True),
-    StructField('update_day', LongType(), True),
-    StructField('signed_state', LongType(), True),
-    StructField('is_system', BooleanType(), True),
-    StructField('is_web_extension', BooleanType(), True),
-    StructField('multiprocess_compatible', BooleanType(), True),
-]))
+addons_type = ArrayType(
+    StructType(
+        [
+            StructField("addon_id", StringType(), False),
+            StructField("blocklisted", BooleanType(), True),
+            StructField("name", StringType(), True),
+            StructField("user_disabled", BooleanType(), True),
+            StructField("app_disabled", BooleanType(), True),
+            StructField("version", StringType(), True),
+            StructField("scope", LongType(), True),
+            StructField("type", StringType(), True),
+            StructField("foreign_install", BooleanType(), True),
+            StructField("has_binary_components", BooleanType(), True),
+            StructField("install_day", LongType(), True),
+            StructField("update_day", LongType(), True),
+            StructField("signed_state", LongType(), True),
+            StructField("is_system", BooleanType(), True),
+            StructField("is_web_extension", BooleanType(), True),
+            StructField("multiprocess_compatible", BooleanType(), True),
+        ]
+    )
+)
 
 
 def generate_addon(addon_id, name, version):
-    return {
-        'addon_id': addon_id,
-        'name': name,
-        'version': version,
-    }
+    return {"addon_id": addon_id, "name": name, "version": version}
 
 
 active_addons = [
-    generate_addon('random@mozilla.com', 'random', '0.1'),
-    generate_addon(
-        'followonsearch@mozilla.com',
-        'Follow-on Search Telemetry',
-        '0.9.5'
-    )
+    generate_addon("random@mozilla.com", "random", "0.1"),
+    generate_addon("followonsearch@mozilla.com", "Follow-on Search Telemetry", "0.9.5"),
 ]
 
 
-search_type = ArrayType(StructType([
-    StructField('engine', StringType(), False),
-    StructField('source', StringType(), False),
-    StructField('count', LongType(), False),
-]))
+search_type = ArrayType(
+    StructType(
+        [
+            StructField("engine", StringType(), False),
+            StructField("source", StringType(), False),
+            StructField("count", LongType(), False),
+        ]
+    )
+)
 
 
 main_summary_schema = [
-    ('client_id', 'a', StringType(), False),
-    ('sample_id', '42', StringType(), False),
-    ('submission_date', '20170101', StringType(), False),
-    ('os', 'windows', StringType(), True),
-    ('channel', 'release', StringType(), True),
-    ('country', 'DE', StringType(), True),
-    ('locale', 'de', StringType(), True),
-    ('search_cohort', None, StringType(), True),
-    ('app_version', '54.0.1', StringType(), True),
-    ('distribution_id', None, StringType(), True),
-    ('subsession_counter', 1, LongType(), True),
-    ('search_counts', [generate_search_count()], search_type, True),
-    ('active_addons', active_addons, addons_type, True),
+    ("client_id", "a", StringType(), False),
+    ("sample_id", "42", StringType(), False),
+    ("submission_date", "20170101", StringType(), False),
+    ("os", "windows", StringType(), True),
+    ("channel", "release", StringType(), True),
+    ("country", "DE", StringType(), True),
+    ("locale", "de", StringType(), True),
+    ("search_cohort", None, StringType(), True),
+    ("app_version", "54.0.1", StringType(), True),
+    ("distribution_id", None, StringType(), True),
+    ("subsession_counter", 1, LongType(), True),
+    ("search_counts", [generate_search_count()], search_type, True),
+    ("active_addons", active_addons, addons_type, True),
     # 30 minutes in active_ticks (30min * 60sec/min / 5sec/tick)
-    ('active_ticks', 360, LongType(), True),
-    (
-        'scalar_parent_browser_engagement_tab_open_event_count',
-        5,
-        LongType(),
-        True
-    ),
-    (
-        'scalar_parent_browser_engagement_max_concurrent_tab_count',
-        10,
-        LongType(),
-        True
-    ),
-    ('subsession_start_date', '2017-01-01 10:00', StringType(), False),
+    ("active_ticks", 360, LongType(), True),
+    ("scalar_parent_browser_engagement_tab_open_event_count", 5, LongType(), True),
+    ("scalar_parent_browser_engagement_max_concurrent_tab_count", 10, LongType(), True),
+    ("subsession_start_date", "2017-01-01 10:00", StringType(), False),
     # One hour per ping
-    ('subsession_length', 60 * 60, LongType(), False),
+    ("subsession_length", 60 * 60, LongType(), False),
     # Roughly 2016-01-01
-    ('profile_creation_date', 16801, LongType(), False),
-    ('default_search_engine', 'google', StringType(), False),
+    ("profile_creation_date", 16801, LongType(), False),
+    ("default_search_engine", "google", StringType(), False),
     (
-        'default_search_engine_data_load_path',
-        'jar:[app]/omni.ja!browser/google.xml',
+        "default_search_engine_data_load_path",
+        "jar:[app]/omni.ja!browser/google.xml",
         StringType(),
-        False
+        False,
     ),
     (
-        'default_search_engine_data_submission_url',
-        'https://www.google.com/search?q=&ie=utf-8&oe=utf-8&client=firefox-b',
+        "default_search_engine_data_submission_url",
+        "https://www.google.com/search?q=&ie=utf-8&oe=utf-8&client=firefox-b",
         StringType(),
-        False
+        False,
     ),
 ]
 
-exploded_schema = [x for x in main_summary_schema if x[0] != 'search_counts'] + [
-    ('engine', 'google', StringType(), False),
-    ('source', 'urlbar', StringType(), False),
-    ('count', 4, LongType(), False),
+exploded_schema = [x for x in main_summary_schema if x[0] != "search_counts"] + [
+    ("engine", "google", StringType(), False),
+    ("source", "urlbar", StringType(), False),
+    ("count", 4, LongType(), False),
 ]
 
 derived_schema = exploded_schema + [
-    ('type', 'chrome-sap', StringType(), False),
-    ('addon_version', '0.9.5', StringType(), False),
+    ("type", "chrome-sap", StringType(), False),
+    ("addon_version", "0.9.5", StringType(), False),
 ]
 
 
@@ -174,21 +163,22 @@ def generate_main_summary_data(define_dataframe_factory):
 def main_summary(generate_main_summary_data):
     return generate_main_summary_data(
         [
+            {"client_id": "b", "country": "US"},
+            {"app_version": "52.0.3"},
+            {"distribution_id": "totally not null"},
             {
-                'client_id': 'b',
-                'country': 'US',
+                "search_counts": [
+                    generate_search_count(engine="bing"),
+                    generate_search_count(engine="yahoo"),
+                ]
             },
-            {'app_version': '52.0.3'},
-            {'distribution_id': 'totally not null'},
-            {'search_counts': [
-                generate_search_count(engine='bing'),
-                generate_search_count(engine='yahoo'),
-            ]}
-        ] +
+        ]
+        +
         # Some duplicate default rows to test aggregation
-        [{}] * 5 +
+        [{}] * 5
+        +
         # Client with no searches
-        [{'client_id': 'c', 'search_counts': None}]
+        [{"client_id": "c", "search_counts": None}]
     )
 
 
@@ -196,10 +186,12 @@ def main_summary(generate_main_summary_data):
 def simple_main_summary(generate_main_summary_data):
     return generate_main_summary_data(
         [
-            {'search_counts': [
-                generate_search_count(engine='bing'),
-                generate_search_count(engine='yahoo'),
-            ]}
+            {
+                "search_counts": [
+                    generate_search_count(engine="bing"),
+                    generate_search_count(engine="yahoo"),
+                ]
+            }
         ]
     )
 
@@ -211,23 +203,22 @@ def generate_exploded_data(define_dataframe_factory):
 
 @pytest.fixture()
 def exploded_simple_main_summary(generate_exploded_data):
-    return generate_exploded_data([
-        {'engine': 'yahoo'},
-        {'engine': 'bing'},
-    ])
+    return generate_exploded_data([{"engine": "yahoo"}, {"engine": "bing"}])
 
 
 @pytest.fixture()
 def exploded_data_for_derived_cols(generate_exploded_data):
-    return generate_exploded_data([
-        {'source': 'sap:urlbar:SomeCodeHere'},
-        {'source': 'follow-on:urlbar:SomeCodeHere'},
-        {'source': 'in-content:sap:SomeCodeHere'},
-        {'source': 'in-content:sap-follow-on:SomeCodeHere'},
-        {'source': 'in-content:organic:something'},
-        {'source': 'unknowngarbagestring'},
-        {'source': 'urlbar'},
-    ])
+    return generate_exploded_data(
+        [
+            {"source": "sap:urlbar:SomeCodeHere"},
+            {"source": "follow-on:urlbar:SomeCodeHere"},
+            {"source": "in-content:sap:SomeCodeHere"},
+            {"source": "in-content:sap-follow-on:SomeCodeHere"},
+            {"source": "in-content:organic:something"},
+            {"source": "unknowngarbagestring"},
+            {"source": "urlbar"},
+        ]
+    )
 
 
 @pytest.fixture()
@@ -235,187 +226,201 @@ def derived_columns(define_dataframe_factory):
     # template for the expected results
     factory = define_dataframe_factory(list(map(to_field, derived_schema)))
 
-    return factory([
-        {'source': 'sap:urlbar:SomeCodeHere',
-         'type': 'tagged-sap'},
-        {'source': 'follow-on:urlbar:SomeCodeHere',
-         'type': 'tagged-follow-on'},
-        {'source': 'in-content:sap:SomeCodeHere',
-         'type': 'tagged-sap'},
-        {'source': 'in-content:sap-follow-on:SomeCodeHere',
-         'type': 'tagged-follow-on'},
-        {'source': 'in-content:organic:something',
-         'type': 'organic'},
-        {'source': 'unknowngarbagestring',
-         'type': 'unknown'},
-        {'source': 'urlbar',
-         'type': 'sap'},
-    ])
+    return factory(
+        [
+            {"source": "sap:urlbar:SomeCodeHere", "type": "tagged-sap"},
+            {"source": "follow-on:urlbar:SomeCodeHere", "type": "tagged-follow-on"},
+            {"source": "in-content:sap:SomeCodeHere", "type": "tagged-sap"},
+            {
+                "source": "in-content:sap-follow-on:SomeCodeHere",
+                "type": "tagged-follow-on",
+            },
+            {"source": "in-content:organic:something", "type": "organic"},
+            {"source": "unknowngarbagestring", "type": "unknown"},
+            {"source": "urlbar", "type": "sap"},
+        ]
+    )
 
 
 @pytest.fixture()
 def expected_search_dashboard_data(define_dataframe_factory):
     # template for the expected results
-    factory = define_dataframe_factory(list(map(to_field, [
-        ('submission_date', '20170101', StringType(), False),
-        ('country', 'DE', StringType(), True),
-        ('locale', 'de', StringType(), True),
-        ('search_cohort', None, StringType(), True),
-        ('app_version', '54.0.1', StringType(), True),
-        ('distribution_id', None, StringType(), True),
-        ('addon_version', '0.9.5', StringType(), False),
-        ('default_search_engine', 'google', StringType(), False),
-        ('engine', 'google', StringType(), False),
-        ('source', 'urlbar', StringType(), False),
-        ('tagged-sap', None, LongType(), True),
-        ('tagged-follow-on', None, LongType(), True),
-        ('tagged_sap', None, LongType(), True),
-        ('tagged_follow_on', None, LongType(), True),
-        ('sap', 4, LongType(), True),
-        ('organic', None, LongType(), True),
-        ('unknown', None, LongType(), True),
-        ('client_count', 1, LongType(), True),
-    ])))
+    factory = define_dataframe_factory(
+        list(
+            map(
+                to_field,
+                [
+                    ("submission_date", "20170101", StringType(), False),
+                    ("country", "DE", StringType(), True),
+                    ("locale", "de", StringType(), True),
+                    ("search_cohort", None, StringType(), True),
+                    ("app_version", "54.0.1", StringType(), True),
+                    ("distribution_id", None, StringType(), True),
+                    ("addon_version", "0.9.5", StringType(), False),
+                    ("default_search_engine", "google", StringType(), False),
+                    ("engine", "google", StringType(), False),
+                    ("source", "urlbar", StringType(), False),
+                    ("tagged-sap", None, LongType(), True),
+                    ("tagged-follow-on", None, LongType(), True),
+                    ("tagged_sap", None, LongType(), True),
+                    ("tagged_follow_on", None, LongType(), True),
+                    ("sap", 4, LongType(), True),
+                    ("organic", None, LongType(), True),
+                    ("unknown", None, LongType(), True),
+                    ("client_count", 1, LongType(), True),
+                ],
+            )
+        )
+    )
 
-    return factory([
-        {'country': 'US'},
-        {'app_version': '52.0.3'},
-        {'distribution_id': 'totally not null'},
-        {'engine': 'yahoo'},
-        {'engine': 'bing'},
-        {'sap': 20},
-    ])
+    return factory(
+        [
+            {"country": "US"},
+            {"app_version": "52.0.3"},
+            {"distribution_id": "totally not null"},
+            {"engine": "yahoo"},
+            {"engine": "bing"},
+            {"sap": 20},
+        ]
+    )
 
 
 @pytest.fixture()
 def expected_search_clients_daily_data(define_dataframe_factory):
     # template for the expected results
-    factory = define_dataframe_factory(list(map(to_field, [
-        ('client_id', 'a', StringType(), False),
-        ('sample_id', '42', StringType(), False),
-        ('submission_date', '20170101', StringType(), False),
-        ('os', 'windows', StringType(), True),
-        ('channel', 'release', StringType(), True),
-        ('country', 'DE', StringType(), True),
-        ('locale', 'de', StringType(), True),
-        ('search_cohort', None, StringType(), True),
-        ('app_version', '54.0.1', StringType(), True),
-        ('distribution_id', None, StringType(), True),
-        ('addon_version', '0.9.5', StringType(), False),
-        ('engine', 'google', StringType(), True),
-        ('source', 'urlbar', StringType(), True),
-        ('tagged-sap', None, LongType(), True),
-        ('tagged-follow-on', None, LongType(), True),
-        ('tagged_sap', None, LongType(), True),
-        ('tagged_follow_on', None, LongType(), True),
-        ('sap', 4, LongType(), True),
-        ('organic', None, LongType(), True),
-        ('unknown', None, LongType(), True),
-        # Roughly 2016-01-01
-        ('profile_creation_date', 16801, LongType(), False),
-        ('default_search_engine', 'google', StringType(), False),
-        (
-            'default_search_engine_data_load_path',
-            'jar:[app]/omni.ja!browser/google.xml',
-            StringType(),
-            False
-        ),
-        (
-            'default_search_engine_data_submission_url',
-            'https://www.google.com/search?q=&ie=utf-8&oe=utf-8&client=firefox-b',
-            StringType(),
-            False
-        ),
-        ('sessions_started_on_this_day', 1, LongType(), True),
-        (
-            'profile_age_in_days',
-            366,
-            LongType(),
-            True
-        ),
-        ('subsession_hours_sum', 1.0, DoubleType(), True),
-        ('active_addons_count_mean', 2.0, DoubleType(), True),
-        ('max_concurrent_tab_count_max', 10, LongType(), True),
-        ('tab_open_event_count_sum', 5, LongType(), True),
-        ('active_hours_sum', .5, DoubleType(), True),
-    ])))
+    factory = define_dataframe_factory(
+        list(
+            map(
+                to_field,
+                [
+                    ("client_id", "a", StringType(), False),
+                    ("sample_id", "42", StringType(), False),
+                    ("submission_date", "20170101", StringType(), False),
+                    ("os", "windows", StringType(), True),
+                    ("channel", "release", StringType(), True),
+                    ("country", "DE", StringType(), True),
+                    ("locale", "de", StringType(), True),
+                    ("search_cohort", None, StringType(), True),
+                    ("app_version", "54.0.1", StringType(), True),
+                    ("distribution_id", None, StringType(), True),
+                    ("addon_version", "0.9.5", StringType(), False),
+                    ("engine", "google", StringType(), True),
+                    ("source", "urlbar", StringType(), True),
+                    ("tagged-sap", None, LongType(), True),
+                    ("tagged-follow-on", None, LongType(), True),
+                    ("tagged_sap", None, LongType(), True),
+                    ("tagged_follow_on", None, LongType(), True),
+                    ("sap", 4, LongType(), True),
+                    ("organic", None, LongType(), True),
+                    ("unknown", None, LongType(), True),
+                    # Roughly 2016-01-01
+                    ("profile_creation_date", 16801, LongType(), False),
+                    ("default_search_engine", "google", StringType(), False),
+                    (
+                        "default_search_engine_data_load_path",
+                        "jar:[app]/omni.ja!browser/google.xml",
+                        StringType(),
+                        False,
+                    ),
+                    (
+                        "default_search_engine_data_submission_url",
+                        "https://www.google.com/search?q=&ie=utf-8&oe=utf-8&client=firefox-b",
+                        StringType(),
+                        False,
+                    ),
+                    ("sessions_started_on_this_day", 1, LongType(), True),
+                    ("profile_age_in_days", 366, LongType(), True),
+                    ("subsession_hours_sum", 1.0, DoubleType(), True),
+                    ("active_addons_count_mean", 2.0, DoubleType(), True),
+                    ("max_concurrent_tab_count_max", 10, LongType(), True),
+                    ("tab_open_event_count_sum", 5, LongType(), True),
+                    ("active_hours_sum", 0.5, DoubleType(), True),
+                ],
+            )
+        )
+    )
 
-    return factory([
-        {'client_id': 'b', 'country': 'US'},
-        # Covers 5 dupe rows and custom app_version, distribution_id rows
-        {
-            'app_version': '52.0.3',
-            'sap': 28,
-            'sessions_started_on_this_day': 7,
-            'subsession_hours_sum': 7.0,
-            'tab_open_event_count_sum': 35,
-            'active_hours_sum': 3.5,
-        },
-        {'engine': 'bing'},
-        {'engine': 'yahoo'},
-        {
-            'client_id': 'c',
-            'unknown': None,
-            'sap': 0,
-            'tagged-sap': None,
-            'tagged-follow-on': None,
-            'tagged_sap': None,
-            'tagged_follow_on': None,
-            'source': None,
-            'engine': None,
-        }
-    ])
+    return factory(
+        [
+            {"client_id": "b", "country": "US"},
+            # Covers 5 dupe rows and custom app_version, distribution_id rows
+            {
+                "app_version": "52.0.3",
+                "sap": 28,
+                "sessions_started_on_this_day": 7,
+                "subsession_hours_sum": 7.0,
+                "tab_open_event_count_sum": 35,
+                "active_hours_sum": 3.5,
+            },
+            {"engine": "bing"},
+            {"engine": "yahoo"},
+            {
+                "client_id": "c",
+                "unknown": None,
+                "sap": 0,
+                "tagged-sap": None,
+                "tagged-follow-on": None,
+                "tagged_sap": None,
+                "tagged_follow_on": None,
+                "source": None,
+                "engine": None,
+            },
+        ]
+    )
 
 
 # Testing functions
 
-def test_explode_search_counts(simple_main_summary,
-                               exploded_simple_main_summary,
-                               df_equals):
+
+def test_explode_search_counts(
+    simple_main_summary, exploded_simple_main_summary, df_equals
+):
     actual = explode_search_counts(simple_main_summary)
 
     assert df_equals(actual, exploded_simple_main_summary)
 
 
-def test_explode_search_counts_bing_absurd(generate_main_summary_data,
-                                           generate_exploded_data,
-                                           df_equals):
+def test_explode_search_counts_bing_absurd(
+    generate_main_summary_data, generate_exploded_data, df_equals
+):
     main_summary_bing_absurd = generate_main_summary_data(
         [
-            {'search_counts': [
-                generate_search_count(engine='bing', count=(MAX_CLIENT_SEARCH_COUNT + 1)),
-                generate_search_count(engine='yahoo'),
-            ]}
+            {
+                "search_counts": [
+                    generate_search_count(
+                        engine="bing", count=(MAX_CLIENT_SEARCH_COUNT + 1)
+                    ),
+                    generate_search_count(engine="yahoo"),
+                ]
+            }
         ]
     )
 
     # expected result only includes yahoo, because the bing entry had an absurd
     # number of searches
-    expected = generate_exploded_data([{'engine': 'yahoo'}])
+    expected = generate_exploded_data([{"engine": "yahoo"}])
 
     actual = explode_search_counts(main_summary_bing_absurd)
 
     assert df_equals(expected, actual)
 
 
-def test_add_derived_columns(exploded_data_for_derived_cols,
-                             derived_columns,
-                             df_equals):
+def test_add_derived_columns(
+    exploded_data_for_derived_cols, derived_columns, df_equals
+):
     actual = add_derived_columns(exploded_data_for_derived_cols)
 
     assert df_equals(actual, derived_columns)
 
 
-def test_basic_aggregation(main_summary,
-                           expected_search_dashboard_data,
-                           df_equals):
+def test_basic_aggregation(main_summary, expected_search_dashboard_data, df_equals):
     actual = search_aggregates(main_summary)
     assert df_equals(actual, expected_search_dashboard_data)
 
 
-def test_search_clients_daily(main_summary,
-                              expected_search_clients_daily_data,
-                              df_equals):
+def test_search_clients_daily(
+    main_summary, expected_search_clients_daily_data, df_equals
+):
     actual = search_clients_daily(main_summary)
 
     assert df_equals(actual, expected_search_clients_daily_data)

--- a/tests/test_shield_privacy_prefs.py
+++ b/tests/test_shield_privacy_prefs.py
@@ -1,48 +1,47 @@
 from pyspark.sql import SQLContext
-from mozetl.shield.privacy_prefs import (transform_state_pings,
-                                         transform_event_pings)
+from mozetl.shield.privacy_prefs import transform_state_pings, transform_event_pings
 
 
 def create_ping_rdd(sc, payload):
-    return sc.parallelize([
-        {
-            'clientId': 'aa',
-            'other-ignored-field': 'who cares',
-            'payload': payload
-        }
-    ])
+    return sc.parallelize(
+        [{"clientId": "aa", "other-ignored-field": "who cares", "payload": payload}]
+    )
 
 
 def create_row(overrides):
-    keys = ["client_id", "branch", "event", "originDomain", "breakage",
-            "notes", "study", "study_state"]
+    keys = [
+        "client_id",
+        "branch",
+        "event",
+        "originDomain",
+        "breakage",
+        "notes",
+        "study",
+        "study_state",
+    ]
 
     # simulate transforuming study_name into study field
-    if 'study_name' in overrides:
-        del overrides['study_name']
-        overrides['study'] = '@shield-study-privacy'
-    overrides['client_id'] = 'aa'
+    if "study_name" in overrides:
+        del overrides["study_name"]
+        overrides["study"] = "@shield-study-privacy"
+    overrides["client_id"] = "aa"
 
     return {key: overrides.get(key, None) for key in keys}
 
 
 def test_study_state_value(row_to_dict, spark_context):
     input_payload = {
-      "study_name": "@shield-study-privacy",
-      "branch": "firstPartyIsolationOpenerAccess",
-      "study_state": "running",
-      "study_version": "0.0.4",
-      "about": {
-        "_src": "shield",
-        "_v": 2
-      }
+        "study_name": "@shield-study-privacy",
+        "branch": "firstPartyIsolationOpenerAccess",
+        "study_state": "running",
+        "study_version": "0.0.4",
+        "about": {"_src": "shield", "_v": 2},
     }
 
     result_payload = input_payload
 
     actual = transform_state_pings(
-        SQLContext(spark_context),
-        create_ping_rdd(spark_context, input_payload)
+        SQLContext(spark_context), create_ping_rdd(spark_context, input_payload)
     ).take(1)[0]
 
     assert row_to_dict(actual) == create_row(result_payload)
@@ -50,24 +49,20 @@ def test_study_state_value(row_to_dict, spark_context):
 
 def test_event_value_problem(row_to_dict, spark_context):
     input_payload = {
-        'study': '@shield-study-privacy',
-        'branch': 'thirdPartyCookiesOnlyFromVisited',
-        'originDomain': 'www.paypal.com',
-        'event': 'page-problem',
-        'breakage': None,
-        'notes': None,
-        'study_version': '0.0.1',
-        'about': {
-            '_src': 'addon',
-            '_v': 2
-        }
+        "study": "@shield-study-privacy",
+        "branch": "thirdPartyCookiesOnlyFromVisited",
+        "originDomain": "www.paypal.com",
+        "event": "page-problem",
+        "breakage": None,
+        "notes": None,
+        "study_version": "0.0.1",
+        "about": {"_src": "addon", "_v": 2},
     }
 
     result_payload = input_payload
 
     actual = transform_event_pings(
-        SQLContext(spark_context),
-        create_ping_rdd(spark_context, input_payload)
+        SQLContext(spark_context), create_ping_rdd(spark_context, input_payload)
     ).take(1)[0]
 
     assert row_to_dict(actual) == create_row(result_payload)
@@ -75,24 +70,20 @@ def test_event_value_problem(row_to_dict, spark_context):
 
 def test_page_breakage(row_to_dict, spark_context):
     input_payload = {
-        'study': '@shield-study-privacy',
-        'branch': 'thirdPartyCookiesOnlyFromVisited',
-        'originDomain': 'www.paypal.com',
-        'event': 'breakage',
-        'breakage': 'other',
-        'notes': None,
-        'study_version': '0.0.1',
-        'about': {
-            '_src': 'addon',
-            '_v': 2
-        }
+        "study": "@shield-study-privacy",
+        "branch": "thirdPartyCookiesOnlyFromVisited",
+        "originDomain": "www.paypal.com",
+        "event": "breakage",
+        "breakage": "other",
+        "notes": None,
+        "study_version": "0.0.1",
+        "about": {"_src": "addon", "_v": 2},
     }
 
     result_payload = input_payload
 
     actual = transform_event_pings(
-        SQLContext(spark_context),
-        create_ping_rdd(spark_context, input_payload)
+        SQLContext(spark_context), create_ping_rdd(spark_context, input_payload)
     ).take(1)[0]
 
     assert row_to_dict(actual) == create_row(result_payload)
@@ -100,24 +91,20 @@ def test_page_breakage(row_to_dict, spark_context):
 
 def test_notes(row_to_dict, spark_context):
     input_payload = {
-        'study': '@shield-study-privacy',
-        'branch': 'thirdPartyCookiesOnlyFromVisited',
-        'originDomain': 'www.paypal.com',
-        'event': 'notes',
-        'breakage': 'other',
-        'notes': 'Paypal prompted me for Reader Mode. WTF?',
-        'study_version': '0.0.1',
-        'about': {
-            '_src': 'addon',
-            '_v': 2
-        }
+        "study": "@shield-study-privacy",
+        "branch": "thirdPartyCookiesOnlyFromVisited",
+        "originDomain": "www.paypal.com",
+        "event": "notes",
+        "breakage": "other",
+        "notes": "Paypal prompted me for Reader Mode. WTF?",
+        "study_version": "0.0.1",
+        "about": {"_src": "addon", "_v": 2},
     }
 
     result_payload = input_payload
 
     actual = transform_event_pings(
-        SQLContext(spark_context),
-        create_ping_rdd(spark_context, input_payload)
+        SQLContext(spark_context), create_ping_rdd(spark_context, input_payload)
     ).take(1)[0]
 
     assert row_to_dict(actual) == create_row(result_payload)
@@ -125,35 +112,27 @@ def test_notes(row_to_dict, spark_context):
 
 def test_combine_state_and_event(row_to_dict, spark_context):
     state_payload = {
-      "study_name": "@shield-study-privacy",
-      "branch": "firstPartyIsolationOpenerAccess",
-      "study_state": "running",
-      "study_version": "0.0.4",
-      "about": {
-        "_src": "shield",
-        "_v": 2
-      }
+        "study_name": "@shield-study-privacy",
+        "branch": "firstPartyIsolationOpenerAccess",
+        "study_state": "running",
+        "study_version": "0.0.4",
+        "about": {"_src": "shield", "_v": 2},
     }
     event_payload = {
-        'study': '@shield-study-privacy',
-        'branch': 'thirdPartyCookiesOnlyFromVisited',
-        'originDomain': 'www.paypal.com',
-        'event': 'disable',
-        'breakage': None,
-        'notes': None,
-        'study_version': '0.0.4',
-        'about': {
-            '_src': 'addon',
-            '_v': 2
-        }
+        "study": "@shield-study-privacy",
+        "branch": "thirdPartyCookiesOnlyFromVisited",
+        "originDomain": "www.paypal.com",
+        "event": "disable",
+        "breakage": None,
+        "notes": None,
+        "study_version": "0.0.4",
+        "about": {"_src": "addon", "_v": 2},
     }
     transformed_event_ping = transform_event_pings(
-        SQLContext(spark_context),
-        create_ping_rdd(spark_context, event_payload)
+        SQLContext(spark_context), create_ping_rdd(spark_context, event_payload)
     )
     transformed_state_ping = transform_state_pings(
-        SQLContext(spark_context),
-        create_ping_rdd(spark_context, state_payload)
+        SQLContext(spark_context), create_ping_rdd(spark_context, state_payload)
     )
 
     transformed_pings = transformed_event_ping.union(transformed_state_ping)
@@ -161,5 +140,6 @@ def test_combine_state_and_event(row_to_dict, spark_context):
     actual_rows = transformed_pings.take(2)
 
     for actual_row in actual_rows:
-        assert (row_to_dict(actual_row) == create_row(state_payload) or
-                row_to_dict(actual_row) == create_row(event_payload))
+        assert row_to_dict(actual_row) == create_row(state_payload) or row_to_dict(
+            actual_row
+        ) == create_row(event_payload)

--- a/tests/test_sync_bookmark.py
+++ b/tests/test_sync_bookmark.py
@@ -5,8 +5,7 @@ import arrow
 import pytest
 from mozetl.sync import bookmark_validation as sbv
 from pyspark.sql import functions as F
-from pyspark.sql.types import (ArrayType, LongType, StringType, StructField,
-                               StructType)
+from pyspark.sql.types import ArrayType, LongType, StringType, StructField, StructType
 
 
 @pytest.fixture()
@@ -17,47 +16,51 @@ def sync_summary_schema():
 
     [1]: https://git.io/vdQ5A
     """
-    failure_type = StructType([
-        StructField("name", StringType(), False),
-    ])
+    failure_type = StructType([StructField("name", StringType(), False)])
 
-    status_type = StructType([
-        StructField("sync", StringType(), True),
-    ])
+    status_type = StructType([StructField("sync", StringType(), True)])
 
-    validation_problems = StructType([
-        StructField("name", StringType(), False),
-        StructField("count", LongType(), False),
-    ])
+    validation_problems = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("count", LongType(), False),
+        ]
+    )
 
-    validation_type = StructType([
-        StructField("version", LongType(), False),
-        StructField("checked", LongType(), False),
-        StructField("took", LongType(), False),
-        StructField("problems", ArrayType(validation_problems, False), True),
-    ])
+    validation_type = StructType(
+        [
+            StructField("version", LongType(), False),
+            StructField("checked", LongType(), False),
+            StructField("took", LongType(), False),
+            StructField("problems", ArrayType(validation_problems, False), True),
+        ]
+    )
 
-    engine_type = StructType([
-        StructField("name", StringType(), False),
-        StructField("status", StringType(), False),
-        StructField("failure_reason", failure_type, True),
-        StructField("validation", validation_type, True),
-    ])
+    engine_type = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("status", StringType(), False),
+            StructField("failure_reason", failure_type, True),
+            StructField("validation", validation_type, True),
+        ]
+    )
 
-    return StructType([
-        StructField("app_build_id", StringType(), True),
-        StructField("app_version", StringType(), True),
-        StructField("app_display_version", StringType(), True),
-        StructField("app_name", StringType(), True),
-        StructField("app_channel", StringType(), True),
-        StructField("uid", StringType(), False),
-        StructField("device_id", StringType(), True),
-        StructField("when", LongType(), False),
-        StructField("failure_reason", failure_type, True),
-        StructField("status", status_type, False),
-        StructField("engines", ArrayType(engine_type, False), True),
-        StructField("submission_date_s3", StringType(), False),
-    ])
+    return StructType(
+        [
+            StructField("app_build_id", StringType(), True),
+            StructField("app_version", StringType(), True),
+            StructField("app_display_version", StringType(), True),
+            StructField("app_name", StringType(), True),
+            StructField("app_channel", StringType(), True),
+            StructField("uid", StringType(), False),
+            StructField("device_id", StringType(), True),
+            StructField("when", LongType(), False),
+            StructField("failure_reason", failure_type, True),
+            StructField("status", status_type, False),
+            StructField("engines", ArrayType(engine_type, False), True),
+            StructField("submission_date_s3", StringType(), False),
+        ]
+    )
 
 
 def to_when(adate):
@@ -68,7 +71,7 @@ def to_submission_date(adate):
     return adate.format("YYYYMMDD")
 
 
-SYNC_ACTIVITY_DATE = arrow.get('2017-10-01')
+SYNC_ACTIVITY_DATE = arrow.get("2017-10-01")
 
 sync_summary_sample = {
     "app_build_id": "id",
@@ -79,9 +82,7 @@ sync_summary_sample = {
     "uid": "uid",
     "device_id": "device_id",
     "when": to_when(SYNC_ACTIVITY_DATE),
-    "status": {
-        "sync": "sync",
-    },
+    "status": {"sync": "sync"},
     "failure_type": None,
     "engines": [
         {
@@ -92,10 +93,8 @@ sync_summary_sample = {
                 "version": 1,
                 "checked": 1,
                 "took": 1,
-                "problems": [
-                    {"name": "name", "count": 1}
-                ],
-            }
+                "problems": [{"name": "name", "count": 1}],
+            },
         }
     ],
     "submission_date_s3": to_submission_date(SYNC_ACTIVITY_DATE),
@@ -110,9 +109,9 @@ def build_sync_summary_snippet(snippet, sample=sync_summary_sample):
     """
 
     result = {}
-    result.update({k: v for k, v in snippet.items() if k != 'engines'})
+    result.update({k: v for k, v in snippet.items() if k != "engines"})
 
-    if 'engines' not in snippet or snippet['engines'] is None:
+    if "engines" not in snippet or snippet["engines"] is None:
         return result
 
     # NOTE: The entire engine sub-tree must be completely materialized before
@@ -129,10 +128,13 @@ def build_sync_summary_snippet(snippet, sample=sync_summary_sample):
     for engine_snippet in snippet["engines"]:
         engine = copy.deepcopy(base_engine)
 
-        engine.update({
-            k: v for k, v in engine_snippet.items()
-            if k not in ["failure_reason", "validation"]
-        })
+        engine.update(
+            {
+                k: v
+                for k, v in engine_snippet.items()
+                if k not in ["failure_reason", "validation"]
+            }
+        )
 
         failure_reason = engine_snippet.get("failure_reason", {})
         if failure_reason is None:
@@ -155,13 +157,12 @@ def build_sync_summary_snippet(snippet, sample=sync_summary_sample):
 @pytest.fixture()
 def generate_data(dataframe_factory, sync_summary_schema):
     def _generate_data(snippets):
-        return (
-            dataframe_factory.create_dataframe(
-                list(map(build_sync_summary_snippet, snippets)),
-                sync_summary_sample,
-                sync_summary_schema
-            )
+        return dataframe_factory.create_dataframe(
+            list(map(build_sync_summary_snippet, snippets)),
+            sync_summary_sample,
+            sync_summary_schema,
         )
+
     return _generate_data
 
 
@@ -170,155 +171,146 @@ def test_transform(spark, generate_data, monkeypatch):
     def _test_transform(snippets):
         def mock_parquet(cls, path):
             return generate_data(snippets)
-        monkeypatch.setattr(
-            "pyspark.sql.DataFrameReader.parquet",
-            mock_parquet
-        )
+
+        monkeypatch.setattr("pyspark.sql.DataFrameReader.parquet", mock_parquet)
         sbv.extract(spark, None, to_submission_date(SYNC_ACTIVITY_DATE))
         sbv.transform(spark)
-        return spark.table("bmk_validation_problems"), \
-            spark.table("bmk_total_per_day")
+        return spark.table("bmk_validation_problems"), spark.table("bmk_total_per_day")
+
     return _test_transform
 
 
 def test_failures_filtered(test_transform):
-    df, _ = test_transform([
-        {'failure_reason': None},
-        {'failure_reason': {"name": "failure!"}},
-        {'failure_reason': {"name": "failure2!"}},
-    ])
+    df, _ = test_transform(
+        [
+            {"failure_reason": None},
+            {"failure_reason": {"name": "failure!"}},
+            {"failure_reason": {"name": "failure2!"}},
+        ]
+    )
 
     assert df.count() == 1
 
 
 def test_validation_problems(test_transform):
-    df, _ = test_transform([
-        # failed, also not a bookmark
-        {
-            'failure_reason': {'name': 'some failure'},
-            'engines': [{
-                'name': 'not bookmarks',
-                'validation': {'problems': None}
-            }]
-        },
-        # not a bookmark
-        {
-            'failure_reason': None,
-            'engines': [{
-                'name': 'not bookmarks',
-                'validation': {'problems': None}
-            }]
-        },
-        # does not contain a problem
-        {
-            'failure_reason': None,
-            'engines': [{
-                'name': 'bookmarks',
-                'validation': {'problems': None}
-            }]
-        },
-        # single engine, single problem, no longer explicitly setting values
-        {
-            'engines': [{
-                'validation': {
-                    'problems': [{'name': '1', 'count': 1}]
-                }
-            }]
-        },
-        # two engines, with one and two problems each
-        {
-            'engines': [
-                # no problems
-                {'name': 'not bookmarks'},
-                # a single problem
-                {
-                    'validation': {
-                        'problems': [{'name': '2', 'count': 10}]
+    df, _ = test_transform(
+        [
+            # failed, also not a bookmark
+            {
+                "failure_reason": {"name": "some failure"},
+                "engines": [
+                    {"name": "not bookmarks", "validation": {"problems": None}}
+                ],
+            },
+            # not a bookmark
+            {
+                "failure_reason": None,
+                "engines": [
+                    {"name": "not bookmarks", "validation": {"problems": None}}
+                ],
+            },
+            # does not contain a problem
+            {
+                "failure_reason": None,
+                "engines": [{"name": "bookmarks", "validation": {"problems": None}}],
+            },
+            # single engine, single problem, no longer explicitly setting values
+            {"engines": [{"validation": {"problems": [{"name": "1", "count": 1}]}}]},
+            # two engines, with one and two problems each
+            {
+                "engines": [
+                    # no problems
+                    {"name": "not bookmarks"},
+                    # a single problem
+                    {"validation": {"problems": [{"name": "2", "count": 10}]}},
+                    {
+                        "validation": {
+                            "problems": [
+                                {"name": "3", "count": 100},
+                                {"name": "4", "count": 1000},
+                            ]
+                        }
+                    },
+                ]
+            },
+            # new bookmarks engine with problems
+            {
+                "failure_reason": None,
+                "engines": [
+                    {
+                        "name": "bookmarks-buffered",
+                        "validation": {
+                            "problems": [
+                                {"name": "new problem", "count": 50},
+                                {"name": "another problem", "count": 4},
+                            ]
+                        },
                     }
-                },
-                {
-                    'validation': {
-                        'problems': [
-                            {'name': '3', 'count': 100},
-                            {'name': '4', 'count': 1000},
-                        ]
-                    }
-                }
-            ]
-        },
-        # new bookmarks engine with problems
-        {
-            'failure_reason': None,
-            'engines': [{
-                'name': 'bookmarks-buffered',
-                'validation': {
-                    'problems': [{
-                        'name': 'new problem',
-                        'count': 50,
-                    }, {
-                        'name': 'another problem',
-                        'count': 4,
-                    }],
-                },
-            }],
-        },
-        # new bookmarks engine without problems
-        {
-            'failure_reason': None,
-            'engines': [{
-                'name': 'bookmarks-buffered',
-                'validation': {'problems': None},
-            }],
-        },
-    ])
+                ],
+            },
+            # new bookmarks engine without problems
+            {
+                "failure_reason": None,
+                "engines": [
+                    {"name": "bookmarks-buffered", "validation": {"problems": None}}
+                ],
+            },
+        ]
+    )
 
     assert df.count() == 6
-    assert df.select(
-        F.sum('engine_validation_problem_count').alias('pcount')
-    ).first().pcount == 1165
+    assert (
+        df.select(F.sum("engine_validation_problem_count").alias("pcount"))
+        .first()
+        .pcount
+        == 1165
+    )
 
-    assert df.where(
-        F.col('engine_name') == 'bookmarks'
-    ).select(
-        F.sum('engine_validation_problem_count').alias('pcount')
-    ).first().pcount == 1111
-    assert df.where(
-        F.col('engine_name') == 'bookmarks-buffered'
-    ).select(
-        F.sum('engine_validation_problem_count').alias('pcount')
-    ).first().pcount == 54
+    assert (
+        df.where(F.col("engine_name") == "bookmarks")
+        .select(F.sum("engine_validation_problem_count").alias("pcount"))
+        .first()
+        .pcount
+        == 1111
+    )
+    assert (
+        df.where(F.col("engine_name") == "bookmarks-buffered")
+        .select(F.sum("engine_validation_problem_count").alias("pcount"))
+        .first()
+        .pcount
+        == 54
+    )
 
 
 def test_total_bookmarks_checked(test_transform):
-    _, df = test_transform([
-        {
-            'engines': [
-                {'validation': {'checked': 1}},
-                {'validation': {'checked': 10}}
-            ]
-        },
-        {
-            'engines': [
-                {'validation': {'checked': 100}},
-                {'validation': None}
-            ]
-        },
-    ])
+    _, df = test_transform(
+        [
+            {
+                "engines": [
+                    {"validation": {"checked": 1}},
+                    {"validation": {"checked": 10}},
+                ]
+            },
+            {"engines": [{"validation": {"checked": 100}}, {"validation": None}]},
+        ]
+    )
 
     assert df.count() == 1
     assert df.select("total_bookmarks_checked").first()[0] == 111
 
 
 def test_total_bookmark_validations(test_transform):
-    _, df = test_transform([
-        {'uid': '0', 'device_id': '0'},
-        {'uid': '0', 'device_id': '1'},
-        {'uid': '1', 'device_id': '0'},
-        {'uid': '1', 'device_id': '1'},
-        # duplicates
-        {'uid': '1', 'device_id': '1'},
-        {'uid': '1', 'device_id': '1'},
-    ])
+    _, df = test_transform(
+        [
+            {"uid": "0", "device_id": "0"},
+            {"uid": "0", "device_id": "1"},
+            {"uid": "1", "device_id": "0"},
+            {"uid": "1", "device_id": "1"},
+            # duplicates
+            {"uid": "1", "device_id": "1"},
+            {"uid": "1", "device_id": "1"},
+        ]
+    )
 
     assert df.count() == 1
     assert df.first().total_bookmark_validations == 4
@@ -328,24 +320,22 @@ def test_total_users_per_day(test_transform, row_to_dict):
     day_1 = SYNC_ACTIVITY_DATE
     day_2 = SYNC_ACTIVITY_DATE.replace(days=-1)
 
-    _, df = test_transform([
-        {'uid': 'date not included', 'submission_date_s3': to_submission_date(day_2)},
-        {'uid': '0', 'when': to_when(day_1)},
-        {'uid': '1', 'when': to_when(day_1)},
-        {'uid': '1', 'when': to_when(day_2)},
-        {'uid': '1', 'when': to_when(day_2)},
-        {'uid': '2', 'when': to_when(day_2)},
-    ])
+    _, df = test_transform(
+        [
+            {
+                "uid": "date not included",
+                "submission_date_s3": to_submission_date(day_2),
+            },
+            {"uid": "0", "when": to_when(day_1)},
+            {"uid": "1", "when": to_when(day_1)},
+            {"uid": "1", "when": to_when(day_2)},
+            {"uid": "1", "when": to_when(day_2)},
+            {"uid": "2", "when": to_when(day_2)},
+        ]
+    )
 
     assert df.count() == 1
-    rows = (
-        df
-        .select('submission_day', 'total_validated_users')
-        .collect()
-    )
+    rows = df.select("submission_day", "total_validated_users").collect()
     assert list(map(row_to_dict, rows)) == [
-        {
-            'submission_day': to_submission_date(day_1),
-            'total_validated_users': 3
-        }
+        {"submission_day": to_submission_date(day_1), "total_validated_users": 3}
     ]

--- a/tests/test_taar_amowhitelist.py
+++ b/tests/test_taar_amowhitelist.py
@@ -229,7 +229,9 @@ EXPECTED_FINAL_JDATA = {
             "text_count": 0.0,
         },
         "summary": {
-            "zh-CN": "\\u4f7f\\u7528OSD Lyrics\\u663e\\u793a\\u8c46\\u74e3\\u7535\\u53f0\\u6b4c\\u8bcd"
+            "zh-CN": (
+                "\\u4f7f\\u7528OSD Lyrics\\u663e\\u793a\\u8c46\\u74e3\\u7535\\u53f0\\u6b4c\\u8bcd"
+            )
         },
         "tags": ["douban", "osd-lyrics", "osdlyrics", "\\u8c46\\u74e3"],
         "weekly_downloads": 1,

--- a/tests/test_taar_amowhitelist.py
+++ b/tests/test_taar_amowhitelist.py
@@ -16,18 +16,14 @@ VALID_PLATFORMS = ["all", "android", "linux", "mac", "windows", None]
 SAMPLE_DATA = {
     "gnome-download-notify@ion201": {
         "is_featured": True,
-        "categories": {
-            "firefox": [
-                "alerts-updates"
-            ]
-        },
+        "categories": {"firefox": ["alerts-updates"]},
         "current_version": {
             "files": [
                 {
                     "id": 844358,
                     "is_webextension": True,
                     "platform": "all",
-                    "status": "public"
+                    "status": "public",
                 }
             ]
         },
@@ -37,14 +33,12 @@ SAMPLE_DATA = {
         },
         "first_create_date": "2015-06-20T11:21:58Z",
         "guid": "gnome-download-notify@ion201",
-        "name": {
-            "en-US": "Download Notifications"
-        },
+        "name": {"en-US": "Download Notifications"},
         "ratings": {
             "average": 5.0,
             "bayesian_average": 4.58373,
             "count": 11.0,
-            "text_count": 6.0
+            "text_count": 6.0,
         },
         "summary": {
             "en-US": "Native notification integration for completed downloads."
@@ -61,9 +55,9 @@ SAMPLE_DATA = {
             "notification",
             "notify-send",
             "unity",
-            "xfce"
+            "xfce",
         ],
-        "weekly_downloads": 105
+        "weekly_downloads": 105,
     },
     "jid0-ujiop74nNc447DlWVPSGIlzMRqY@jetpack": {
         "is_featured": True,
@@ -74,7 +68,7 @@ SAMPLE_DATA = {
                     "id": 149005,
                     "is_webextension": False,
                     "platform": "all",
-                    "status": "public"
+                    "status": "public",
                 }
             ]
         },
@@ -82,35 +76,27 @@ SAMPLE_DATA = {
         "description": None,
         "first_create_date": "2012-04-13T08:55:39Z",
         "guid": "jid0-ujiop74nNc447DlWVPSGIlzMRqY@jetpack",
-        "name": {
-            "en-US": "Luffi"
-        },
+        "name": {"en-US": "Luffi"},
         "ratings": {
             "average": 1.0,
             "bayesian_average": 0.698215,
             "count": 1.0,
-            "text_count": 1.0
+            "text_count": 1.0,
         },
-        "summary": {
-            "en-US": "Luffi - Let\u00b4s use freeware! fun included:)"
-        },
+        "summary": {"en-US": "Luffi - Let\u00b4s use freeware! fun included:)"},
         "tags": [],
-        "weekly_downloads": 0
+        "weekly_downloads": 0,
     },
     "jid1-tpeRu7ABM810Fw@jetpack": {
         "is_featured": True,
-        "categories": {
-            "firefox": [
-                "photos-music-videos"
-            ]
-        },
+        "categories": {"firefox": ["photos-music-videos"]},
         "current_version": {
             "files": [
                 {
                     "id": 216360,
                     "is_webextension": False,
                     "platform": "all",
-                    "status": "public"
+                    "status": "public",
                 }
             ]
         },
@@ -118,40 +104,29 @@ SAMPLE_DATA = {
         "description": None,
         "first_create_date": "2011-10-13T04:55:06Z",
         "guid": "jid1-tpeRu7ABM810Fw@jetpack",
-        "name": {
-            "zh-CN": "\u8c46\u74e3\u7535\u53f0OSD Lyrics\u63d2\u4ef6"
-        },
+        "name": {"zh-CN": "\u8c46\u74e3\u7535\u53f0OSD Lyrics\u63d2\u4ef6"},
         "ratings": {
             "average": 3.0,
             "bayesian_average": 2.38892,
             "count": 3.0,
-            "text_count": 0.0
+            "text_count": 0.0,
         },
         "summary": {
             "zh-CN": "\u4f7f\u7528OSD Lyrics\u663e\u793a\u8c46\u74e3\u7535\u53f0\u6b4c\u8bcd"
         },
-        "tags": [
-            "douban",
-            "osd-lyrics",
-            "osdlyrics",
-            "\u8c46\u74e3"
-        ],
-        "weekly_downloads": 1
+        "tags": ["douban", "osd-lyrics", "osdlyrics", "\u8c46\u74e3"],
+        "weekly_downloads": 1,
     },
     "nellyfurtado@browsernation.com": {
         "is_featured": False,
-        "categories": {
-            "firefox": [
-                "feeds-news-blogging"
-            ]
-        },
+        "categories": {"firefox": ["feeds-news-blogging"]},
         "current_version": {
             "files": [
                 {
                     "id": 114512,
                     "is_webextension": False,
                     "platform": "all",
-                    "status": "public"
+                    "status": "public",
                 }
             ]
         },
@@ -161,14 +136,12 @@ SAMPLE_DATA = {
         },
         "first_create_date": "2010-11-03T09:38:20Z",
         "guid": "nellyfurtado@browsernation.com",
-        "name": {
-            "en-US": "The Official Nelly Furtado Add-on for Firefox"
-        },
+        "name": {"en-US": "The Official Nelly Furtado Add-on for Firefox"},
         "ratings": {
             "average": 0.0,
             "bayesian_average": 0.0,
             "count": 0.0,
-            "text_count": 0.0
+            "text_count": 0.0,
         },
         "summary": {
             "en-US": "Stay connected to Nelly Furtado and download her new browser application."
@@ -181,26 +154,22 @@ SAMPLE_DATA = {
             "pop",
             "rss reader",
             "theme",
-            "toolbar"
+            "toolbar",
         ],
-        "weekly_downloads": 0
-    }
+        "weekly_downloads": 0,
+    },
 }
 
 EXPECTED_FINAL_JDATA = {
     "gnome-download-notify@ion201": {
-        "categories": {
-            "firefox": [
-                "alerts-updates"
-            ]
-        },
+        "categories": {"firefox": ["alerts-updates"]},
         "current_version": {
             "files": [
                 {
                     "id": 844358,
                     "is_webextension": True,
                     "platform": "all",
-                    "status": "public"
+                    "status": "public",
                 }
             ]
         },
@@ -210,14 +179,12 @@ EXPECTED_FINAL_JDATA = {
         },
         "first_create_date": "2015-06-20T11:21:58Z",
         "guid": "gnome-download-notify@ion201",
-        "name": {
-            "en-US": "Download Notifications"
-        },
+        "name": {"en-US": "Download Notifications"},
         "ratings": {
             "average": 5.0,
             "bayesian_average": 4.58373,
             "count": 11.0,
-            "text_count": 6.0
+            "text_count": 6.0,
         },
         "summary": {
             "en-US": "Native notification integration for completed downloads."
@@ -234,23 +201,19 @@ EXPECTED_FINAL_JDATA = {
             "notification",
             "notify-send",
             "unity",
-            "xfce"
+            "xfce",
         ],
-        "weekly_downloads": 105
+        "weekly_downloads": 105,
     },
     "jid1-tpeRu7ABM810Fw@jetpack": {
-        "categories": {
-            "firefox": [
-                "photos-music-videos"
-            ]
-        },
+        "categories": {"firefox": ["photos-music-videos"]},
         "current_version": {
             "files": [
                 {
                     "id": 216360,
                     "is_webextension": False,
                     "platform": "all",
-                    "status": "public"
+                    "status": "public",
                 }
             ]
         },
@@ -258,27 +221,19 @@ EXPECTED_FINAL_JDATA = {
         "description": None,
         "first_create_date": "2011-10-13T04:55:06Z",
         "guid": "jid1-tpeRu7ABM810Fw@jetpack",
-        "name": {
-            "zh-CN": "\\u8c46\\u74e3\\u7535\\u53f0OSD Lyrics\\u63d2\\u4ef6"
-        },
+        "name": {"zh-CN": "\\u8c46\\u74e3\\u7535\\u53f0OSD Lyrics\\u63d2\\u4ef6"},
         "ratings": {
             "average": 3.0,
             "bayesian_average": 2.38892,
             "count": 3.0,
-            "text_count": 0.0
+            "text_count": 0.0,
         },
         "summary": {
-            "zh-CN":
-                "\\u4f7f\\u7528OSD Lyrics\\u663e\\u793a\\u8c46\\u74e3\\u7535\\u53f0\\u6b4c\\u8bcd"
+            "zh-CN": "\\u4f7f\\u7528OSD Lyrics\\u663e\\u793a\\u8c46\\u74e3\\u7535\\u53f0\\u6b4c\\u8bcd"
         },
-        "tags": [
-            "douban",
-            "osd-lyrics",
-            "osdlyrics",
-            "\\u8c46\\u74e3"
-        ],
-        "weekly_downloads": 1
-    }
+        "tags": ["douban", "osd-lyrics", "osdlyrics", "\\u8c46\\u74e3"],
+        "weekly_downloads": 1,
+    },
 }
 
 
@@ -286,46 +241,52 @@ EXPECTED_FINAL_JDATA = {
 def s3_fixture():
     mock_s3().start()
 
-    conn = boto3.resource('s3', region_name='us-west-2')
+    conn = boto3.resource("s3", region_name="us-west-2")
     conn.create_bucket(Bucket=taar_amowhitelist.AMO_DUMP_BUCKET)
-    taar_utils.store_json_to_s3(json.dumps(SAMPLE_DATA),
-                                taar_amowhitelist.AMO_DUMP_BASE_FILENAME,
-                                '20171106',
-                                taar_amowhitelist.AMO_DUMP_PREFIX,
-                                taar_amowhitelist.AMO_DUMP_BUCKET)
+    taar_utils.store_json_to_s3(
+        json.dumps(SAMPLE_DATA),
+        taar_amowhitelist.AMO_DUMP_BASE_FILENAME,
+        "20171106",
+        taar_amowhitelist.AMO_DUMP_PREFIX,
+        taar_amowhitelist.AMO_DUMP_BUCKET,
+    )
     yield conn, SAMPLE_DATA
     mock_s3().stop()
 
 
 def test_extract(s3_fixture):
-    '''
+    """
     The transform for the AMOTransformer is just filtering by
     age using `first_create_date` and using the ratings.average
     with a minimum of 3.0
-    '''
+    """
 
-    etl = taar_amowhitelist.AMOTransformer(taar_amowhitelist.AMO_DUMP_BUCKET,
-                                           taar_amowhitelist.AMO_DUMP_PREFIX,
-                                           taar_amowhitelist.AMO_DUMP_FILENAME,
-                                           taar_amowhitelist.MIN_RATING,
-                                           taar_amowhitelist.MIN_AGE)
+    etl = taar_amowhitelist.AMOTransformer(
+        taar_amowhitelist.AMO_DUMP_BUCKET,
+        taar_amowhitelist.AMO_DUMP_PREFIX,
+        taar_amowhitelist.AMO_DUMP_FILENAME,
+        taar_amowhitelist.MIN_RATING,
+        taar_amowhitelist.MIN_AGE,
+    )
     jdata = etl.extract()
     assert jdata == SAMPLE_DATA
 
 
 def test_transform_whitelist(s3_fixture):
-    '''
+    """
     The transform for the AMOTransformer is just filtering by
     age using `first_create_date` and using the ratings.average
     with a minimum of 3.0
-    '''
+    """
 
     conn, data = s3_fixture
-    etl = taar_amowhitelist.AMOTransformer(taar_amowhitelist.AMO_DUMP_BUCKET,
-                                           taar_amowhitelist.AMO_DUMP_PREFIX,
-                                           taar_amowhitelist.AMO_DUMP_FILENAME,
-                                           taar_amowhitelist.MIN_RATING,
-                                           taar_amowhitelist.MIN_AGE)
+    etl = taar_amowhitelist.AMOTransformer(
+        taar_amowhitelist.AMO_DUMP_BUCKET,
+        taar_amowhitelist.AMO_DUMP_PREFIX,
+        taar_amowhitelist.AMO_DUMP_FILENAME,
+        taar_amowhitelist.MIN_RATING,
+        taar_amowhitelist.MIN_AGE,
+    )
     etl.transform(data)
 
     final_jdata = etl.get_whitelist()
@@ -333,28 +294,32 @@ def test_transform_whitelist(s3_fixture):
 
     today = datetime.datetime.today().replace(tzinfo=None)
     for client_data in list(final_jdata.values()):
-        assert client_data['current_version']['files'][0]['is_webextension']
-        assert client_data['ratings']['average'] >= taar_amowhitelist.MIN_RATING
-        create_datetime = parse(client_data['first_create_date']).replace(tzinfo=None)
-        assert create_datetime + datetime.timedelta(days=taar_amowhitelist.MIN_AGE) < today
-        assert 'is_featured' in client_data
+        assert client_data["current_version"]["files"][0]["is_webextension"]
+        assert client_data["ratings"]["average"] >= taar_amowhitelist.MIN_RATING
+        create_datetime = parse(client_data["first_create_date"]).replace(tzinfo=None)
+        assert (
+            create_datetime + datetime.timedelta(days=taar_amowhitelist.MIN_AGE) < today
+        )
+        assert "is_featured" in client_data
         # Verify that the platform data is in the transform output
-        assert client_data['current_version']['files'][0]['platform'] in VALID_PLATFORMS
+        assert client_data["current_version"]["files"][0]["platform"] in VALID_PLATFORMS
 
 
 def test_transform_featuredlist(s3_fixture):
-    '''
+    """
     The transform for the AMOTransformer is just filtering by
     age using `first_create_date` and using the ratings.average
     with a minimum of 3.0
-    '''
+    """
 
     conn, data = s3_fixture
-    etl = taar_amowhitelist.AMOTransformer(taar_amowhitelist.AMO_DUMP_BUCKET,
-                                           taar_amowhitelist.AMO_DUMP_PREFIX,
-                                           taar_amowhitelist.AMO_DUMP_FILENAME,
-                                           taar_amowhitelist.MIN_RATING,
-                                           taar_amowhitelist.MIN_AGE)
+    etl = taar_amowhitelist.AMOTransformer(
+        taar_amowhitelist.AMO_DUMP_BUCKET,
+        taar_amowhitelist.AMO_DUMP_PREFIX,
+        taar_amowhitelist.AMO_DUMP_FILENAME,
+        taar_amowhitelist.MIN_RATING,
+        taar_amowhitelist.MIN_AGE,
+    )
     etl.transform(data)
 
     final_jdata = etl.get_featuredlist()
@@ -364,34 +329,40 @@ def test_transform_featuredlist(s3_fixture):
     assert len(final_jdata) == 3
 
     for rec in list(final_jdata.values()):
-        assert rec['is_featured']
+        assert rec["is_featured"]
 
 
 def test_load_whitelist(s3_fixture):
     conn, data = s3_fixture
 
-    etl = taar_amowhitelist.AMOTransformer(taar_amowhitelist.AMO_DUMP_BUCKET,
-                                           taar_amowhitelist.AMO_DUMP_PREFIX,
-                                           taar_amowhitelist.AMO_DUMP_FILENAME,
-                                           taar_amowhitelist.MIN_RATING,
-                                           taar_amowhitelist.MIN_AGE)
+    etl = taar_amowhitelist.AMOTransformer(
+        taar_amowhitelist.AMO_DUMP_BUCKET,
+        taar_amowhitelist.AMO_DUMP_PREFIX,
+        taar_amowhitelist.AMO_DUMP_FILENAME,
+        taar_amowhitelist.MIN_RATING,
+        taar_amowhitelist.MIN_AGE,
+    )
     etl.transform(data)
 
     etl.load()
 
-    s3 = boto3.resource('s3', region_name='us-west-2')
+    s3 = boto3.resource("s3", region_name="us-west-2")
     bucket_obj = s3.Bucket(taar_amowhitelist.AMO_DUMP_BUCKET)
 
-    available_objects = list(bucket_obj.objects.filter(Prefix=taar_amowhitelist.AMO_DUMP_PREFIX))
+    available_objects = list(
+        bucket_obj.objects.filter(Prefix=taar_amowhitelist.AMO_DUMP_PREFIX)
+    )
 
     # Check that whitelist file exists
-    full_s3_name = '{}{}'.format(taar_amowhitelist.AMO_DUMP_PREFIX,
-                                 taar_amowhitelist.FILTERED_AMO_FILENAME)
+    full_s3_name = "{}{}".format(
+        taar_amowhitelist.AMO_DUMP_PREFIX, taar_amowhitelist.FILTERED_AMO_FILENAME
+    )
     keys = [o.key for o in available_objects]
     assert full_s3_name in keys
 
     # Check that featured addon file exists
-    full_s3_name = '{}{}'.format(taar_amowhitelist.AMO_DUMP_PREFIX,
-                                 taar_amowhitelist.FEATURED_FILENAME)
+    full_s3_name = "{}{}".format(
+        taar_amowhitelist.AMO_DUMP_PREFIX, taar_amowhitelist.FEATURED_FILENAME
+    )
     keys = [o.key for o in available_objects]
     assert full_s3_name in keys

--- a/tests/test_taar_lite_guidguid.py
+++ b/tests/test_taar_lite_guidguid.py
@@ -20,82 +20,133 @@ MOCK_TELEMETRY_SAMPLE = [
     Row(installed_addons=["test-guid-1", "test-guid-3"]),
     Row(installed_addons=["test-guid-1", "test-guid-4"]),
     Row(installed_addons=["test-guid-2", "test-guid-5", "test-guid-6"]),
-    Row(installed_addons=["test-guid-1", "test-guid-1"])
+    Row(installed_addons=["test-guid-1", "test-guid-1"]),
 ]
 
 EXPECTED_ADDON_INSTALLATIONS = [
-        (    # noqa
-            Row(key_addon='test-guid-1',
-                coinstalled_addons=['test-guid-2', 'test-guid-3', 'test-guid-4']),
-            [Row(key_addon='test-guid-1',
-                coinstalled_addons=['test-guid-3', 'test-guid-4']),
-             Row(key_addon='test-guid-2',
-                 coinstalled_addons=['test-guid-1', 'test-guid-5', 'test-guid-6']),
-             Row(key_addon='test-guid-2',
-                 coinstalled_addons=['test-guid-1'])]
+    (  # noqa
+        Row(
+            key_addon="test-guid-1",
+            coinstalled_addons=["test-guid-2", "test-guid-3", "test-guid-4"],
         ),
-        (
-            Row(key_addon='test-guid-1',
-                coinstalled_addons=['test-guid-3', 'test-guid-4']),
-            [Row(key_addon='test-guid-1',
-                 coinstalled_addons=['test-guid-2', 'test-guid-3', 'test-guid-4']),
-             Row(key_addon='test-guid-2',
-                 coinstalled_addons=['test-guid-1', 'test-guid-5', 'test-guid-6']),
-             Row(key_addon='test-guid-2',
-                 coinstalled_addons=['test-guid-1'])]
+        [
+            Row(
+                key_addon="test-guid-1",
+                coinstalled_addons=["test-guid-3", "test-guid-4"],
+            ),
+            Row(
+                key_addon="test-guid-2",
+                coinstalled_addons=["test-guid-1", "test-guid-5", "test-guid-6"],
+            ),
+            Row(key_addon="test-guid-2", coinstalled_addons=["test-guid-1"]),
+        ],
+    ),
+    (
+        Row(key_addon="test-guid-1", coinstalled_addons=["test-guid-3", "test-guid-4"]),
+        [
+            Row(
+                key_addon="test-guid-1",
+                coinstalled_addons=["test-guid-2", "test-guid-3", "test-guid-4"],
+            ),
+            Row(
+                key_addon="test-guid-2",
+                coinstalled_addons=["test-guid-1", "test-guid-5", "test-guid-6"],
+            ),
+            Row(key_addon="test-guid-2", coinstalled_addons=["test-guid-1"]),
+        ],
+    ),
+    (
+        Row(
+            key_addon="test-guid-2",
+            coinstalled_addons=["test-guid-1", "test-guid-5", "test-guid-6"],
         ),
-        (
-            Row(key_addon='test-guid-2',
-                coinstalled_addons=['test-guid-1', 'test-guid-5', 'test-guid-6']),
-            [Row(key_addon='test-guid-1',
-                 coinstalled_addons=['test-guid-2', 'test-guid-3', 'test-guid-4']),
-             Row(key_addon='test-guid-1',
-                 coinstalled_addons=['test-guid-3', 'test-guid-4']),
-             Row(key_addon='test-guid-2',
-                 coinstalled_addons=['test-guid-1'])]
-        ),
-        (
-            Row(key_addon='test-guid-2',
-                coinstalled_addons=['test-guid-1']),
-            [Row(key_addon='test-guid-1',
-                 coinstalled_addons=['test-guid-2', 'test-guid-3', 'test-guid-4']),
-             Row(key_addon='test-guid-1',
-                 coinstalled_addons=['test-guid-3', 'test-guid-4']),
-             Row(key_addon='test-guid-2',
-                 coinstalled_addons=['test-guid-1', 'test-guid-5', 'test-guid-6'])]
-        )]
+        [
+            Row(
+                key_addon="test-guid-1",
+                coinstalled_addons=["test-guid-2", "test-guid-3", "test-guid-4"],
+            ),
+            Row(
+                key_addon="test-guid-1",
+                coinstalled_addons=["test-guid-3", "test-guid-4"],
+            ),
+            Row(key_addon="test-guid-2", coinstalled_addons=["test-guid-1"]),
+        ],
+    ),
+    (
+        Row(key_addon="test-guid-2", coinstalled_addons=["test-guid-1"]),
+        [
+            Row(
+                key_addon="test-guid-1",
+                coinstalled_addons=["test-guid-2", "test-guid-3", "test-guid-4"],
+            ),
+            Row(
+                key_addon="test-guid-1",
+                coinstalled_addons=["test-guid-3", "test-guid-4"],
+            ),
+            Row(
+                key_addon="test-guid-2",
+                coinstalled_addons=["test-guid-1", "test-guid-5", "test-guid-6"],
+            ),
+        ],
+    ),
+]
 
 MOCK_KEYED_ADDONS = [
-    Row(key_addon='test-guid-1',
-        coinstalled_addons=['test-guid-2', 'test-guid-3', 'test-guid-4']),
-    Row(key_addon='test-guid-1',
-        coinstalled_addons=['test-guid-3', 'test-guid-4']),
-    Row(key_addon="test-guid-2",
-        coinstalled_addons=['test-guid-1', 'test-guid-5', 'test-guid-6']),
-    Row(key_addon="test-guid-2",
-        coinstalled_addons=['test-guid-1'])
-    ]
+    Row(
+        key_addon="test-guid-1",
+        coinstalled_addons=["test-guid-2", "test-guid-3", "test-guid-4"],
+    ),
+    Row(key_addon="test-guid-1", coinstalled_addons=["test-guid-3", "test-guid-4"]),
+    Row(
+        key_addon="test-guid-2",
+        coinstalled_addons=["test-guid-1", "test-guid-5", "test-guid-6"],
+    ),
+    Row(key_addon="test-guid-2", coinstalled_addons=["test-guid-1"]),
+]
 
 
 EXPECTED_GUID_GUID_DATA = [
-    Row(key_addon=u'test-guid-2',
-        coinstallation_counts=[Row(id=u'test-guid-6', n=1),
-                               Row(id=u'test-guid-5', n=1),
-                               Row(id=u'test-guid-3', n=1),
-                               Row(id=u'test-guid-1', n=1)]),
-    Row(key_addon=u'test-guid-4',
-        coinstallation_counts=[Row(id=u'test-guid-1', n=1)]),
-    Row(key_addon=u'test-guid-3',
-        coinstallation_counts=[Row(id=u'test-guid-2', n=1), Row(id=u'test-guid-1', n=2)]),
-    Row(key_addon=u'test-guid-5',
-        coinstallation_counts=[Row(id=u'test-guid-6', n=1), Row(id=u'test-guid-2', n=1)]),
-    Row(key_addon=u'test-guid-1',
-        coinstallation_counts=[Row(id=u'test-guid-2', n=1),
-                               Row(id=u'test-guid-1', n=2),
-                               Row(id=u'test-guid-3', n=2),
-                               Row(id=u'test-guid-4', n=1)]),
-    Row(key_addon=u'test-guid-6',
-        coinstallation_counts=[Row(id=u'test-guid-2', n=1), Row(id=u'test-guid-5', n=1)])]
+    Row(
+        key_addon=u"test-guid-2",
+        coinstallation_counts=[
+            Row(id=u"test-guid-6", n=1),
+            Row(id=u"test-guid-5", n=1),
+            Row(id=u"test-guid-3", n=1),
+            Row(id=u"test-guid-1", n=1),
+        ],
+    ),
+    Row(key_addon=u"test-guid-4", coinstallation_counts=[Row(id=u"test-guid-1", n=1)]),
+    Row(
+        key_addon=u"test-guid-3",
+        coinstallation_counts=[
+            Row(id=u"test-guid-2", n=1),
+            Row(id=u"test-guid-1", n=2),
+        ],
+    ),
+    Row(
+        key_addon=u"test-guid-5",
+        coinstallation_counts=[
+            Row(id=u"test-guid-6", n=1),
+            Row(id=u"test-guid-2", n=1),
+        ],
+    ),
+    Row(
+        key_addon=u"test-guid-1",
+        coinstallation_counts=[
+            Row(id=u"test-guid-2", n=1),
+            Row(id=u"test-guid-1", n=2),
+            Row(id=u"test-guid-3", n=2),
+            Row(id=u"test-guid-4", n=1),
+        ],
+    ),
+    Row(
+        key_addon=u"test-guid-6",
+        coinstallation_counts=[
+            Row(id=u"test-guid-2", n=1),
+            Row(id=u"test-guid-5", n=1),
+        ],
+    ),
+]
 
 
 # Exercise the only part of the ETL job happening outside of spark.
@@ -121,17 +172,17 @@ def test_transform_is_valid(spark, df_equals):
 def test_load_s3(spark):
     BUCKET = taar_lite_guidguid.OUTPUT_BUCKET
     PREFIX = taar_lite_guidguid.OUTPUT_PREFIX
-    dest_filename = taar_lite_guidguid.OUTPUT_BASE_FILENAME + '.json'
+    dest_filename = taar_lite_guidguid.OUTPUT_BASE_FILENAME + ".json"
 
     # Create the bucket before we upload
-    conn = boto3.resource('s3', region_name='us-west-2')
+    conn = boto3.resource("s3", region_name="us-west-2")
     bucket_obj = conn.create_bucket(Bucket=BUCKET)
 
     load_df = spark.createDataFrame(EXPECTED_GUID_GUID_DATA)
-    taar_lite_guidguid.load_s3(load_df, '20180301', PREFIX, BUCKET)
+    taar_lite_guidguid.load_s3(load_df, "20180301", PREFIX, BUCKET)
 
     # Now check that the file is there
     available_objects = list(bucket_obj.objects.filter(Prefix=PREFIX))
-    full_s3_name = '{}{}'.format(PREFIX, dest_filename)
+    full_s3_name = "{}{}".format(PREFIX, dest_filename)
     keys = [o.key for o in available_objects]
     assert full_s3_name in keys

--- a/tests/test_taar_lite_guidranking.py
+++ b/tests/test_taar_lite_guidranking.py
@@ -14,31 +14,43 @@ Expected schema of co-installation counts dict.
 | | | -- n: long(nullable=true)
 """
 
-MOCK_LONGITUDINAL_SAMPLE = [   # noqa
-        Row(active_addons=[{
-            'test-guid-1': {'addon_data_row': 'blah'},
-            'test-guid-2': {'addon_data_row': 'blah'},
-            'test-guid-3': {'addon_data_row': 'blah'},
-            'test-guid-5': {'addon_data_row': 'blah'},
-            }],
-            normalized_channel='release',
-            build=[{'application_name': 'Firefox'}]),
-        Row(active_addons=[{
-            'test-guid-5': {'addon_data_row': 'blah'},
-            'test-guid-2': {'addon_data_row': 'blah'},
-            'test-guid-3': {'addon_data_row': 'blah'},
-            'test-guid-4': {'addon_data_row': 'blah'},
-            }],
-            normalized_channel='release',
-            build=[{'application_name': 'Firefox'}]),
-        Row(active_addons=[{
-            'test-guid-6': {'addon_data_row': 'blah'},
-            'test-guid-2': {'addon_data_row': 'blah'},
-            'test-guid-3': {'addon_data_row': 'blah'},
-            'test-guid-4': {'addon_data_row': 'blah'},
-            }],
-            normalized_channel='release',
-            build=[{'application_name': 'Firefox'}]),
+MOCK_LONGITUDINAL_SAMPLE = [  # noqa
+    Row(
+        active_addons=[
+            {
+                "test-guid-1": {"addon_data_row": "blah"},
+                "test-guid-2": {"addon_data_row": "blah"},
+                "test-guid-3": {"addon_data_row": "blah"},
+                "test-guid-5": {"addon_data_row": "blah"},
+            }
+        ],
+        normalized_channel="release",
+        build=[{"application_name": "Firefox"}],
+    ),
+    Row(
+        active_addons=[
+            {
+                "test-guid-5": {"addon_data_row": "blah"},
+                "test-guid-2": {"addon_data_row": "blah"},
+                "test-guid-3": {"addon_data_row": "blah"},
+                "test-guid-4": {"addon_data_row": "blah"},
+            }
+        ],
+        normalized_channel="release",
+        build=[{"application_name": "Firefox"}],
+    ),
+    Row(
+        active_addons=[
+            {
+                "test-guid-6": {"addon_data_row": "blah"},
+                "test-guid-2": {"addon_data_row": "blah"},
+                "test-guid-3": {"addon_data_row": "blah"},
+                "test-guid-4": {"addon_data_row": "blah"},
+            }
+        ],
+        normalized_channel="release",
+        build=[{"application_name": "Firefox"}],
+    ),
 ]
 
 MOCK_TELEMETRY_SAMPLE = [
@@ -48,10 +60,12 @@ MOCK_TELEMETRY_SAMPLE = [
     Row(addon_guid="test-guid-4", install_count=400),
 ]
 
-EXPECTED_ADDON_INSTALLATIONS = {u'test-guid-1': 100,
-                                u'test-guid-2': 200,
-                                u'test-guid-3': 300,
-                                u'test-guid-4': 400}
+EXPECTED_ADDON_INSTALLATIONS = {
+    u"test-guid-1": 100,
+    u"test-guid-2": 200,
+    u"test-guid-3": 300,
+    u"test-guid-4": 400,
+}
 
 
 def test_extract_phase(spark):
@@ -63,13 +77,16 @@ def test_extract_phase(spark):
 
     def lambda_func(x):
         return (x.addon_guid, x.install_count)
+
     output = dict(extract_df.rdd.map(lambda_func).collect())
-    EXPECTED = {u'test-guid-1': 1,
-                u'test-guid-2': 3,
-                u'test-guid-3': 3,
-                u'test-guid-4': 2,
-                u'test-guid-5': 2,
-                u'test-guid-6': 1}
+    EXPECTED = {
+        u"test-guid-1": 1,
+        u"test-guid-2": 3,
+        u"test-guid-3": 3,
+        u"test-guid-4": 2,
+        u"test-guid-5": 2,
+        u"test-guid-6": 1,
+    }
     assert EXPECTED == output
 
 
@@ -92,18 +109,18 @@ def test_transform_is_valid(spark):
 def test_load_s3(spark):
     BUCKET = taar_lite_guidranking.OUTPUT_BUCKET
     PREFIX = taar_lite_guidranking.OUTPUT_PREFIX
-    dest_filename = taar_lite_guidranking.OUTPUT_BASE_FILENAME + '.json'
+    dest_filename = taar_lite_guidranking.OUTPUT_BASE_FILENAME + ".json"
 
     # Create the bucket before we upload
-    conn = boto3.resource('s3', region_name='us-west-2')
+    conn = boto3.resource("s3", region_name="us-west-2")
     bucket_obj = conn.create_bucket(Bucket=BUCKET)
 
     rdd = spark.createDataFrame(MOCK_TELEMETRY_SAMPLE)
     result_json = taar_lite_guidranking.transform(rdd)
-    taar_lite_guidranking.load_s3(result_json, '20180301', PREFIX, BUCKET)
+    taar_lite_guidranking.load_s3(result_json, "20180301", PREFIX, BUCKET)
 
     # Now check that the file is there
     available_objects = list(bucket_obj.objects.filter(Prefix=PREFIX))
-    full_s3_name = '{}{}'.format(PREFIX, dest_filename)
+    full_s3_name = "{}{}".format(PREFIX, dest_filename)
     keys = [o.key for o in available_objects]
     assert full_s3_name in keys

--- a/tests/test_taar_locale.py
+++ b/tests/test_taar_locale.py
@@ -84,7 +84,8 @@ default_sample = {
             "signed_state": 2,
             "type": "extension",
             "user_disabled": False,
-        }, {
+        },
+        {
             "addon_id": "non-whitelisted-addon",
             "app_disabled": False,
             "blocklisted": False,
@@ -93,7 +94,7 @@ default_sample = {
             "signed_state": 2,
             "type": "extension",
             "user_disabled": False,
-        }
+        },
     ],
 }
 
@@ -169,7 +170,7 @@ def test_generate_dictionary(spark, multi_locales_df):
 
     # The "en-US" locale must not be reported: we set it to a low
     # frequency on |multi_locale_df|.
-    expected = {'it-IT': [['test-guid-0001', 1.0]]}
+    expected = {"it-IT": [["test-guid-0001", 1.0]]}
 
     actual = taar_locale.generate_dictionary(spark, 5)
     assert actual == expected

--- a/tests/test_taar_similarity.py
+++ b/tests/test_taar_similarity.py
@@ -289,16 +289,18 @@ def test_get_samples(spark, dataframe_factory):
         }
 
     data = [
-        client_row("c-1", "20181219", 5), client_row("c-1", "20181220", 20),
+        client_row("c-1", "20181219", 5),
+        client_row("c-1", "20181220", 20),
         client_row("c-2", "20181220"),
         client_row("c-3", "20181001"),
     ]
 
-    clients_sample = dataframe_factory.create_dataframe(snippets=data, base=default_sample,
-                                                        schema=clientsdaily_schema)
+    clients_sample = dataframe_factory.create_dataframe(
+        snippets=data, base=default_sample, schema=clientsdaily_schema
+    )
     clients_sample.createOrReplaceTempView("clients_daily")
 
-    samples_df = taar_similarity.get_samples(spark, date_from='20181201')
+    samples_df = taar_similarity.get_samples(spark, date_from="20181201")
     samples_df.cache()
 
     # There should be two entries since `c-1` occurred twice in original dataset
@@ -311,7 +313,7 @@ def test_get_samples(spark, dataframe_factory):
 
 def test_get_addons(spark, addon_whitelist, multi_clusters_df):
 
-    samples_df = taar_similarity.get_samples(spark, date_from='20180101')
+    samples_df = taar_similarity.get_samples(spark, date_from="20180101")
 
     # Force caching in the test case
     samples_df.cache()
@@ -330,7 +332,7 @@ def test_compute_donors(spark, addon_whitelist, multi_clusters_df):
     # Perform the clustering on our test data. We expect
     # 3 clusters out of this and 10 donors.
     _, donors_df = taar_similarity.get_donors(
-        spark, 3, 10, addon_whitelist, date_from='20180101', random_seed=42
+        spark, 3, 10, addon_whitelist, date_from="20180101", random_seed=42
     )
     donors = taar_similarity.format_donors_dictionary(donors_df)
 

--- a/tests/test_tab_spinner_aggregates.py
+++ b/tests/test_tab_spinner_aggregates.py
@@ -6,7 +6,7 @@ from mozetl.tab_spinner.utils import get_short_and_long_spinners
 
 
 def create_row():
-    with open('tests/tab_spinner_ping.json') as infile:
+    with open("tests/tab_spinner_ping.json") as infile:
         return json.load(infile)
 
 
@@ -26,7 +26,7 @@ def test_simple_transform(simple_rdd, spark_context):
 
     expected = {
         "short": {"20170101": pd.Series([0, 1.0, 0, 0, 0, 0, 0, 0])},
-        "long": {"20170101":  pd.Series([0, 0.0, 1.0, 0, 0, 0, 0, 0])}
+        "long": {"20170101": pd.Series([0, 0.0, 1.0, 0, 0, 0, 0, 0])},
     }
 
     for k, v in expected.items():

--- a/tests/test_topline_historical_backfill.py
+++ b/tests/test_topline_historical_backfill.py
@@ -12,8 +12,10 @@ from six import text_type
 @pytest.fixture(autouse=True)
 def no_spark_stop(monkeypatch):
     """ Disable stopping the shared spark session during tests """
+
     def nop(*args, **kwargs):
         print("Disabled spark.stop for testing")
+
     monkeypatch.setattr("pyspark.sql.SparkSession.stop", nop)
 
 
@@ -33,7 +35,7 @@ default_sample = {
     "google": "1",
     "bing": "1",
     "yahoo": "1",
-    "other": "1"
+    "other": "1",
 }
 
 
@@ -42,21 +44,21 @@ def generate_data(dataframe_factory):
     return functools.partial(
         dataframe_factory.create_dataframe,
         base=default_sample,
-        schema=historical_schema
+        schema=historical_schema,
     )
 
 
 # does not include rows containing `all` from original data
 def test_excludes_rows_containing_all(spark, generate_data, tmpdir):
     snippets = [
-        {'geo': 'all'},
-        {'os': 'all'},
-        {'channel': 'all'},
-        {}  # There must be a single data point
+        {"geo": "all"},
+        {"os": "all"},
+        {"channel": "all"},
+        {},  # There must be a single data point
     ]
     input_df = generate_data(snippets)
 
-    path = str(tmpdir.join('test/mode=weekly/'))
+    path = str(tmpdir.join("test/mode=weekly/"))
     backfill.backfill_topline_summary(input_df, path, overwrite=True)
 
     df = spark.read.parquet(path)
@@ -66,10 +68,7 @@ def test_excludes_rows_containing_all(spark, generate_data, tmpdir):
 
 
 def test_multiple_dates_fails(generate_data, tmpdir):
-    snippets = [
-        {'date': '2016-01-01'},
-        {'date': '2016-01-08'}
-    ]
+    snippets = [{"date": "2016-01-01"}, {"date": "2016-01-08"}]
     input_df = generate_data(snippets)
 
     path = str(tmpdir)
@@ -79,60 +78,48 @@ def test_multiple_dates_fails(generate_data, tmpdir):
 
 # writes out partitions by report_date
 def test_multiple_dates_batch(generate_data, tmpdir):
-    snippets = [
-        {'date': '2016-01-01'},
-        {'date': '2016-01-08'}
-    ]
+    snippets = [{"date": "2016-01-01"}, {"date": "2016-01-08"}]
     input_df = generate_data(snippets)
 
     path = str(tmpdir)
-    backfill.backfill_topline_summary(input_df, path,
-                                      batch=True, overwrite=True)
+    backfill.backfill_topline_summary(input_df, path, batch=True, overwrite=True)
 
-    parts = [name for name in os.listdir(path)
-             if name.startswith('report_start')]
+    parts = [name for name in os.listdir(path) if name.startswith("report_start")]
     assert len(parts) == 2
 
 
 # data is correctly written to the correct location given default prefix
 def test_cli_monthly(generate_data, tmpdir, monkeypatch):
     # generate test data
-    snippets = [
-        {'date': '2016-01-01'},
-    ]
+    snippets = [{"date": "2016-01-01"}]
     input_df = generate_data(snippets)
 
     # add a csv file to the test folder
     toplevel = tmpdir
-    input_csv = toplevel.join('test.csv')
+    input_csv = toplevel.join("test.csv")
 
-    csv_data = ','.join(input_df.columns) + '\n'
+    csv_data = ",".join(input_df.columns) + "\n"
     for row in input_df.collect():
-        csv_data += ','.join([text_type(x) for x in row]) + '\n'
+        csv_data += ",".join([text_type(x) for x in row]) + "\n"
 
     input_csv.write(csv_data)
 
     # create the output directory
-    testdir = toplevel.join('test')
+    testdir = toplevel.join("test")
     output_path = str(testdir)
 
     # change s3_path to use file:// protocol
     def mock_format_output_path(bucket, prefix):
         return "file://{}/{}".format(bucket, prefix)
-    monkeypatch.setattr(backfill, 'format_output_path',
-                        mock_format_output_path)
+
+    monkeypatch.setattr(backfill, "format_output_path", mock_format_output_path)
 
     # Run the application via the cli
     runner = CliRunner()
-    args = [
-        'file://' + str(input_csv),
-        'monthly',
-        output_path
-    ]
+    args = ["file://" + str(input_csv), "monthly", output_path]
     result = runner.invoke(backfill.main, args)
     assert result.exit_code == 0
 
     # test that the results can be read via spark
-    path = str(testdir.join('topline_summary/v1/'
-                            'mode=monthly/report_start=20160101'))
+    path = str(testdir.join("topline_summary/v1/" "mode=monthly/report_start=20160101"))
     assert os.path.isdir(path)

--- a/tests/test_topline_summary.py
+++ b/tests/test_topline_summary.py
@@ -6,7 +6,12 @@ import pytest
 from click.testing import CliRunner
 from pyspark.sql import functions as F, Row
 from pyspark.sql.types import (
-    StructField, StructType, StringType, BooleanType, ArrayType, LongType
+    StructField,
+    StructType,
+    StringType,
+    BooleanType,
+    ArrayType,
+    LongType,
 )
 from six import text_type
 
@@ -23,7 +28,7 @@ def generate_dates(submission_date_s3, ts_offset=0, creation_offset=0):
     # variables for conversion
     epoch = arrow.get(0)
     seconds_per_day = topline.seconds_per_day
-    nanoseconds_per_second = 10**9
+    nanoseconds_per_second = 10 ** 9
 
     date_snippet = {
         "submission_date_s3": submission_date_s3,
@@ -32,40 +37,44 @@ def generate_dates(submission_date_s3, ts_offset=0, creation_offset=0):
         ),
         "timestamp": (
             int((timestamp - epoch).total_seconds() * nanoseconds_per_second)
-        )
+        ),
     }
 
     return date_snippet
 
 
-def search_row(engine='hooli', count=1, source='searchbar'):
-    return Row(
-        engine=text_type(engine),
-        source=text_type(source),
-        count=count
-    )
+def search_row(engine="hooli", count=1, source="searchbar"):
+    return Row(engine=text_type(engine), source=text_type(source), count=count)
 
 
-schema = StructType([
-    StructField("document_id", StringType(), True),
-    StructField("client_id", StringType(), True),
-    StructField("timestamp", StringType(), True),
-    StructField("is_default_browser", BooleanType(), True),
-    StructField("search_counts",
-                ArrayType(
-                    StructType([
+schema = StructType(
+    [
+        StructField("document_id", StringType(), True),
+        StructField("client_id", StringType(), True),
+        StructField("timestamp", StringType(), True),
+        StructField("is_default_browser", BooleanType(), True),
+        StructField(
+            "search_counts",
+            ArrayType(
+                StructType(
+                    [
                         StructField("engine", StringType(), True),
                         StructField("source", StringType(), True),
-                        StructField("count", LongType(), True)
-                    ]), True),
-                True),
-    StructField("country", StringType(), True),
-    StructField("profile_creation_date", LongType(), True),
-    StructField("normalized_channel", StringType(), True),
-    StructField("os", StringType(), True),
-    StructField("subsession_length", LongType(), True),
-    StructField("submission_date_s3", StringType(), True),
-])
+                        StructField("count", LongType(), True),
+                    ]
+                ),
+                True,
+            ),
+            True,
+        ),
+        StructField("country", StringType(), True),
+        StructField("profile_creation_date", LongType(), True),
+        StructField("normalized_channel", StringType(), True),
+        StructField("os", StringType(), True),
+        StructField("subsession_length", LongType(), True),
+        StructField("submission_date_s3", StringType(), True),
+    ]
+)
 
 
 start_ds = "20170601"
@@ -74,7 +83,7 @@ end_ds = "20170608"
 default_sample = {
     "document_id": "document-id",
     "client_id": "client-id",
-    "timestamp": int(1.4962752e+18),
+    "timestamp": int(1.4962752e18),
     "is_default_browser": True,
     "search_counts": [search_row()],
     "country": "US",
@@ -93,7 +102,7 @@ def generate_data(dataframe_factory):
         dataframe_factory.create_dataframe_with_key,
         base=default_sample,
         key="document_id",
-        schema=schema
+        schema=schema,
     )
 
 
@@ -111,7 +120,7 @@ def cool_df(dataframe_factory):
         "penguin suit",
         # anywhere
         "dinosaurs are always cool",
-        "chickens are dinosaurs, somewhat"
+        "chickens are dinosaurs, somewhat",
     ]
     snippets = [{"items": row} for row in rows]
     base = {"items": "foo"}
@@ -130,12 +139,7 @@ def test_column_like(cool_df):
 
 @pytest.mark.skip(reason="Bug 1377730 - Weekly Topline Summary aborts on save")
 def test_deduplicate_documents(dataframe_factory):
-    snippets = [
-        {"document_id": "1"},
-        {"document_id": "2"},
-        {"document_id": "2"},
-
-    ]
+    snippets = [{"document_id": "1"}, {"document_id": "2"}, {"document_id": "2"}]
     df = dataframe_factory.create_dataframe(snippets, default_sample, schema=schema)
 
     res = topline.clean_input(df, start_ds, end_ds)
@@ -147,7 +151,7 @@ def test_clean_input_date_range(generate_data):
         generate_dates("20170601"),
         generate_dates("20170602"),
         generate_dates("20170501"),
-        generate_dates("20170608")
+        generate_dates("20170608"),
     ]
 
     df = generate_data(snippets)
@@ -156,10 +160,7 @@ def test_clean_input_date_range(generate_data):
 
 
 def test_clean_input_country(generate_data):
-    snippets = [
-        {"country": "INVALID"},
-        {"country": "US"}
-    ]
+    snippets = [{"country": "INVALID"}, {"country": "US"}]
 
     df = generate_data(snippets)
     res = topline.clean_input(df, start_ds, end_ds)
@@ -168,10 +169,7 @@ def test_clean_input_country(generate_data):
 
 
 def test_clean_input_profile_creation(generate_data):
-    snippets = [
-        {"profile_creation_date": 1},
-        {"profile_creation_date": -1},
-    ]
+    snippets = [{"profile_creation_date": 1}, {"profile_creation_date": -1}]
 
     df = generate_data(snippets)
     res = topline.clean_input(df, start_ds, end_ds)
@@ -182,8 +180,14 @@ def test_clean_input_profile_creation(generate_data):
 
 def test_clean_input_os(generate_data):
     oses = [
-        "Windows_NT", "WINNT", "Darwin", "Linux",   # 4
-        "xWindows", "Mac", "SUN", "BaDsTrInG",      # 4
+        "Windows_NT",
+        "WINNT",
+        "Darwin",
+        "Linux",  # 4
+        "xWindows",
+        "Mac",
+        "SUN",
+        "BaDsTrInG",  # 4
     ]
     snippets = [{"os": os} for os in oses]
     df = generate_data(snippets)
@@ -211,13 +215,7 @@ def test_transform_searches(generate_data):
     snippets = [
         {"search_counts": None},
         {"search_counts": [search_row("google")]},
-        {
-            "country": "CA",
-            "search_counts": [
-                search_row("hooli"),
-                search_row("google")
-            ]
-        },
+        {"country": "CA", "search_counts": [search_row("hooli"), search_row("google")]},
     ]
 
     df = generate_data(snippets)
@@ -226,18 +224,15 @@ def test_transform_searches(generate_data):
     assert res.count() == 2
     assert res.groupBy().sum().first()["sum(google)"] == 2
     assert (
-        res
-        .groupBy("geo")
-        .sum()
-        .where(F.col("geo") == "CA")
-        .first()["sum(other)"]) == 1
+        res.groupBy("geo").sum().where(F.col("geo") == "CA").first()["sum(other)"]
+    ) == 1
 
 
 def test_transform_searches_filters_incontent(generate_data):
     snippets = [
-        {'search_counts': [search_row("google", source="in-content")]},   # no
-        {'search_counts': [search_row("google", source="contextmenu")]},  # yes
-        {'search_counts': [search_row("google", source="abouthome")]},    # yes
+        {"search_counts": [search_row("google", source="in-content")]},  # no
+        {"search_counts": [search_row("google", source="contextmenu")]},  # yes
+        {"search_counts": [search_row("google", source="abouthome")]},  # yes
     ]
 
     df = generate_data(snippets)
@@ -260,34 +255,20 @@ def test_transform_hours(generate_data):
     assert res.count() == 2
     assert res.groupBy().sum().first()["sum(hours)"] == 2.0
     assert (
-        res
-        .groupBy("geo")
-        .sum()
-        .where(F.col("geo") == "CA")
-        .first()["sum(hours)"]) == 1.0
+        res.groupBy("geo").sum().where(F.col("geo") == "CA").first()["sum(hours)"]
+    ) == 1.0
 
 
 def test_transform_clients(generate_data):
     submission_dates = generate_dates(start_ds)
     snippets = [
         # not new, default
-        {
-            "client_id": "0",
-            "profile_creation_date": 0,
-        },
+        {"client_id": "0", "profile_creation_date": 0},
         # new, but duplicate
-        {
-            "client_id": "1"
-        },
-        {
-            "client_id": "1",
-            "timestamp": submission_dates["timestamp"] + 1,
-        },
+        {"client_id": "1"},
+        {"client_id": "1", "timestamp": submission_dates["timestamp"] + 1},
         # new, not default
-        {
-            "client_id": "2",
-            "is_default_browser": False
-        }
+        {"client_id": "2", "is_default_browser": False},
     ]
 
     df = generate_data(snippets)
@@ -305,34 +286,30 @@ def test_job_weekly(spark, generate_data, monkeypatch, tmpdir):
     test_bucket = str(tmpdir)
     test_prefix = "prefix"
 
-    snippets = [
-        {"client_id": "1"},
-        {"client_id": "2"},
-        {"client_id": "3"},
-    ]
+    snippets = [{"client_id": "1"}, {"client_id": "2"}, {"client_id": "3"}]
 
     def mock_extract(spark_session, source_path):
         return generate_data(snippets)
-    monkeypatch.setattr(topline, 'extract', mock_extract)
+
+    monkeypatch.setattr(topline, "extract", mock_extract)
 
     def mock_format_spark_path(bucket, prefix):
         return "file://{}/{}".format(bucket, prefix)
-    monkeypatch.setattr(topline, 'format_spark_path', mock_format_spark_path)
+
+    monkeypatch.setattr(topline, "format_spark_path", mock_format_spark_path)
 
     runner = CliRunner()
-    args = [
-        start_ds,
-        "weekly",
-        test_bucket,
-        test_prefix,
-    ]
+    args = [start_ds, "weekly", test_bucket, test_prefix]
 
     result = runner.invoke(topline.main, args)
     assert result.exit_code == 0
 
     # assert path was written
-    assert os.path.isdir("{}/{}/v1/mode=weekly/report_start={}"
-                         .format(test_bucket, test_prefix, start_ds))
+    assert os.path.isdir(
+        "{}/{}/v1/mode=weekly/report_start={}".format(
+            test_bucket, test_prefix, start_ds
+        )
+    )
 
     # assert data can be read
     path = mock_format_spark_path(test_bucket, test_prefix)
@@ -343,5 +320,7 @@ def test_job_weekly(spark, generate_data, monkeypatch, tmpdir):
     assert row.actives == 3
 
     # the module schema does not include the mode, and the partition column is a string
-    df = df.drop("mode").withColumn("report_start", F.col("report_start").astype("string"))
+    df = df.drop("mode").withColumn(
+        "report_start", F.col("report_start").astype("string")
+    )
     assert df.schema == topline_schema

--- a/tests/test_txp_mau_dau.py
+++ b/tests/test_txp_mau_dau.py
@@ -4,18 +4,19 @@ import requests
 import json
 
 
-class MockRequest():
+class MockRequest:
     def raise_for_status(self):
         pass
 
     def json(self):
-        return json.loads(get_resource('txp_experiments.json'))
+        return json.loads(get_resource("txp_experiments.json"))
 
 
 def test_get_experiments(monkeypatch):
     def mock_get(url):
         return MockRequest()
-    monkeypatch.setattr(requests, 'get', mock_get)
+
+    monkeypatch.setattr(requests, "get", mock_get)
     # There are 14 total experiments in the file but one should be filtered out
     # due to not having an addon_id -- we base this mau/dau on the addons dataset
     assert len(get_experiments()) == 13

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,9 +7,7 @@ from moto import mock_s3
 
 from mozetl import utils
 
-default_sample = {
-    "test": "data",
-}
+default_sample = {"test": "data"}
 
 
 @pytest.fixture()
@@ -17,23 +15,23 @@ def generate_data(dataframe_factory):
     """Return a function that generates a dataframe from a list of strings."""
 
     def create_dataframe_from_list(row=None):
-        snippets = None if row is None else [{'test': x} for x in row]
+        snippets = None if row is None else [{"test": x} for x in row]
         return dataframe_factory.create_dataframe(snippets, default_sample)
 
     return create_dataframe_from_list
 
 
 def test_write_csv_ascii(generate_data, tmpdir):
-    test_data = ['hello', 'world']
+    test_data = ["hello", "world"]
     df = generate_data(test_data)
 
-    path = str(tmpdir.join('test_data.csv'))
+    path = str(tmpdir.join("test_data.csv"))
     utils.write_csv(df, path)
 
-    with open(path, 'rb') as f:
+    with open(path, "rb") as f:
         data = f.read()
 
-    assert [l.decode('utf-8') for l in data.rstrip().split(b'\r\n')[1:]] == test_data
+    assert [l.decode("utf-8") for l in data.rstrip().split(b"\r\n")[1:]] == test_data
 
 
 def test_generate_filter_parameters():
@@ -41,102 +39,87 @@ def test_generate_filter_parameters():
     Check the two meaningful cases: DAU (0 days) and MAU(28 days).
     """
     expected0 = {
-        'min_activity_iso': '2017-01-31',
-        'max_activity_iso': '2017-02-01',
-        'min_submission_string': '20170131',
-        'max_submission_string': '20170210'
+        "min_activity_iso": "2017-01-31",
+        "max_activity_iso": "2017-02-01",
+        "min_submission_string": "20170131",
+        "max_submission_string": "20170210",
     }
     actual0 = utils.generate_filter_parameters(DT.date(2017, 1, 31), 0)
     assert expected0 == actual0, str(actual0)
 
     expected28 = {
-        'min_activity_iso': '2017-01-03',
-        'max_activity_iso': '2017-02-01',
-        'min_submission_string': '20170103',
-        'max_submission_string': '20170210'
+        "min_activity_iso": "2017-01-03",
+        "max_activity_iso": "2017-02-01",
+        "min_submission_string": "20170103",
+        "max_submission_string": "20170210",
     }
     actual28 = utils.generate_filter_parameters(DT.date(2017, 1, 31), 28)
     assert expected28 == actual28
 
 
 def test_write_csv_valid_unicode(generate_data, tmpdir):
-    test_data = [u'∆', u'∫', u'∬']
+    test_data = [u"∆", u"∫", u"∬"]
     df = generate_data(test_data)
 
-    path = str(tmpdir.join('test_data.csv'))
+    path = str(tmpdir.join("test_data.csv"))
     utils.write_csv(df, path)
 
-    with open(path, 'rb') as f:
+    with open(path, "rb") as f:
         data = f.read()
 
-    assert [l.decode('utf-8') for l in data.rstrip().split(b'\r\n')[1:]] == test_data
+    assert [l.decode("utf-8") for l in data.rstrip().split(b"\r\n")[1:]] == test_data
 
 
 @mock_s3
 def test_write_csv_to_s3(generate_data):
-    bucket = 'test-bucket'
-    key = 'test.csv'
+    bucket = "test-bucket"
+    key = "test.csv"
 
-    conn = boto3.resource('s3', region_name='us-west-2')
+    conn = boto3.resource("s3", region_name="us-west-2")
     conn.create_bucket(Bucket=bucket)
 
     utils.write_csv_to_s3(generate_data(["foo"]), bucket, key)
 
-    body = (
-        conn
-        .Object(bucket, key)
-        .get()['Body']
-        .read().decode('utf-8')
-    )
+    body = conn.Object(bucket, key).get()["Body"].read().decode("utf-8")
 
     # header + 1x row = 2
-    assert len(body.rstrip().split('\n')) == 2
+    assert len(body.rstrip().split("\n")) == 2
 
 
 @mock_s3
 def test_write_csv_to_s3_no_header(generate_data):
-    bucket = 'test-bucket'
-    key = 'test.csv'
+    bucket = "test-bucket"
+    key = "test.csv"
 
-    conn = boto3.resource('s3', region_name='us-west-2')
+    conn = boto3.resource("s3", region_name="us-west-2")
     conn.create_bucket(Bucket=bucket)
 
     utils.write_csv_to_s3(generate_data(), bucket, key, header=False)
 
-    body = (
-        conn
-        .Object(bucket, key)
-        .get()['Body']
-        .read().decode('utf-8')
-    )
+    body = conn.Object(bucket, key).get()["Body"].read().decode("utf-8")
 
-    assert len(body.rstrip().split('\n')) == 1
+    assert len(body.rstrip().split("\n")) == 1
 
 
 @mock_s3
 def test_write_csv_to_s3_existing(generate_data):
-    bucket = 'test-bucket'
-    key = 'test.csv'
+    bucket = "test-bucket"
+    key = "test.csv"
 
-    conn = boto3.resource('s3', region_name='us-west-2')
+    conn = boto3.resource("s3", region_name="us-west-2")
     conn.create_bucket(Bucket=bucket)
 
     utils.write_csv_to_s3(generate_data(["foo"]), bucket, key)
     utils.write_csv_to_s3(generate_data(["foo", "bar"]), bucket, key)
 
-    body = (
-        conn
-        .Object(bucket, key)
-        .get()['Body']
-        .read().decode('utf-8')
-    )
+    body = conn.Object(bucket, key).get()["Body"].read().decode("utf-8")
 
     # header + 2x row = 3
-    assert len(body.rstrip().split('\n')) == 3
+    assert len(body.rstrip().split("\n")) == 3
 
 
 def test_stop_session_safely_emr():
-    spark_session = Mock(conf={'spark.home': '/var/lib/spark/'})
+    spark_session = Mock(conf={"spark.home": "/var/lib/spark/"})
 
     utils.stop_session_safely(spark_session)
 
@@ -144,7 +127,7 @@ def test_stop_session_safely_emr():
 
 
 def test_stop_session_safely_databricks():
-    spark_session = Mock(conf={'spark.home': '/databricks/spark'})
+    spark_session = Mock(conf={"spark.home": "/databricks/spark"})
 
     utils.stop_session_safely(spark_session)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,7 @@ def get_resource_path(filename):
     :return: the fully qualified path for the file as a string
     """
     root = os.path.dirname(__file__)
-    return os.path.join(root, 'resources', filename)
+    return os.path.join(root, "resources", filename)
 
 
 def get_resource(filename):


### PR DESCRIPTION
This is part 3 in a series to support python 3 in mozetl.

Black is a code formatting tool to keep style consistent across the code-base. It may help to reformat things in light of running other automated tools like 2to3. This is enforced in CI, so this fixes all of the tests introduced in #290.

This PR should be equivalent to #282. 