### PR TITLE
DENG-1023 crash_symbolication stores results on gcs instead of s3 (prod)

### DIFF
--- a/mozetl/symbolication/top_signatures_correlations.py
+++ b/mozetl/symbolication/top_signatures_correlations.py
@@ -38,7 +38,7 @@ TOP_SIGNATURE_PERIOD_DAYS = 5
 TELEMETRY_CRASHES_PERIOD_DAYS = 30
 
 # Name of the GCS bucket where results are stored
-RESULTS_GCS_BUCKET = "moz-fx-data-static-websit-f7e0-analysis-output"
+RESULTS_GCS_BUCKET = "moz-fx-data-static-websit-8565-analysis-output"
 
 
 from crashcorrelations import (  # noqa E402


### PR DESCRIPTION
The job worked in dev, so I'm updating the bucket with the prod one.

Note: last execution sent results to dev bucket, which I manually copied over to prod and tested by downloading some files from https://analysis-output.telemetry.mozilla.org