### PR TITLE
Fix the bhr script to handle the extra arguements

### DIFF
--- a/mozetl/bhr_collection/bhr_collection.py
+++ b/mozetl/bhr_collection/bhr_collection.py
@@ -1137,14 +1137,19 @@ def write_file(name, stuff, config):
     elif config["use_gcs"]:
         bucket_name = "moz-fx-data-static-websit-8565-analysis-output"
         gcs_key = "bhr/data/hang_aggregates/" + name + ".json"
+        extra_args = {"ContentType": "application/json", "ContentEncoding": "gzip"}
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(bucket_name)
+        blob = bucket.blob(gcs_key)
+        blob.upload_from_filename(gzfilename, **extra_args)
         if config["uuid"] is not None:
             gcs_key = (
                 "bhr/data/hang_aggregates/" + name + "_" + config["uuid"] + ".json"
             )
-        storage_client = storage.Client()
-        bucket = storage_client.bucket(bucket_name)
-        blob = bucket.blob(gcs_key)
-        blob.upload_from_filename(gzfilename)
+            storage_client = storage.Client()
+            bucket = storage_client.bucket(bucket_name)
+            blob = bucket.blob(gcs_key)
+            blob.upload_from_filename(gzfilename, **extra_args)
 
 
 default_config = {


### PR DESCRIPTION
The previous PR - https://github.com/mozilla/python_mozetl/pull/387 did not handle the `extra_args = {"ContentType": "application/json", "ContentEncoding": "gzip"}`. due to which the process was unable to read the files.


