### PR TITLE
Fixes extraction bug in the clients_daily port of taarlite_guidguid

### DIFF
--- a/mozetl/taar/taar_lite_guidguid.py
+++ b/mozetl/taar/taar_lite_guidguid.py
@@ -53,22 +53,21 @@ def get_addons_per_client(broadcast_amo_whitelist, users_df):
 
     # Create an add-ons dataset un-nesting the add-on map from each
     # user to a list of add-on GUIDs. Also filter undesired add-ons.
-    return (
-        users_df.rdd.map(
-            lambda p: (
-                p["client_id"],
-                [
-                    addon_data.addon_id
-                    for addon_data in p["active_addons"]
-                    if is_valid_addon(
-                        broadcast_amo_whitelist, addon_data.addon_id, addon_data
-                    )
-                ],
-            )
+    rdd_list = users_df.rdd.map(
+        lambda p: (
+            p["client_id"],
+            [
+                addon_data.addon_id
+                for addon_data in p["active_addons"]
+                if is_valid_addon(
+                    broadcast_amo_whitelist, addon_data.addon_id, addon_data
+                )
+            ],
         )
-        .filter(lambda p: len(p[1]) > 1)
-        .toDF(["client_id", "addon_ids"])
     )
+    filtered_rdd = rdd_list.filter(lambda p: len(p[1]) > 1)
+    df = filtered_rdd.toDF(["client_id", "addon_ids"])
+    return df
 
 
 def get_initial_sample(spark):


### PR DESCRIPTION
The longitudinal table was structured as a dictionary of addon_guid -> addon_metadata, but the clients_daily table models the active_addons as a list of just addon_metadata.

This patch fixes the extraction of addon data per client to reflect the clients_daily schema.

This patch also unrolls the `extract_telemetry` function from using any nested functions to aid clarity.