### PR TITLE
Fix test pilot experiments fetch

### DIFF
--- a/mozetl/addon_aggregates/addon_aggregates.py
+++ b/mozetl/addon_aggregates/addon_aggregates.py
@@ -30,12 +30,16 @@ def get_test_pilot_addons():
     the experiments.json file.
     :return a list of addon_ids
     """
-    url = "https://testpilot.firefox.com/api/experiments.json"
-    response = urllib.request.urlopen(url)
-    data = json.loads(response.read().decode("utf-8"))
-    all_tp_addons = ["@testpilot-addon"] + [
-        i.get("addon_id") for i in data["results"] if i.get("addon_id")
-    ]
+    try:
+        url = "https://testpilot.firefox.com/api/experiments.json"
+        response = urllib.request.urlopen(url)
+        data = json.loads(response.read().decode("utf-8"))
+        all_tp_addons = ["@testpilot-addon"] + [
+            i.get("addon_id") for i in data["results"] if i.get("addon_id")
+        ]
+    except:  # noqa
+        print("Couldn't fetch experiments.json from testpilot")
+        all_tp_addons = []
     return all_tp_addons
 
 


### PR DESCRIPTION
This is a quick fix for fetching test pilot experiments list.
Test pilot was retired making this function throw exception, this should be revisited with a proper fix.