### PR TITLE
Fix tab-spinner click command

### DIFF
--- a/mozetl/tab_spinner/tab_spinner.py
+++ b/mozetl/tab_spinner/tab_spinner.py
@@ -6,7 +6,7 @@ from generate_counts import run_spinner_etl
 @click.command()
 def main():
     spark = SparkSession.builder.appName("long_tab_spinners").getOrCreate()
-    run_spinner_etl(spark)
+    run_spinner_etl(spark.sparkContext)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We were passing the wrong type of spark object to the actual etl
code.