### PR TITLE
Add a minimal click command for the tab spinner etl job

### DIFF
--- a/mozetl/cli.py
+++ b/mozetl/cli.py
@@ -10,6 +10,7 @@ from mozetl.landfill import sampler as landfill_sampler
 from mozetl.maudau import maudau
 from mozetl.search.aggregates import search_aggregates_click, search_clients_daily_click
 from mozetl.sync import bookmark_validation
+from mozetl.tab_spinner import tab_spinner
 from mozetl.taar import (
     taar_locale,
     taar_similarity,
@@ -46,6 +47,7 @@ entry_point.add_command(taar_update_whitelist.main, "taar_update_whitelist")
 entry_point.add_command(addon_aggregates.main, "addon_aggregates")
 entry_point.add_command(maudau.main, "engagement_ratio")
 entry_point.add_command(landfill_sampler.main, "landfill_sampler")
+entry_point.add_command(tab_spinner.main, "long_tab_spinners")
 
 # Kept for backwards compatibility
 entry_point.add_command(search_aggregates_click, "search_dashboard")

--- a/mozetl/tab_spinner/tab_spinner.py
+++ b/mozetl/tab_spinner/tab_spinner.py
@@ -1,0 +1,13 @@
+import click
+from pyspark.sql import SparkSession
+from generate_counts import run_spinner_etl
+
+
+@click.command()
+def main():
+    spark = SparkSession.builder.appName("long_tab_spinners").getOrCreate()
+    run_spinner_etl(spark)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This will let us use `mozetl-submit` inside airflow, which is quite
a bit cleaner.