### PR TITLE
bug(1914369): remove GRAPHICS_SANITY_TEST* related code from graphics dashboard due to related deprecation in gecko-dev

### DIFF
--- a/mozetl/graphics/graphics_telemetry_dashboard.py
+++ b/mozetl/graphics/graphics_telemetry_dashboard.py
@@ -77,7 +77,6 @@ FeaturesKey = "environment/system/gfx/features"
 UserPrefsKey = "environment/settings/userPrefs"
 DeviceResetReasonKey = "payload/histograms/DEVICE_RESET_REASON"
 SANITY_TEST = "payload/histograms/GRAPHICS_SANITY_TEST"
-SANITY_TEST_REASON = "payload/histograms/GRAPHICS_SANITY_TEST_REASON"
 STARTUP_TEST_KEY = "payload/histograms/GRAPHICS_DRIVER_STARTUP_TEST"
 WebGLSuccessKey = "payload/histograms/CANVAS_WEBGL_SUCCESS"
 WebGL2SuccessKey = "payload/histograms/CANVAS_WEBGL2_SUCCESS"
@@ -97,7 +96,6 @@ PropertyList = [
     ArchKey,
     DeviceResetReasonKey,
     SANITY_TEST,
-    SANITY_TEST_REASON,
     STARTUP_TEST_KEY,
     WebGLSuccessKey,
     WebGL2SuccessKey,
@@ -253,6 +251,7 @@ def fetch_and_format(**kwargs):
 ##################################################################
 # Helper function block for massaging pings into aggregate data. #
 ##################################################################
+
 
 # Take each key in |b| and add it to |a|, accumulating its value into
 # |a| if it already exists.
@@ -463,6 +462,7 @@ timed_export(
 
 # ## TDR Statistics
 
+
 #############################
 # Perform the TDR analysis. #
 #############################
@@ -633,11 +633,6 @@ SANITY_TEST_FAILED_VIDEO = 2
 SANITY_TEST_CRASHED = 3
 SANITY_TEST_TIMEDOUT = 4
 SANITY_TEST_LAST_VALUE = 5
-SANITY_TEST_REASON_FIRST_RUN = 0
-SANITY_TEST_REASON_FIREFOX_CHANGED = 1
-SANITY_TEST_REASON_DEVICE_CHANGED = 2
-SANITY_TEST_REASON_DRIVER_CHANGED = 3
-SANITY_TEST_REASON_LAST_VALUE = 4
 
 
 # We don't want to fold FAILED_LAYERS and FAILED_VIDEO into the same
@@ -899,6 +894,7 @@ timed_export(
 
 # ### Helpers for Compositor/Acceleration fields
 
+
 # Build graphics feature statistics.
 def get_compositor(p):
     compositor = p[FeaturesKey].get("compositor", "none")
@@ -970,6 +966,7 @@ def advanced_layers_status(p):
 
 
 # ## Windows Compositor and Blacklisting Statistics
+
 
 # Get pings with graphics features. This landed in roughly the 7-19-2015 nightly.
 def windows_feature_filter(p):


### PR DESCRIPTION
# bug(1914369): remove GRAPHICS_SANITY_TEST* related code from graphics dashboard due to related deprecation in gecko-dev

The following commit in gecko-dev deprecated GRAPHICS_SANITY_TEST from `Histograms.json` which appears to have resulted in the ETL job using this python_mozetl logic to break as the result. We're expecting this code change to resolve this issue by the login no longer attempting to access the `GRAPHICS_SANITY_TEST` histogram.