### PR TITLE
[hotfix!] Update dependencies for churn-v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,13 @@
 from setuptools import setup, find_packages
 
 test_deps = [
-    'coverage',
-    'pytest-cov',
-    'pytest-timeout',
-    'moto',
-    'mock',
-    'pytest',
+    'coverage==4.5.2',
+    'pytest-cov==2.6.0',
+    'pytest-timeout==1.3.3',
+    'moto==1.3.6',
+    'mock==2.0.0',
+    'pytest==3.10.1',
+    'flake8==3.6.0'
 ]
 
 extras = {
@@ -24,14 +25,19 @@ setup(
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     install_requires=[
-        'pyspark',
-        'python_moztelemetry',  # TODO: pin version
-        'click',
-        'requests',
-        'click_datetime',
-        'arrow',
-        'scipy',
-        'numpy'
+        'arrow==0.10.0',
+        'click==6.7',
+        'click_datetime==0.2',
+        'numpy==1.13.3',
+        'pandas>=0.23.0',
+        'pyspark==2.3.1',
+        'pyspark_hyperloglog==2.1.1',
+        'python_moztelemetry==0.10.2',
+        'requests-toolbelt==0.8.0',
+        'requests==2.20.1',
+        'scipy==1.0.0rc1',
+        'typing==3.6.4',
+        'six==1.11.0',
     ],
     tests_require=test_deps,
     extras_require=extras,


### PR DESCRIPTION
```
Traceback (most recent call last):
File "/tmp/tmp.JRoh7UGRIS/runner.py", line 1, in 
from mozetl import cli
File "build/bdist.linux-x86_64/egg/mozetl/__init__.py", line 1, in 
File "build/bdist.linux-x86_64/egg/mozetl/main.py", line 4, in 
File "/mnt/anaconda2/lib/python2.7/site-packages/moztelemetry/__init__.py", line 2, in 
from .spark import *
File "/mnt/anaconda2/lib/python2.7/site-packages/moztelemetry/spark.py", line 17, in 
from .histogram import Histogram
File "/mnt/anaconda2/lib/python2.7/site-packages/moztelemetry/histogram.py", line 12, in 
import pandas as pd
File "/mnt/anaconda2/lib/python2.7/site-packages/pandas/__init__.py", line 23, in 
from pandas.compat.numpy import *
File "/mnt/anaconda2/lib/python2.7/site-packages/pandas/compat/numpy/__init__.py", line 22, in 
'this pandas version'.format(_np_version))
ImportError: this version of pandas is incompatible with numpy < 1.12.0
your numpy version is 1.11.1.
Please upgrade numpy to >= 1.12.0 to use this pandas version
```