### PR TITLE
Fix tab_spinner job

### DIFF
--- a/mozetl/tab_spinner/generate_counts.py
+++ b/mozetl/tab_spinner/generate_counts.py
@@ -7,6 +7,7 @@ from moztelemetry.dataset import Dataset
 
 from .utils import get_short_and_long_spinners
 
+
 # numpy.float64 is not JSON serializable, so an encoder is provided for
 # serialization. In this particular case, the values are within a pandas series.
 # See: https://stackoverflow.com/a/47626762

--- a/mozetl/tab_spinner/tab_spinner.py
+++ b/mozetl/tab_spinner/tab_spinner.py
@@ -1,6 +1,6 @@
 import click
 from pyspark.sql import SparkSession
-from generate_counts import run_spinner_etl
+from .generate_counts import run_spinner_etl
 
 
 @click.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,2 @@
+def test_cli_import():
+    from mozetl import cli

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,2 +1,2 @@
 def test_cli_import():
-    from mozetl import cli
+    from mozetl import cli  # noqa

--- a/tests/test_tab_spinner_aggregates.py
+++ b/tests/test_tab_spinner_aggregates.py
@@ -1,8 +1,12 @@
 import pytest
 import json
 import pandas as pd
+import boto3
+from click.testing import CliRunner
+from moto import mock_s3
 
 from mozetl.tab_spinner.utils import get_short_and_long_spinners
+from mozetl.tab_spinner import tab_spinner
 
 
 def create_row():
@@ -32,3 +36,32 @@ def test_simple_transform(simple_rdd, spark_context):
     for k, v in expected.items():
         for build_id, series in v.items():
             assert all(result[k][build_id] == series)
+
+
+@mock_s3
+def test_tab_spinner_main(monkeypatch, simple_rdd):
+    bucket = "telemetry-public-analysis-2"
+    prefix = "spinner-severity-generator/data/severities_by_build_id_nightly.json"
+
+    conn = boto3.resource("s3", region_name="us-west-2")
+    conn.create_bucket(Bucket=bucket)
+
+    class Dataset:
+        @staticmethod
+        def from_source(*args, **kwargs):
+            return Dataset()
+
+        def where(self, *args, **kwargs):
+            return self
+
+        def records(self, *args, **kwargs):
+            return simple_rdd
+
+    monkeypatch.setattr("mozetl.tab_spinner.generate_counts.Dataset", Dataset)
+
+    runner = CliRunner()
+    result = runner.invoke(tab_spinner.main, [])
+    assert result.exit_code == 0
+
+    # should not raise a botocore exception
+    conn.Object(bucket, prefix).load()


### PR DESCRIPTION
This fixes two issues with the tab_spinner job. The first is a relative import error in the module. The second is a serialization error due to the existence of the `numpy.float64` type.

The first is referenced in mozilla/telemetry-airflow#441. I've added a test that should prevent import errors from occurring again in `test_cli.py`. To verify that the tab spinner job works, I've tested the entire command using the `click.CliRunner`. This also caught the import error, as well as a hidden serialization error:

```
E       AssertionError: assert -1 == 0
E        +  where -1 = <Result TypeError('unaffected           0.0\n0ms - 999ms          0.0\n1000ms - 2296ms      1.0\n2297ms - 5276ms      ...124ms - 27855ms    0.0\n27856ms - 63999ms    0.0\n64000ms+             0.0\ndtype: float64 is not JSON serializable',)>.exit_code
```


