### PR TITLE
DENG-1025: gfx export to prod gcs bucket

### DIFF
--- a/mozetl/graphics/graphics_telemetry_dashboard.py
+++ b/mozetl/graphics/graphics_telemetry_dashboard.py
@@ -46,7 +46,7 @@ def parse_args():
     parser.add_argument("--default-time-window", type=int, default=14)
     parser.add_argument("--release-fraction", type=float, default=0.003)
     parser.add_argument(
-        "--output-bucket", default="moz-fx-data-static-websit-f7e0-analysis-output"
+        "--output-bucket", default="moz-fx-data-static-websit-8565-analysis-output"
     )
     parser.add_argument("--output-prefix", default="gfx/telemetry-data/")
     return parser.parse_args()

--- a/mozetl/graphics/graphics_telemetry_trends.py
+++ b/mozetl/graphics/graphics_telemetry_trends.py
@@ -48,7 +48,7 @@ MaxHistoryInDays = datetime.timedelta(days=210)
 
 # Bucket we'll drop files into on GCS. If this is None, we won't attempt any
 # GCS uploads, and the analysis will start from scratch.
-GCS_BUCKET = "moz-fx-data-static-websit-f7e0-analysis-output"
+GCS_BUCKET = "moz-fx-data-static-websit-8565-analysis-output"
 GCS_PREFIX = "gfx/telemetry-data/"
 GITHUB_REPO = "https://raw.githubusercontent.com/FirefoxGraphics/moz-gfx-telemetry"
 
@@ -594,7 +594,7 @@ def parse_args():
     parser.add_argument("--force-max-backfill", action="store_true")
     parser.add_argument("--weekly-fraction", type=float, default=0.003)
     parser.add_argument(
-        "--gcs-bucket", default="moz-fx-data-static-websit-f7e0-analysis-output"
+        "--gcs-bucket", default="moz-fx-data-static-websit-8565-analysis-output"
     )
     parser.add_argument("--gcs-prefix", default="gfx/telemetry-data/")
     parser.add_argument("--max-history-in-days", type=int, default=210)


### PR DESCRIPTION
Follow-up of https://github.com/mozilla/python_mozetl/pull/388
Updating GCS bucket with prod name after testing with nonprod.
Will be merged along with https://github.com/mozilla/telemetry-airflow/pull/1777