### PR TITLE
TAAR whitelist uses recommended addons only now.

### DIFF
--- a/mozetl/taar/taar_update_whitelist.py
+++ b/mozetl/taar/taar_update_whitelist.py
@@ -25,8 +25,13 @@ class GUIDError(BaseException):
     pass
 
 
-def load_raw_json(url):
-    r = requests.get(url)
+def load_amo_editorial(url, only_recommended=True):
+    param_dict = {}
+
+    if only_recommended:
+        param_dict["recommended"] = "true"
+
+    r = requests.get(url, params=param_dict)
     if 200 == r.status_code:
         # process stuff here
         json_data = json.loads(r.text)
@@ -74,11 +79,11 @@ def load_etl(transformed_data, date, prefix, bucket):
 @click.command()
 @click.option("--date", required=True)
 @click.option("--url", default=EDITORIAL_URI)
+@click.option("--only-recommended", default=True)
 @click.option("--bucket", default="telemetry-parquet")
 @click.option("--prefix", default="taar/locale/")
 @click.option("--validate_guid", default=False)
-def main(date, url, bucket, prefix, validate_guid):
-
-    data_extract = load_raw_json(url)
+def main(date, url, only_recommended, bucket, prefix, validate_guid):
+    data_extract = load_amo_editorial(url, only_recommended)
     jdata = parse_json(data_extract, False, validate_guid)
     load_etl(jdata, date, prefix, bucket)

--- a/tests/test_taar_update_whitelist.py
+++ b/tests/test_taar_update_whitelist.py
@@ -3,18 +3,12 @@ whitelist of addons for whitelist Job."""
 
 import json
 
-
 from moto import mock_s3
 import pytest
 import boto3
 from mozetl.taar import taar_update_whitelist
 from mozetl.taar.taar_update_whitelist import LoadError, ShortWhitelistError
 import mock
-
-# from mozetl.taar import taar_utils
-
-
-EDITORIAL_URL = "https://addons.mozilla.org/api/v4/discovery/editorial/"
 
 
 @pytest.fixture
@@ -58,7 +52,7 @@ def mocked_requests_get_404(*args, **kwargs):
 @mock.patch("requests.get", side_effect=mocked_requests_get_404)
 def test_amo_network_failure(mock_get):
     with pytest.raises(LoadError) as err:
-        _ = taar_update_whitelist.load_raw_json("http://some/editorial/url")  # noqa
+        taar_update_whitelist.load_amo_editorial("http://some/editorial/url")  # noqa
     assert (
         err.value.args[0] == "HTTP 404 status loading JSON from AMO editorial endpoint."
     )


### PR DESCRIPTION
The AMO whitelist URL is now requested with a 'recex=True' option added
to the end of the URL to restrict addons to only the recommended list
for TAAR recommendd addons now.

cc @muffinresearch