### PR TITLE
Pin flake8 and protobuf to fix lint and py37 CI jobs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ test_deps = [
     'moto==1.3.16',
     'mock==2.0.0',
     'pytest==3.10.1',
-    'flake8==3.8.4'
+    'flake8==4.0.0'
 ]
 
 extras = {

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'click_datetime==0.2',
         'numpy==1.19.4',
         'pandas==1.1.4',
+        'protobuf==3.20.3',
         'pyspark==2.3.2',
         'python-moztelemetry @ git+http://github.com/mozilla/python_moztelemetry.git@v0.10.2#egg=python-moztelemetry',
         'requests-toolbelt==0.9.1',

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ test_deps = [
     'moto==1.3.16',
     'mock==2.0.0',
     'pytest==3.10.1',
+    # NOTE: this is pinned to 4.0.0 so as to pin importlib to a version that works.
     'flake8==4.0.0'
 ]
 
@@ -34,6 +35,7 @@ setup(
         'click_datetime==0.2',
         'numpy==1.19.4',
         'pandas==1.1.4',
+        # NOTE: this is pinned to 3.20.3 because protos changed and we can't regenerate them.
         'protobuf==3.20.3',
         'pyspark==2.3.2',
         'python-moztelemetry @ git+http://github.com/mozilla/python_moztelemetry.git@v0.10.2#egg=python-moztelemetry',


### PR DESCRIPTION
Dependency update for CI fix.

`flake8` for the `lint` job - 4.0.0 because it pins `importlib` due to a breaking change which caused the `AttributeError: 'EntryPoints' object has no attribute 'get'` problem. 

`protobuf` for the tests - 3.20.3 because that's what's suggested in the warnings:
```
E   TypeError: Descriptors cannot not be created directly.
E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
E   If you cannot immediately regenerate your protos, some other possible workarounds are:
E    1. Downgrade the protobuf package to 3.20.x or lower.
E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
E   
E   More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

Closes https://github.com/mozilla/python_mozetl/issues/373

Probably worth keeping an eye on airflow as well.