### PR TITLE
DENG-1023 crash_symbolication stores results on gcs instead of s3 (dev bucket for testing)

### DIFF
--- a/mozetl/symbolication/create_cluster.sh
+++ b/mozetl/symbolication/create_cluster.sh
@@ -14,7 +14,7 @@ fi
 gcloud dataproc clusters create symbolication \
     --image-version=1.5 \
     --region=us-central1 \
-    --metadata='PIP_PACKAGES=boto3==1.16.20 scipy==1.5.4' \
+    --metadata='PIP_PACKAGES=boto3==1.16.20 scipy==1.5.4 google-cloud-storage==2.7.0' \
     --num-workers=2 \
     --worker-machine-type='n2-standard-4' \
     --properties "core:fs.s3.awsAccessKeyId=$AWS_ACCESS_KEY_ID,core:fs.s3.awsSecretAccessKey=$AWS_SECRET_ACCESS_KEY,spark-env:AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID,spark-env:AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \

--- a/mozetl/symbolication/top_signatures_correlations.py
+++ b/mozetl/symbolication/top_signatures_correlations.py
@@ -38,7 +38,7 @@ TOP_SIGNATURE_PERIOD_DAYS = 5
 TELEMETRY_CRASHES_PERIOD_DAYS = 30
 
 # Name of the GCS bucket where results are stored
-RESULTS_GCS_BUCKET = 'moz-fx-data-static-websit-f7e0-analysis-output'
+RESULTS_GCS_BUCKET = "moz-fx-data-static-websit-f7e0-analysis-output"
 
 
 from crashcorrelations import (  # noqa E402
@@ -70,7 +70,7 @@ def parse_args():
 
 def remove_results_gcs(job_name):
     bucket = gcs_client.bucket(RESULTS_GCS_BUCKET)
-    for key in bucket.list_blobs(prefix=job_name + '/data/'):
+    for key in bucket.list_blobs(prefix=job_name + "/data/"):
         key.delete()
 
 
@@ -79,8 +79,13 @@ def upload_results_gcs(job_name, directory):
     for root, dirs, files in os.walk(directory):
         for name in files:
             full_path = os.path.join(root, name)
-            blob = bucket.blob('{}/data/{}'.format(job_name, full_path[len(directory) + 1:]))
-            blob.upload_from_filename(full_path, content_type='application/json')
+            blob = bucket.blob(
+                "{}/data/{}".format(
+                    job_name, full_path[len(directory) + 1 :]  # noqa E203
+                )
+            )
+            blob.upload_from_filename(full_path, content_type="application/json")
+
 
 args = parse_args()
 
@@ -188,6 +193,4 @@ print(datetime.utcnow())
 # Will be uploaded under
 # https://analysis-output.telemetry.mozilla.org/top-signatures-correlations/data/
 remove_results_gcs("top-signatures-correlations")
-upload_results_gcs(
-    "top-signatures-correlations", "top-signatures-correlations_output"
-)
+upload_results_gcs("top-signatures-correlations", "top-signatures-correlations_output")

--- a/mozetl/symbolication/top_signatures_correlations.py
+++ b/mozetl/symbolication/top_signatures_correlations.py
@@ -13,6 +13,8 @@ from datetime import datetime
 from pyspark import SparkContext
 from pyspark.sql import SparkSession
 
+from google.cloud import storage
+
 sys.path += [os.path.abspath("."), os.path.abspath("crashcorrelations")]
 os.system("git clone https://github.com/marco-c/crashcorrelations.git")
 
@@ -21,6 +23,7 @@ os.system("tar xf stemming-1.0.1.tar.gz")
 
 sc = SparkContext.getOrCreate()
 spark = SparkSession.builder.appName("modules-with-missing-symbols").getOrCreate()
+gcs_client = storage.Client()
 
 sc.addPyFile("stemming-1.0.1/stemming/porter2.py")
 
@@ -33,6 +36,9 @@ TOP_SIGNATURE_PERIOD_DAYS = 5
 
 # Number of days to look at for telemetry crash data
 TELEMETRY_CRASHES_PERIOD_DAYS = 30
+
+# Name of the GCS bucket where results are stored
+RESULTS_GCS_BUCKET = 'moz-fx-data-static-websit-f7e0-analysis-output'
 
 
 from crashcorrelations import (  # noqa E402
@@ -61,6 +67,20 @@ def parse_args():
     )
     return parser.parse_args()
 
+
+def remove_results_gcs(job_name):
+    bucket = gcs_client.bucket(RESULTS_GCS_BUCKET)
+    for key in bucket.list_blobs(prefix=job_name + '/data/'):
+        key.delete()
+
+
+def upload_results_gcs(job_name, directory):
+    bucket = gcs_client.bucket(RESULTS_GCS_BUCKET)
+    for root, dirs, files in os.walk(directory):
+        for name in files:
+            full_path = os.path.join(root, name)
+            blob = bucket.blob('{}/data/{}'.format(job_name, full_path[len(directory) + 1:]))
+            blob.upload_from_filename(full_path, content_type='application/json')
 
 args = parse_args()
 
@@ -167,7 +187,7 @@ print(datetime.utcnow())
 
 # Will be uploaded under
 # https://analysis-output.telemetry.mozilla.org/top-signatures-correlations/data/
-utils.remove_results("top-signatures-correlations")
-utils.upload_results(
+remove_results_gcs("top-signatures-correlations")
+upload_results_gcs(
     "top-signatures-correlations", "top-signatures-correlations_output"
 )


### PR DESCRIPTION
Along with https://github.com/mozilla/telemetry-airflow/pull/1829

This also removes the dependency on https://github.com/marco-c/crashcorrelations for storing result files in buckets.

Once I can confirm the files are written to the dev bucket I'll open another PR with the prod bucket name