### PR TITLE
bug 1775444: drop top signatures from 250 to 200

### DIFF
--- a/mozetl/symbolication/top_signatures_correlations.py
+++ b/mozetl/symbolication/top_signatures_correlations.py
@@ -26,7 +26,7 @@ sc.addPyFile("stemming-1.0.1/stemming/porter2.py")
 
 
 # Number of top signatures to look at
-TOP_SIGNATURE_COUNT = 250
+TOP_SIGNATURE_COUNT = 200
 
 # Number of days to look at to figure out top signatures
 TOP_SIGNATURE_PERIOD_DAYS = 5


### PR DESCRIPTION
We're having memory issues and it looks like the total number of crash
reports for the top signatures is increasing over time. This drops the
number of top signatures we look at which will drop the number of crash
reports which should reduce the memory used back to a workable number.