### PR TITLE
Improve Taar similarity jobs performance, fix #280

### DIFF
--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -34,6 +34,7 @@ CONTINUOUS_FEATURES = [
 ]
 
 logging.basicConfig(level=logging.INFO)
+logging.getLogger("py4j").setLevel(logging.ERROR)
 logger = logging.getLogger(__name__)
 
 

--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -62,7 +62,7 @@ def get_samples(spark):
             "client_id as client_id",
             "active_addons as active_addons",
             "city as city",
-            "subsession_hours_sum",
+            "cast(subsession_hours_sum as double)",
             "locale as locale",
             "os as os",
             "places_bookmarks_count_mean AS bookmark_count",

--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -19,6 +19,7 @@ from pyspark.ml.feature import HashingTF, IDF
 from pyspark.ml.clustering import BisectingKMeans
 from pyspark.ml import Pipeline
 from pyspark.mllib.stat import KernelDensity
+from pyspark.statcounter import StatCounter
 from scipy.spatial import distance
 from taar_utils import store_json_to_s3
 from taar_utils import load_amo_curated_whitelist
@@ -306,8 +307,9 @@ def get_lr_curves(
 
     # Determine a range of observed similarity values linearly spaced.
     all_scores_rdd = same_cluster_scores_rdd.union(different_clusters_scores_rdd)
-    min_similarity = all_scores_rdd.min()
-    max_similarity = all_scores_rdd.max()
+    stats = all_scores_rdd.aggregate(StatCounter(), StatCounter.merge, StatCounter.mergeStats)
+    min_similarity = stats.minValue
+    max_similarity = stats.maxValue
     lr_index = np.arange(
         min_similarity,
         max_similarity,

--- a/mozetl/taar/taar_similarity.py
+++ b/mozetl/taar/taar_similarity.py
@@ -174,6 +174,7 @@ def get_donors(spark, num_clusters, num_donors, addon_whitelist, random_seed=Non
     # Get add-ons from selected users and make sure they are
     # useful for making a recommendation.
     addons_df = get_addons_per_client(users_sample, addon_whitelist, 2)
+    addons_df.cache()
     # Perform clustering by using the add-on info.
     clusters = compute_clusters(addons_df, num_clusters, random_seed)
     # Sample representative ("donors") users from each cluster.
@@ -359,6 +360,7 @@ def main(
 
     # Compute the donors clusters and the LR curves.
     cluster_ids, donors_df = get_donors(spark, num_clusters, num_donors, whitelist)
+    donors_df.cache()
     lr_curves = get_lr_curves(
         spark, donors_df, cluster_ids, kernel_bandwidth, num_pdf_points
     )

--- a/tests/test_taar_similarity.py
+++ b/tests/test_taar_similarity.py
@@ -321,6 +321,7 @@ def test_get_addons(spark, addon_whitelist, multi_clusters_df):
     assert isinstance(addons_df.schema.fields[1].dataType, ArrayType)
 
 
+@pytest.mark.timeout(600)
 def test_compute_donors(spark, addon_whitelist, multi_clusters_df):
     multi_clusters_df.createOrReplaceTempView("clients_daily")
 


### PR DESCRIPTION
This PR:
* limits clients' sample to 1 row per client from the last 90 days (configurable), fixes #280
* contains some performance and minor improvements (of which the most important is caching iteratively read datasets)

/cc @mlopatka @crankycoder 