### PR TITLE
Pin pandas to 0.23.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     url='https://github.com/mozilla/python_mozetl.git',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
+    # PLEASE pin any dependencies to exact versions, otherwise things might unexpectedly break!!
     install_requires=[
         'arrow==0.10.0',
         'boto==2.49.0',
@@ -32,7 +33,7 @@ setup(
         'click==6.7',
         'click_datetime==0.2',
         'numpy==1.13.3',
-        'pandas>=0.23.0',
+        'pandas==0.23.4',
         'pyspark==2.3.1',
         'pyspark_hyperloglog==2.1.1',
         'python_moztelemetry==0.10.2',


### PR DESCRIPTION
It seems like the implicit upgrade to pandas 0.24 broke the tab spinner severity job, due to
a compatibility mismatch between the executor and workers. Let's pin our pandas version
to the last known working version (0.23.4) and add a comment warning people about this
in case they want to add new things in the future (the dependencies were explicitly pinned before 
for this exact reason). See: https://bugzilla.mozilla.org/show_bug.cgi?id=1525022