### PR TITLE
chore: switch sender for crash symbolication

### DIFF
--- a/mozetl/symbolication/modules_with_missing_symbols.py
+++ b/mozetl/symbolication/modules_with_missing_symbols.py
@@ -230,7 +230,7 @@ body += "</pre>"
 client = boto3.client("ses", region_name="us-west-2")
 
 client.send_email(
-    Source="mcastelluccio@data.mozaws.net",
+    Source="telemetry-alerts@mozilla.com",
     Destination={
         "ToAddresses": [
             "mcastelluccio@mozilla.com",


### PR DESCRIPTION
This needs to be landed in tandem with https://github.com/mozilla/telemetry-airflow/pull/2367