### PR TITLE
Add dummy folder for testing BHR switch to gcs

### DIFF
--- a/mozetl/bhr_collection/bhr_collection.py
+++ b/mozetl/bhr_collection/bhr_collection.py
@@ -1136,7 +1136,7 @@ def write_file(name, stuff, config):
             transfer.upload_file(gzfilename, bucket, s3_uuid_key, extra_args=extra_args)
     elif config["use_gcs"]:
         bucket_name = "moz-fx-data-static-websit-8565-analysis-output"
-        gcs_key = "bhr/data/hang_aggregates/" + name + ".json"
+        gcs_key = "bhr/test_folder/hang_aggregates/" + name + ".json"
         extra_args = {"ContentType": "application/json", "ContentEncoding": "gzip"}
         storage_client = storage.Client()
         bucket = storage_client.bucket(bucket_name)
@@ -1144,7 +1144,7 @@ def write_file(name, stuff, config):
         blob.upload_from_filename(gzfilename, **extra_args)
         if config["uuid"] is not None:
             gcs_key = (
-                "bhr/data/hang_aggregates/" + name + "_" + config["uuid"] + ".json"
+                "bhr/test_folder/hang_aggregates/" + name + "_" + config["uuid"] + ".json"
             )
             storage_client = storage.Client()
             bucket = storage_client.bucket(bucket_name)

--- a/mozetl/bhr_collection/bhr_collection.py
+++ b/mozetl/bhr_collection/bhr_collection.py
@@ -1144,7 +1144,11 @@ def write_file(name, stuff, config):
         blob.upload_from_filename(gzfilename, **extra_args)
         if config["uuid"] is not None:
             gcs_key = (
-                "bhr/test_folder/hang_aggregates/" + name + "_" + config["uuid"] + ".json"
+                "bhr/test_folder/hang_aggregates/"
+                + name
+                + "_"
+                + config["uuid"]
+                + ".json"
             )
             storage_client = storage.Client()
             bucket = storage_client.bucket(bucket_name)


### PR DESCRIPTION
The task of writing to gcs instead of s3 keeps is not working. 
The GCS bucket has been pointed to the test folder for testing purposes and will be reverted once the root cause of issue has been identified.