### PR TITLE
Revert "Add content-based version detection."

### DIFF
--- a/mozetl/landfill/sampler.py
+++ b/mozetl/landfill/sampler.py
@@ -14,11 +14,16 @@ v2 - Addition of document version as a partition value
 v3 - Retain whitelisted metadata fields and simplify schema
 """
 
+import re
+
 import click
 from moztelemetry.dataset import Dataset
 from pyspark.sql import Window, SparkSession
 from pyspark.sql.functions import col, row_number
 from pyspark.sql.types import StructType, StructField, StringType
+
+# regex for capturing the telemetry version from the uri arguments
+META_ARG_VERSION = re.compile(r"v=([\d]+)")
 
 # whitelist for fields to keep from the ingestion metadata
 META_WHITELIST = {
@@ -51,21 +56,6 @@ def extract(sc, submission_date, sample=0.01):
     return landfill
 
 
-# Detect document version from the payload itself.
-# Should match with the logic here:
-# https://github.com/mozilla-services/lua_sandbox_extensions/blob/master/moz_telemetry/io_modules/decoders/moz_ingest/telemetry.lua#L162
-def _detect_telemetry_version(content):
-    if "ver" in content:
-        return str(content["ver"])
-    if "version" in content:
-        return str(content["version"])
-    if "deviceinfo" in content:
-        return "3"
-    if "v" in content:
-        return str(content["v"])
-    return "1"
-
-
 def _process(message):
     """Process the URI specification from the tagged metadata
 
@@ -80,18 +70,18 @@ def _process(message):
     # Some paths do not adhere to the spec, so append empty values to avoid index errors.
     path = meta["uri"].split("/")[2:] + [None, None, None, None]
     namespace = path[0]
-    content = message.get("content")
 
     if namespace == "telemetry":
         doc_type = path[TELEMETRY_DOC_TYPE]
-        doc_version = _detect_telemetry_version(content)
+        arg = META_ARG_VERSION.search(meta.get("args", ""))
+        doc_version = arg.group(1) if arg else None
         doc_id = path[TELEMETRY_DOC_ID]
     else:
         doc_type = path[GENERIC_DOC_TYPE]
         doc_version = path[GENERIC_DOC_VER]
         doc_id = path[GENERIC_DOC_ID]
 
-    return namespace, doc_type, doc_version, doc_id, meta, content
+    return namespace, doc_type, doc_version, doc_id, meta, message.get("content")
 
 
 def transform(landfill, n_documents=1000):

--- a/tests/test_landfill_sampler.py
+++ b/tests/test_landfill_sampler.py
@@ -63,18 +63,23 @@ def test_process_namespace_telemetry_deviceinfo(sample_document):
     assert row[:4] == ("telemetry", "appusage", "3", "doc-id")
 
 
-def test_process_namespace_telemetry_version(sample_document):
+def test_process_namespace_telemetry_version_4(sample_document):
     uri = "/submit/telemetry/doc-id/main/Firefox/61.0.2/release/20180807170231"
     sample_document["meta"]["uri"] = uri
     sample_document["content"]["version"] = 4
     row = sampler._process(sample_document)
     assert row[:4] == ("telemetry", "main", "4", "doc-id")
+
+
+def test_process_namespace_telemetry_version_5(sample_document):
+    uri = "/submit/telemetry/doc-id/main/Firefox/61.0.2/release/20180807170231"
+    sample_document["meta"]["uri"] = uri
     sample_document["content"]["version"] = 5
     row = sampler._process(sample_document)
     assert row[:4] == ("telemetry", "main", "5", "doc-id")
 
 
-def test_process_namespace_telemetry_ver(sample_document):
+def test_process_namespace_telemetry_ver_6(sample_document):
     uri = "/submit/telemetry/doc-id/main/Firefox/61.0.2/release/20180807170231"
     sample_document["meta"]["uri"] = uri
     sample_document["content"]["ver"] = 6
@@ -82,10 +87,10 @@ def test_process_namespace_telemetry_ver(sample_document):
     assert row[:4] == ("telemetry", "main", "6", "doc-id")
 
 
-def test_process_namespace_telemetry_v(sample_document):
+def test_process_namespace_telemetry_v_7(sample_document):
     uri = "/submit/telemetry/doc-id/main/Firefox/61.0.2/release/20180807170231"
     sample_document["meta"]["uri"] = uri
-    sample_document["content"]["v"] = 7
+    sample_document["content"]["ver"] = 7
     row = sampler._process(sample_document)
     assert row[:4] == ("telemetry", "main", "7", "doc-id")
 

--- a/tests/test_landfill_sampler.py
+++ b/tests/test_landfill_sampler.py
@@ -52,59 +52,7 @@ def test_process_namespace_telemetry(sample_document):
     uri = "/submit/telemetry/doc-id/main/Firefox/61.0.2/release/20180807170231"
     sample_document["meta"]["uri"] = uri
     row = sampler._process(sample_document)
-    assert row[:4] == ("telemetry", "main", "1", "doc-id")
-
-
-def test_process_namespace_telemetry_deviceinfo(sample_document):
-    uri = "/submit/telemetry/doc-id/appusage/Firefox/61.0.2/release/20180807170231"
-    sample_document["meta"]["uri"] = uri
-    sample_document["content"]["deviceinfo"] = "foo"
-    row = sampler._process(sample_document)
-    assert row[:4] == ("telemetry", "appusage", "3", "doc-id")
-
-
-def test_process_namespace_telemetry_version_4(sample_document):
-    uri = "/submit/telemetry/doc-id/main/Firefox/61.0.2/release/20180807170231"
-    sample_document["meta"]["uri"] = uri
-    sample_document["content"]["version"] = 4
-    row = sampler._process(sample_document)
     assert row[:4] == ("telemetry", "main", "4", "doc-id")
-
-
-def test_process_namespace_telemetry_version_5(sample_document):
-    uri = "/submit/telemetry/doc-id/main/Firefox/61.0.2/release/20180807170231"
-    sample_document["meta"]["uri"] = uri
-    sample_document["content"]["version"] = 5
-    row = sampler._process(sample_document)
-    assert row[:4] == ("telemetry", "main", "5", "doc-id")
-
-
-def test_process_namespace_telemetry_ver_6(sample_document):
-    uri = "/submit/telemetry/doc-id/main/Firefox/61.0.2/release/20180807170231"
-    sample_document["meta"]["uri"] = uri
-    sample_document["content"]["ver"] = 6
-    row = sampler._process(sample_document)
-    assert row[:4] == ("telemetry", "main", "6", "doc-id")
-
-
-def test_process_namespace_telemetry_v_7(sample_document):
-    uri = "/submit/telemetry/doc-id/main/Firefox/61.0.2/release/20180807170231"
-    sample_document["meta"]["uri"] = uri
-    sample_document["content"]["ver"] = 7
-    row = sampler._process(sample_document)
-    assert row[:4] == ("telemetry", "main", "7", "doc-id")
-
-
-def test_process_namespace_telemetry_ver_version_v(sample_document):
-    uri = "/submit/telemetry/doc-id/main/Firefox/61.0.2/release/20180807170231"
-    sample_document["meta"]["uri"] = uri
-    # Populate all the version-related fields.
-    sample_document["content"]["ver"] = 8
-    sample_document["content"]["version"] = 9
-    sample_document["content"]["v"] = 10
-    sample_document["content"]["deviceinfo"] = "foo"
-    row = sampler._process(sample_document)
-    assert row[:4] == ("telemetry", "main", "8", "doc-id")
 
 
 def test_process_namespace_generic(sample_document):


### PR DESCRIPTION
Reverts mozilla/python_mozetl#320

A validation ping or schema is missing for this test, which should note that the content is actually a string. 

```
Job aborted due to stage failure: Task 29 in stage 1.0 failed 4 times, most recent failure: Lost task 29.3 in stage 1.0 (TID 187, 10.166.227.193, executor 0): org.apache.spark.api.python.PythonException: Traceback (most recent call last):
  File "/databricks/spark/python/pyspark/worker.py", line 262, in main
    process()
  File "/databricks/spark/python/pyspark/worker.py", line 257, in process
    serializer.dump_stream(func(split_index, iterator), outfile)
  File "/databricks/spark/python/pyspark/serializers.py", line 381, in dump_stream
    vs = list(itertools.islice(iterator, batch))
  File "/databricks/spark/python/pyspark/util.py", line 55, in wrapper
    return f(*args, **kwargs)
  File "/databricks/python/lib/python3.5/site-packages/mozetl/landfill/sampler.py", line 87, in _process
    doc_version = _detect_telemetry_version(content)
  File "/databricks/python/lib/python3.5/site-packages/mozetl/landfill/sampler.py", line 59, in _detect_telemetry_version
    return str(content["ver"])
TypeError: string indices must be integers

	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.handlePythonException(PythonRunner.scala:317)
	at org.apache.spark.api.python.PythonRunner$$anon$1.read(PythonRunner.scala:457)
	at org.apache.spark.api.python.PythonRunner$$anon$1.read(PythonRunner.scala:440)
	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.hasNext(PythonRunner.scala:271)
	at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
	at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:439)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$10$$anon$1.hasNext(WholeStageCodegenExec.scala:620)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
	at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:125)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:96)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:53)
	at org.apache.spark.scheduler.Task.run(Task.scala:112)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:384)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

Driver stacktrace:
```
Direct link: https://dbc-caf9527b-e073.cloud.databricks.com/#setting/sparkui/0323-021331-abler283/driver-8080888691866958688

Reverting this for the weekend, but we can run a backfill to test the changes next time.