### PR TITLE
Set content encoding for gcs objects

### DIFF
--- a/mozetl/symbolication/top_signatures_correlations.py
+++ b/mozetl/symbolication/top_signatures_correlations.py
@@ -84,6 +84,7 @@ def upload_results_gcs(job_name, directory):
                     job_name, full_path[len(directory) + 1 :]  # noqa E203
                 )
             )
+            blob.content_encoding = "gzip"
             blob.upload_from_filename(full_path, content_type="application/json")
 
 


### PR DESCRIPTION
right now correlations aren't working in crash stats, because it expects js to automatically handle gzip encoding, but it won't do that unless the content encoding header is properly set

r? @ANich 

cc @willkg 