### PR TITLE
fix(DENG-1146): fixing install dependencies ci step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,15 @@
 install_dependencies: &install_dependencies
   name: install dependencies
   command: |
+    # Update stretch repositories
+    # source:https://stackoverflow.com/a/76095392
+    sed -i \
+      -e 's/deb.debian.org/archive.debian.org/g' \
+      -e 's|security.debian.org|archive.debian.org/|g' \
+      -e '/stretch-updates/d' /etc/apt/sources.list
     apt update
     apt install -y libsnappy-dev openjdk-8-jre-headless
-    pip install tox coverage==5.3
+    pip install tox==4.6.4 coverage==5.3
 
 save_cache_settings: &save_cache_settings
   key: v1-python_mozetl-{{ checksum "setup.py" }}
@@ -70,11 +76,11 @@ jobs:
     <<: *test_settings
     parallelism: 4
     docker:
-      - image: python:3.7-stretch
+      - image: python:3.7.11-stretch
 
   lint:
     docker:
-      - image: python:3.7-stretch
+      - image: python:3.7.11-stretch
     working_directory: ~/python_mozetl
     steps:
       - checkout
@@ -88,7 +94,7 @@ jobs:
 
   docs:
     docker:
-      - image: python:3.7-stretch
+      - image: python:3.7.11-stretch
     working_directory: ~/python_mozetl
     steps:
       - checkout


### PR DESCRIPTION
# fix(DENG-1146): fixing install dependencies CI step

Changed include:

- Updated docker image to `3.7.11`-stretch
- pinning tox version inside the CI pipeline (install_dependencies instructions)
- Updating stretch repositories to fix the not found error.

This fixed the CI errors we were seeing related to repositories not being found.