### PR TITLE
Bug 1547777 - Remove client count hll column from search_aggregates

### DIFF
--- a/mozetl/search/aggregates.py
+++ b/mozetl/search/aggregates.py
@@ -13,9 +13,7 @@ This allows for deeper analysis into user level search behavior.
 import click
 import logging
 import datetime
-from pyspark_hyperloglog import hll
 from pyspark.sql.functions import (
-    expr,
     explode,
     col,
     when,
@@ -104,9 +102,8 @@ def search_clients_daily(main_summary):
 
 
 def search_aggregates(main_summary):
-    hll.register()
     return agg_search_data(
-        main_summary.withColumn("hll", expr("hll_create(client_id, 12)")),
+        main_summary,
         [
             "addon_version",
             "app_version",
@@ -119,7 +116,7 @@ def search_aggregates(main_summary):
             "submission_date",
             "default_search_engine",
         ],
-        [expr("hll_cardinality(hll_merge(hll)) as client_count")],
+        [],
     ).where(col("engine").isNotNull())
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'numpy==1.13.3',
         'pandas==0.23.4',
         'pyspark==2.3.1',
-        'pyspark_hyperloglog==2.1.1',
         'python_moztelemetry==0.10.2',
         'requests-toolbelt==0.8.0',
         'requests==2.20.1',

--- a/tests/test_search_aggregates.py
+++ b/tests/test_search_aggregates.py
@@ -267,7 +267,6 @@ def expected_search_dashboard_data(define_dataframe_factory):
                     ("sap", 4, LongType(), True),
                     ("organic", None, LongType(), True),
                     ("unknown", None, LongType(), True),
-                    ("client_count", 1, LongType(), True),
                 ],
             )
         )


### PR DESCRIPTION
It didn't work correctly when aggregating across dimensions and was
unused. Best to just use search_clients_daily for this use case.