### PR TITLE
 Add date in YYYY-mm-dd to end of email subject line

### DIFF
--- a/mozetl/symbolication/modules_with_missing_symbols.py
+++ b/mozetl/symbolication/modules_with_missing_symbols.py
@@ -167,7 +167,10 @@ top_missing_with_avail_info = [
     for name, (version, debug_id, debug_file), count in top_missing
 ]
 
-subject = "Weekly report of modules with missing symbols in crash reports: %s" % datetime.today().strftime("%Y-%m-%d")
+subject = (
+    "Weekly report of modules with missing symbols in crash reports: %s"
+    % datetime.today().strftime("%Y-%m-%d")
+)
 
 body = """
 <table style="border-collapse:collapse;">

--- a/mozetl/symbolication/modules_with_missing_symbols.py
+++ b/mozetl/symbolication/modules_with_missing_symbols.py
@@ -167,7 +167,7 @@ top_missing_with_avail_info = [
     for name, (version, debug_id, debug_file), count in top_missing
 ]
 
-subject = "Weekly report of modules with missing symbols in crash reports"
+subject = "Weekly report of modules with missing symbols in crash reports: %s" % datetime.today().strftime("%Y-%m-%d")
 
 body = """
 <table style="border-collapse:collapse;">

--- a/mozetl/symbolication/modules_with_missing_symbols.py
+++ b/mozetl/symbolication/modules_with_missing_symbols.py
@@ -167,9 +167,9 @@ top_missing_with_avail_info = [
     for name, (version, debug_id, debug_file), count in top_missing
 ]
 
+today_date = datetime.today().strftime("%Y-%m-%d")
 subject = (
-    "Weekly report of modules with missing symbols in crash reports: %s"
-    % datetime.today().strftime("%Y-%m-%d")
+    f"Weekly report of modules with missing symbols in crash reports: {today_date}"
 )
 
 body = """


### PR DESCRIPTION
This adds the date in YYYY-mm-dd to the end of the email subject line so as to fix threading in the google groups interface.

This mirrors the change here: https://github.com/marco-c/missing_symbols/commit/2c3a1b4cc83e0012c5c18e0379f144d8533d9419