### PR TITLE
Revert to 300 signatures for correlations (#368)

### DIFF
--- a/mozetl/symbolication/top_signatures_correlations.py
+++ b/mozetl/symbolication/top_signatures_correlations.py
@@ -72,7 +72,7 @@ signatures = {}
 
 for channel in channels:
     signatures[channel] = download_data.get_top(
-        1000, versions=channel_to_versions[channel], days=5
+        300, versions=channel_to_versions[channel], days=5
     )
 
 utils.rmdir("top-signatures-correlations_output")


### PR DESCRIPTION
We recently raised the number of signatures to look at to 1000 (PR #367), but this caused the container to run out of memory when working on correlations for the release channel.

This reverts back to the previous value of 300.