### PR TITLE
Update `mozetl-databricks.py` for running external mozetl-compatible modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ python bin/mozetl-databricks.py \
 Run `python bin/mozetl-databricks.py --help` for more options, including increasing the number of workers and using python 3.
 Refer to this [pull request](https://github.com/mozilla/python_mozetl/pull/296) for more examples.
 
+It is also possible to use this script for external mozetl-compatible modules by setting the `--git-path` and `--module-name` options appropriately.
+See this [pull request](https://github.com/mozilla/python_mozetl/pull/316) for more information about building a mozetl-compatible repository that can be scheduled on Databricks.
+
 
 # Scheduling
 

--- a/bin/mozetl-databricks.py
+++ b/bin/mozetl-databricks.py
@@ -29,9 +29,7 @@ def generate_runner(module_name, instance, token):
     logging.debug(dedent(runner_data))
 
     request = {
-        "content": b64encode(dedent(runner_data)),
-        "format": "SOURCE",
-        "language": "PYTHON",
+        "contents": b64encode(dedent(runner_data)),
         "overwrite": True,
         "path": "/FileStore/airflow/{module}_runner.py".format(module=module_name),
     }
@@ -41,7 +39,7 @@ def generate_runner(module_name, instance, token):
         "Authorization": "Bearer {token}".format(token=token),
         "Content-Type": "application/json",
     }
-    conn.request("POST", "/api/2.0/workspace/import", json.dumps(request), headers)
+    conn.request("POST", "/api/2.0/dbfs/put", json.dumps(request), headers)
     resp = conn.getresponse()
     logging.info("status: {} reason: {}".format(resp.status, resp.reason))
     logging.info(resp.read())
@@ -61,7 +59,7 @@ def run_submit(args):
             },
         },
         "spark_python_task": {
-            "python_file": "s3://telemetry-airflow/steps/mozetl_runner.py",
+            "python_file": "dbfs:/FileStore/airflow/{module}_runner.py".format(args.module_name),
             "parameters": args.command,
         },
         "libraries": {

--- a/bin/mozetl-databricks.py
+++ b/bin/mozetl-databricks.py
@@ -1,12 +1,30 @@
 #!/usr/bin/env python2
 
 import argparse
-import httplib
 import os
 import json
 import logging
 from base64 import b64encode
 from textwrap import dedent
+
+try:
+    from urllib.request import urlopen, Request
+except ImportError:
+    from urllib2 import urlopen, Request
+
+
+def api_request(instance, route, data, token):
+    api_endpoint = "https://{instance}/{route}".format(
+        instance=instance, route=route.lstrip("/")
+    )
+    headers = {
+        "Authorization": "Bearer {token}".format(token=token),
+        "Content-Type": "application/json",
+    }
+    req = Request(api_endpoint, data=data.encode(), headers=headers)
+    resp = urlopen(req)
+    logging.info("status: {} info: {}".format(resp.getcode(), resp.info()))
+    return resp
 
 
 def generate_runner(module_name, instance, token):
@@ -29,21 +47,13 @@ def generate_runner(module_name, instance, token):
     logging.debug(dedent(runner_data))
 
     request = {
-        "contents": b64encode(dedent(runner_data)),
+        "contents": b64encode(dedent(runner_data).encode()).decode(),
         "overwrite": True,
         "path": "/FileStore/airflow/{module}_runner.py".format(module=module_name),
     }
     logging.debug(json.dumps(request, indent=2))
-    conn = httplib.HTTPSConnection(instance)
-    headers = {
-        "Authorization": "Bearer {token}".format(token=token),
-        "Content-Type": "application/json",
-    }
-    conn.request("POST", "/api/2.0/dbfs/put", json.dumps(request), headers)
-    resp = conn.getresponse()
-    logging.info("status: {} reason: {}".format(resp.status, resp.reason))
+    resp = api_request(instance, "/api/2.0/dbfs/put", json.dumps(request), token)
     logging.info(resp.read())
-    resp.close()
 
 
 def run_submit(args):
@@ -59,7 +69,9 @@ def run_submit(args):
             },
         },
         "spark_python_task": {
-            "python_file": "dbfs:/FileStore/airflow/{module}_runner.py".format(module=args.module_name),
+            "python_file": "dbfs:/FileStore/airflow/{module}_runner.py".format(
+                module=args.module_name
+            ),
             "parameters": args.command,
         },
         "libraries": {
@@ -79,16 +91,10 @@ def run_submit(args):
     logging.debug(json.dumps(config, indent=2))
 
     # https://docs.databricks.com/api/latest/jobs.html#runs-submit
-    conn = httplib.HTTPSConnection(args.instance)
-    headers = {
-        "Authorization": "Bearer {token}".format(token=args.token),
-        "Content-Type": "application/json",
-    }
-    conn.request("POST", "/api/2.0/jobs/runs/submit", json.dumps(config), headers)
-    resp = conn.getresponse()
-    logging.info("status: {} reason: {}".format(resp.status, resp.reason))
+    resp = api_request(
+        args.instance, "/api/2.0/jobs/runs/submit", json.dumps(config), args.token
+    )
     logging.info(resp.read())
-    resp.close()
 
 
 def parse_arguments():

--- a/bin/mozetl-databricks.py
+++ b/bin/mozetl-databricks.py
@@ -59,7 +59,7 @@ def run_submit(args):
             },
         },
         "spark_python_task": {
-            "python_file": "dbfs:/FileStore/airflow/{module}_runner.py".format(args.module_name),
+            "python_file": "dbfs:/FileStore/airflow/{module}_runner.py".format(module=args.module_name),
             "parameters": args.command,
         },
         "libraries": {
@@ -79,7 +79,7 @@ def run_submit(args):
     logging.debug(json.dumps(config, indent=2))
 
     # https://docs.databricks.com/api/latest/jobs.html#runs-submit
-    conn = httplib.HTTPSConnection(instance)
+    conn = httplib.HTTPSConnection(args.instance)
     headers = {
         "Authorization": "Bearer {token}".format(token=args.token),
         "Content-Type": "application/json",

--- a/mozetl/cli.py
+++ b/mozetl/cli.py
@@ -21,6 +21,7 @@ from mozetl.taar import (
     taar_lite_guidranking,
     taar_update_whitelist,
 )
+from mozetl import system_check
 
 
 @click.group()
@@ -48,6 +49,7 @@ entry_point.add_command(addon_aggregates.main, "addon_aggregates")
 entry_point.add_command(maudau.main, "engagement_ratio")
 entry_point.add_command(landfill_sampler.main, "landfill_sampler")
 entry_point.add_command(tab_spinner.main, "long_tab_spinners")
+entry_point.add_command(system_check.main, "system_check")
 
 # Kept for backwards compatibility
 entry_point.add_command(search_aggregates_click, "search_dashboard")

--- a/mozetl/system_check.py
+++ b/mozetl/system_check.py
@@ -58,7 +58,7 @@ def main(
         main_summary = spark.read.parquet(input_path)
         subset = main_summary.where(
             "submission_date_s3 = '{}'".format(ds_nodash)
-        ).where("sample_id='{}".format(1))
+        ).where("sample_id='{}'".format(1))
         print("Saw {} documents".format(subset.count()))
 
         summary = subset.select(
@@ -67,8 +67,7 @@ def main(
         summary.show()
 
         summary.write.parquet(
-            output_path + "/submission_date_s3='{}'/".format(ds_nodash),
-            mode="overwrite",
+            output_path + "/submission_date_s3={}/".format(ds_nodash), mode="overwrite"
         )
 
     stop_session_safely(spark)

--- a/mozetl/system_check.py
+++ b/mozetl/system_check.py
@@ -23,12 +23,18 @@ logging.basicConfig(level=logging.DEBUG)
 
 @click.command()
 @click.argument("--local/--no-local", default=False)
-@click.argument("--submission-date-s3", type=str, default=format_as_submission_date(datetime.now() - timedelta(2)))
+@click.argument(
+    "--submission-date-s3",
+    type=str,
+    default=format_as_submission_date(datetime.now() - timedelta(2)),
+)
 @click.argument("--input-bucket", type=str, default="telemetry-parquet")
 @click.argument("--input-prefix", type=str, default="main_summary/v4")
 @click.argument("--output-bucket", type=str, default="telemetry-test-bucket")
 @click.argument("--output-prefix", type=str, default="mozetl_system_check")
-def main(local, submission_date_s3, input_bucket, input_prefix, output_bucket, output_prefix):
+def main(
+    local, submission_date_s3, input_bucket, input_prefix, output_bucket, output_prefix
+):
     # print argument information
     for k, v in locals():
         print("{}: {}".format(k, v))

--- a/mozetl/system_check.py
+++ b/mozetl/system_check.py
@@ -22,16 +22,16 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 @click.command()
-@click.argument("--local/--no-local", default=False)
-@click.argument(
+@click.option("--local/--no-local", default=False)
+@click.option(
     "--submission-date-s3",
     type=str,
     default=format_as_submission_date(datetime.now() - timedelta(2)),
 )
-@click.argument("--input-bucket", type=str, default="telemetry-parquet")
-@click.argument("--input-prefix", type=str, default="main_summary/v4")
-@click.argument("--output-bucket", type=str, default="telemetry-test-bucket")
-@click.argument("--output-prefix", type=str, default="mozetl_system_check")
+@click.option("--input-bucket", type=str, default="telemetry-parquet")
+@click.option("--input-prefix", type=str, default="main_summary/v4")
+@click.option("--output-bucket", type=str, default="telemetry-test-bucket")
+@click.option("--output-prefix", type=str, default="mozetl_system_check")
 def main(
     local, submission_date_s3, input_bucket, input_prefix, output_bucket, output_prefix
 ):

--- a/mozetl/system_check.py
+++ b/mozetl/system_check.py
@@ -55,10 +55,8 @@ def main(
             )
         )
 
-        main_summary = spark.read.parquet(input_path)
-        subset = main_summary.where(
-            "submission_date_s3 = '{}'".format(ds_nodash)
-        ).where("sample_id='{}'".format(1))
+        path = "{}/submission_date_s3={}/sample_id={}".format(input_path, ds_nodash, 1)
+        subset = spark.read.parquet(path)
         print("Saw {} documents".format(subset.count()))
 
         summary = subset.select(

--- a/mozetl/system_check.py
+++ b/mozetl/system_check.py
@@ -10,7 +10,7 @@ import click
 import logging
 
 from datetime import datetime, timedelta
-from pyspark.sql import SparkSession, Row
+from pyspark.sql import SparkSession
 from mozetl.utils import (
     format_as_submission_date,
     format_spark_path,

--- a/mozetl/system_check.py
+++ b/mozetl/system_check.py
@@ -23,12 +23,12 @@ logging.basicConfig(level=logging.DEBUG)
 
 @click.command()
 @click.argument("--local/--no-local", default=False)
+@click.argument("--submission-date-s3", type=str, default=format_as_submission_date(datetime.now() - timedelta(2)))
 @click.argument("--input-bucket", type=str, default="telemetry-parquet")
 @click.argument("--input-prefix", type=str, default="main_summary/v4")
 @click.argument("--output-bucket", type=str, default="telemetry-test-bucket")
 @click.argument("--output-prefix", type=str, default="mozetl_system_check")
-@click
-def main(local, input_bucket, input_prefix, output_bucket, output_prefix):
+def main(local, submission_date_s3, input_bucket, input_prefix, output_bucket, output_prefix):
     # print argument information
     for k, v in locals():
         print("{}: {}".format(k, v))
@@ -39,7 +39,7 @@ def main(local, input_bucket, input_prefix, output_bucket, output_prefix):
 
     # run a basic count over a sample of `main_summary` from 2 days ago
     if not local:
-        ds_nodash = format_as_submission_date(datetime.now() - timedelta(2))
+        ds_nodash = submission_date_s3
         input_path = format_spark_path(input_bucket, input_prefix)
         output_path = format_spark_path(output_bucket, output_prefix)
 

--- a/mozetl/system_check.py
+++ b/mozetl/system_check.py
@@ -36,7 +36,7 @@ def main(
     local, submission_date_s3, input_bucket, input_prefix, output_bucket, output_prefix
 ):
     # print argument information
-    for k, v in locals():
+    for k, v in locals().items():
         print("{}: {}".format(k, v))
 
     print("Python version: {}".format(sys.version_info))

--- a/mozetl/system_check.py
+++ b/mozetl/system_check.py
@@ -1,0 +1,69 @@
+""""A system check for testing integration of various libraries with mozetl.
+
+This sub-module will print out relevant version info. It will also read data
+from `main_summary` and print basic statistics to verify that the system is
+correctly set-up.
+"""
+
+import sys
+import click
+import logging
+
+from datetime import datetime, timedelta
+from pyspark.sql import SparkSession, Row
+from mozetl.utils import (
+    format_as_submission_date,
+    format_spark_path,
+    stop_session_safely,
+)
+
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+@click.command()
+@click.argument("--local/--no-local", default=False)
+@click.argument("--input-bucket", type=str, default="telemetry-parquet")
+@click.argument("--input-prefix", type=str, default="main_summary/v4")
+@click.argument("--output-bucket", type=str, default="telemetry-test-bucket")
+@click.argument("--output-prefix", type=str, default="mozetl_system_check")
+@click
+def main(local, input_bucket, input_prefix, output_bucket, output_prefix):
+    # print argument information
+    for k, v in locals():
+        print("{}: {}".format(k, v))
+
+    print("Python version: {}".format(sys.version_info))
+    spark = SparkSession.builder.getOrCreate()
+    print("Spark version: {}".format(spark.version))
+
+    # run a basic count over a sample of `main_summary` from 2 days ago
+    if not local:
+        ds_nodash = format_as_submission_date(datetime.now() - timedelta(2))
+        input_path = format_spark_path(input_bucket, input_prefix)
+        output_path = format_spark_path(output_bucket, output_prefix)
+
+        print(
+            "Reading data for {ds_nodash} from {input_path} and writing to {output_path}".format(
+                ds_nodash=ds_nodash, input_path=input_path, output_path=output_path
+            )
+        )
+
+        main_summary = spark.read.parquet(input_path)
+        subset = main_summary.where(
+            "submission_date_s3 = '{}'".format(ds_nodash)
+        ).where("sample_id='{}".format(1))
+        print("Saw {} documents".format(subset.count()))
+
+        summary = subset.select(
+            "memory_mb", "cpu_cores", "subsession_length"
+        ).describe()
+        summary.show()
+
+        summary.write.parquet(
+            output_path + "/submission_date_s3='{}'/".format(ds_nodash),
+            mode="overwrite",
+        )
+
+    stop_session_safely(spark)
+    print("Done!")

--- a/tests/test_system_check.py
+++ b/tests/test_system_check.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from click.testing import CliRunner
 from pyspark.sql import Row
@@ -64,9 +65,7 @@ def test_job(spark, monkeypatch, tmpdir):
 
     # assert path was written
     assert os.path.isdir(
-        "{}/{}/v1/submission_date_s3={}".format(
-            test_bucket, test_output_prefix, ds_nodash
-        )
+        "{}/{}/submission_date_s3={}".format(test_bucket, test_output_prefix, ds_nodash)
     )
 
     # assert data can be read

--- a/tests/test_system_check.py
+++ b/tests/test_system_check.py
@@ -1,0 +1,76 @@
+import pytest
+from click.testing import CliRunner
+from pyspark.sql import Row
+from mozetl import system_check
+
+
+def test_job(spark, monkeypatch, tmpdir):
+    ds_nodash = "20190201"
+
+    test_bucket = str(tmpdir)
+    test_prefix = "main_summary/v4"
+    test_output_prefix = "mozetl_system_check"
+
+    test_data = spark.createDataFrame(
+        [
+            Row(
+                submission_date_s3=ds_nodash,
+                sample_id=1,
+                memory_mb=2048,
+                cpu_cores=2,
+                subsession_length=1,
+            ),
+            Row(
+                submission_date_s3=ds_nodash,
+                sample_id=2,
+                memory_mb=2048,
+                cpu_cores=2,
+                subsession_length=1,
+            ),
+            Row(
+                submission_date_s3="20180101",
+                sample_id=1,
+                memory_mb=2048,
+                cpu_cores=2,
+                subsession_length=1,
+            ),
+        ]
+    )
+    test_data.write.parquet(
+        "file://{}/{}/".format(test_bucket, test_prefix),
+        partitionBy=["submission_date_s3", "sample_id"],
+    )
+
+    def mock_format_spark_path(bucket, prefix):
+        return "file://{}/{}".format(bucket, prefix)
+
+    monkeypatch.setattr(system_check, "format_spark_path", mock_format_spark_path)
+
+    runner = CliRunner()
+    args = [
+        "--submission-date-s3",
+        ds_nodash,
+        "--input-bucket",
+        test_bucket,
+        "--input-prefix",
+        test_prefix,
+        "--output-bucket",
+        test_bucket,
+        "--output-prefix",
+        test_output_prefix,
+    ]
+    result = runner.invoke(system_check.main, args)
+    assert result.exit_code == 0
+
+    # assert path was written
+    assert os.path.isdir(
+        "{}/{}/v1/submission_date_s3={}".format(
+            test_bucket, test_output_prefix, ds_nodash
+        )
+    )
+
+    # assert data can be read
+    path = mock_format_spark_path(test_bucket, test_output_prefix)
+    df = spark.read.parquet(path)
+    df.show()
+    assert df.count() > 0

--- a/tests/test_system_check.py
+++ b/tests/test_system_check.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 from click.testing import CliRunner
 from pyspark.sql import Row
 from mozetl import system_check


### PR DESCRIPTION
This updates the Databricks workflow for supporting external modules that follow the mozetl convention. The convention is as follows:

* The module uses the `click` library for defining a command-line interface
* All arguments use the `@click.option` decorator. Arguments that are required should use the `required=True` parameter.
  - `click` will expose command-line arguments via environment variables
* The module has a top-level `cli` submodule such that `from my_module import cli` is a valid command

A module that adheres to these basic conventions can be scheduled via Airflow using standard tooling.