### PR TITLE
Pin pandas to 0.18.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     url='https://github.com/mozilla/python_mozetl.git',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    # PLEASE pin any dependencies to exact versions, otherwise things might unexpectedly break!!
     install_requires=[
         'arrow==0.10.0',
         'boto==2.49.0',
@@ -33,7 +32,7 @@ setup(
         'click==6.7',
         'click_datetime==0.2',
         'numpy==1.13.3',
-        'pandas==0.23.4',
+        'pandas==0.18.1',
         'pyspark==2.3.1',
         'pyspark_hyperloglog==2.1.1',
         'python_moztelemetry==0.10.2',

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,6 @@ setup(
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     # PLEASE pin any dependencies to exact versions, otherwise things might unexpectedly break!!
-    # When bumping dependencies, please keep the versions here in sync with the versions of
-    # the python packages installed by https://github.com/mozilla/emr-bootstrap-spark/
-    # (both explicitly and via the conda environment)
     install_requires=[
         'arrow==0.10.0',
         'boto==2.49.0',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'click==6.7',
         'click_datetime==0.2',
         'numpy==1.13.3',
-        'pandas==0.18.1',
+        'pandas==0.19.2',
         'pyspark==2.3.1',
         'pyspark_hyperloglog==2.1.1',
         'python_moztelemetry==0.10.2',

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,10 @@ setup(
     url='https://github.com/mozilla/python_mozetl.git',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
+    # PLEASE pin any dependencies to exact versions, otherwise things might unexpectedly break!!
+    # When bumping dependencies, please keep the versions here in sync with the versions of
+    # the python packages installed by https://github.com/mozilla/emr-bootstrap-spark/
+    # (both explicitly and via the conda environment)
     install_requires=[
         'arrow==0.10.0',
         'boto==2.49.0',


### PR DESCRIPTION
This is the version installed on the EMR clusters via anaconda 4.2.0: https://docs.anaconda.com/anaconda/packages/old-pkg-lists/4.2.0/py35/

This commit should unbreak jobs like the tab spinner which depend on the same version of pandas running on the executor as on the master.