### PR TITLE
Fix overcounting error when exploding ad fields

### DIFF
--- a/mozetl/search/aggregates.py
+++ b/mozetl/search/aggregates.py
@@ -222,21 +222,17 @@ def explode_search_counts(main_summary):
         return derived
 
     def _select_counts(main_summary, col_name, count_udf=None):
-        ad_fields = ("ad_click", "search_with_ads")
-        if col_name in ad_fields:
-            # special case for ad click probes
-            derived = main_summary
-        else:
+        if col_name == "single_search_count":
             derived = main_summary.withColumn(
                 "single_search_count", explode(col("search_counts"))
             ).filter("single_search_count.count < %s" % MAX_CLIENT_SEARCH_COUNT)
+        else:
+            derived = main_summary
         if count_udf is not None:
             derived = derived.withColumn(col_name, explode(count_udf))
         derived = _drop_source_columns(
             derived.select(["*"] + _get_search_fields(col_name)).drop(col_name)
         )
-        if col_name is not "single_search_count" or col_name in ad_fields:
-            derived = derived.drop("single_search_count")
         return derived
 
     def _get_ad_counts(scalar_name, col_name, udf_function):

--- a/mozetl/search/aggregates.py
+++ b/mozetl/search/aggregates.py
@@ -221,10 +221,12 @@ def explode_search_counts(main_summary):
             derived = derived.drop(source_col)
         return derived
 
-    def _select_counts(main_summary, col_name, count_udf=None, get_single_search_count=True):
+    def _select_counts(
+        main_summary, col_name, count_udf=None, get_single_search_count=True
+    ):
         if get_single_search_count:
             derived = main_summary.withColumn(
-              "single_search_count", explode(col("search_counts"))
+                "single_search_count", explode(col("search_counts"))
             ).filter("single_search_count.count < %s" % MAX_CLIENT_SEARCH_COUNT)
         else:
             # special case for ad-click and search-with-ads probes
@@ -251,8 +253,12 @@ def explode_search_counts(main_summary):
                 )
             ),
         )
-        return _select_counts(main_summary, col_name, count_udf(scalar_name),
-                              get_single_search_count=False)
+        return _select_counts(
+            main_summary,
+            col_name,
+            count_udf(scalar_name),
+            get_single_search_count=False,
+        )
 
     exploded_search_counts = _select_counts(main_summary, "single_search_count")
 


### PR DESCRIPTION
I found an error when looking at the ad probes using search clients daily versus main_summary. There is an over-counting error when exploding those fields.

The error/fix can be more easily explored in this minimal reproduction:

https://dbc-caf9527b-e073.cloud.databricks.com/#notebook/141261/command/141311

@harterrt r?