### PR TITLE
#409 Migrate BHR collection to Glean data

### DIFF
--- a/mozetl/bhr_collection/bhr_collection.py
+++ b/mozetl/bhr_collection/bhr_collection.py
@@ -551,7 +551,7 @@ def get_data(sc, sql_context, config, date, end_date=None):
         # sql results need to be saved to a table
         .option("materializationProject", "mozdata")
         .option("materializationDataset", "tmp")
-        .option("billingProject", "mozdata")
+        .option("billingProject", config["billing_project"])
         .load()
     )
 
@@ -1195,6 +1195,7 @@ default_config = {
     "exclude_modules": False,
     "uuid": uuid.uuid4().hex,
     "thread_filter": "Gecko",
+    "billing_project": "mozdata",
 }
 
 
@@ -1256,6 +1257,11 @@ def etl_job_daily(sc, sql_context, config=None):
 
 
 @click.command()
+@click.option(
+    "--billing-project",
+    default="mozdata",
+    help="GCP project to use for BigQuery billing.",
+)
 @click.option("--date", type=datetime.fromisoformat, required=True)
 @click.option(
     "--sample-size",
@@ -1280,7 +1286,15 @@ def etl_job_daily(sc, sql_context, config=None):
     help="If present, add to spark.jars config.  Used for local testing, "
     "e.g. --bq-connector-jar=spark-bigquery-latest.jar",
 )
-def start_job(date, sample_size, use_gcs, thread_filter, output_tag, bq_connector_jar):
+def start_job(
+    billing_project,
+    date,
+    sample_size,
+    use_gcs,
+    thread_filter,
+    output_tag,
+    bq_connector_jar,
+):
     print(f"Running for {date}")
     print(f"Using sample size {sample_size}")
 
@@ -1305,6 +1319,7 @@ def start_job(date, sample_size, use_gcs, thread_filter, output_tag, bq_connecto
             "hang_upper_bound": 65536,
             "sample_size": sample_size,
             "use_gcs": use_gcs,
+            "billing_project": billing_project,
         },
     )
 

--- a/mozetl/bhr_collection/bhr_collection.py
+++ b/mozetl/bhr_collection/bhr_collection.py
@@ -533,11 +533,11 @@ def get_data(sc, sql_context, config, date, end_date=None):
 
     sql = f"""
     SELECT
-      environment,
-      application,
-      payload,
+      client_info,
+      ping_info,
+      metrics,
     FROM
-      `moz-fx-data-shared-prod.telemetry_stable.bhr_v4`
+      `moz-fx-data-shared-prod.firefox_desktop_stable.hang_report_v1`
     WHERE
       -- Use document_id to sample
       ABS(MOD(FARM_FINGERPRINT(document_id), {max_sample_slices})) < {sample_slices}
@@ -557,20 +557,20 @@ def get_data(sc, sql_context, config, date, end_date=None):
 
     if config["exclude_modules"]:
         properties = [
-            "environment/system/os/name",
-            "environment/system/os/version",
-            "application/architecture",
-            "application/build_id",
-            "payload/hangs",
+            "client_info/os",
+            "client_info/os_version",
+            "client_info/architecture",
+            "client_info/app_build",
+            "metrics/object/hangs_reports",
         ]
     else:
         properties = [
-            "environment/system/os/name",
-            "environment/system/os/version",
-            "application/architecture",
-            "application/build_id",
-            "payload/modules",
-            "payload/hangs",
+            "client_info/os",
+            "client_info/os_version",
+            "client_info/architecture",
+            "client_info/app_build",
+            "metrics/object/hangs_modules",
+            "metrics/object/hangs_reports",
         ]
 
     print("%d results total" % pings_df.rdd.count())
@@ -580,8 +580,8 @@ def get_data(sc, sql_context, config, date, end_date=None):
 
     try:
         result = mapped.filter(
-            lambda p: p["application/build_id"][:8] >= date_str
-            and p["application/build_id"][:8] <= end_date_str
+            lambda p: p["client_info/app_build"][:8] >= date_str
+            and p["client_info/app_build"][:8] <= end_date_str
         )
         print("%d results after first filter" % result.count())
         return result
@@ -590,11 +590,13 @@ def get_data(sc, sql_context, config, date, end_date=None):
 
 
 def ping_is_valid(ping):
-    if not isinstance(ping["environment/system/os/version"], str):
+    if not isinstance(ping["client_info/os_version"], str):
         return False
-    if not isinstance(ping["environment/system/os/name"], str):
+    if not isinstance(ping["client_info/os"], str):
         return False
-    if not isinstance(ping["application/build_id"], str):
+    if not isinstance(ping["client_info/app_build"], str):
+        return False
+    if ping["metrics/object/hangs_reports"] is None:
         return False
 
     return True
@@ -616,14 +618,32 @@ def string_to_module(string_module):
 
 
 def process_frame(frame, modules):
+    # Glean format:
+    # {"frame": "...", "module": 0}
+    if isinstance(frame, dict):
+        module_index = frame.get("module")
+        offset = frame.get("frame")
+
+        if module_index is None:
+            return (("pseudo", None), offset)
+
+        if module_index < 0 or module_index >= len(modules):
+            return (None, offset)
+
+        debug_name, breakpad_id = modules[module_index]
+        return ((debug_name, breakpad_id), offset)
+
+    # Legacy telemetry format:
+    # [module_index, offset]
     if isinstance(frame, list):
         module_index, offset = frame
         if module_index is None or module_index < 0 or module_index >= len(modules):
             return (None, offset)
         debug_name, breakpad_id = modules[module_index]
         return ((debug_name, breakpad_id), offset)
-    else:
-        return (("pseudo", None), frame)
+
+    # Pseudo frame fallback.
+    return (("pseudo", None), frame)
 
 
 def filter_hang(hang, config):
@@ -635,18 +655,25 @@ def filter_hang(hang, config):
 
 
 def process_hang(hang):
-    result = hang.asDict()
-    result["stack"] = json.loads(hang["stack"])
-    return result
+    if hasattr(hang, "asDict"):
+        return hang.asDict(recursive=True)
+    return hang
 
 
 def process_hangs(ping, config):
-    build_date = ping["application/build_id"][:8]  # "YYYYMMDD" : 8 characters
+    build_date = ping["client_info/app_build"][:8]  # "YYYYMMDD" : 8 characters
 
-    platform = "{}".format(ping["environment/system/os/name"])
+    platform = "{}".format(ping["client_info/os"])
 
-    modules = ping["payload/modules"]
-    hangs = [process_hang(h) for h in ping["payload/hangs"]]
+    modules = ping["metrics/object/hangs_modules"]
+    if isinstance(modules, str):
+        modules = json.loads(modules)
+
+    raw_hangs = ping["metrics/object/hangs_reports"]
+    if isinstance(raw_hangs, str):
+        raw_hangs = json.loads(raw_hangs)
+
+    hangs = [process_hang(h) for h in raw_hangs]
     if hangs is None:
         return []
 
@@ -661,7 +688,7 @@ def process_hangs(ping, config):
             h["thread"],
             "",
             h["process"],
-            h["annotations"],
+            h.get("annotations") or [],
             build_date,
             platform,
         )
@@ -800,10 +827,9 @@ def process_hang_key(key, processed_modules):
 
 
 def process_hang_value(key, val, usage_hours_by_date):
-    stack, runnable_name, thread, build_date, annotations, platform = key
     return (
-        val[0] / usage_hours_by_date[build_date],
-        val[1] / usage_hours_by_date[build_date],
+        val[0],
+        val[1],
     )
 
 
@@ -891,20 +917,6 @@ def get_grouped_sums_and_counts(hangs, usage_hours_by_date, config):
     )
     items = [(k, process_hang_value(k, v, usage_hours_by_date)) for k, v in reduced]
     return [k + v for k, v in items if k is not None]
-
-
-def get_usage_hours(ping):
-    build_date = ping["application/build_id"][:8]  # "YYYYMMDD" : 8 characters
-    usage_hours = float(ping["payload/time_since_last_ping"]) / 3600000.0
-    return (build_date, usage_hours)
-
-
-def merge_usage_hours(a, b):
-    return a + b
-
-
-def get_usage_hours_by_date(pings):
-    return pings.map(get_usage_hours).reduceByKey(merge_usage_hours).collectAsMap()
 
 
 def make_sym_map(data, url=None):
@@ -1057,9 +1069,7 @@ def transform_pings(_, pings, config):
 
     hangs = symbolicate_hang_keys(hangs, processed_modules)
 
-    usage_hours_by_date = time_code(
-        "Getting usage hours", lambda: get_usage_hours_by_date(filtered)
-    )
+    usage_hours_by_date = {}
 
     result = time_code(
         "Grouping stacks",

--- a/mozetl/bhr_collection/bhr_collection.py
+++ b/mozetl/bhr_collection/bhr_collection.py
@@ -562,7 +562,6 @@ def get_data(sc, sql_context, config, date, end_date=None):
             "application/architecture",
             "application/build_id",
             "payload/hangs",
-            "payload/time_since_last_ping",
         ]
     else:
         properties = [
@@ -572,7 +571,6 @@ def get_data(sc, sql_context, config, date, end_date=None):
             "application/build_id",
             "payload/modules",
             "payload/hangs",
-            "payload/time_since_last_ping",
         ]
 
     print("%d results total" % pings_df.rdd.count())
@@ -597,8 +595,6 @@ def ping_is_valid(ping):
     if not isinstance(ping["environment/system/os/name"], str):
         return False
     if not isinstance(ping["application/build_id"], str):
-        return False
-    if not isinstance(ping["payload/time_since_last_ping"], int):
         return False
 
     return True

--- a/mozetl/bhr_collection/bhr_collection.py
+++ b/mozetl/bhr_collection/bhr_collection.py
@@ -549,8 +549,9 @@ def get_data(sc, sql_context, config, date, end_date=None):
         .option("query", sql)
         .option("viewsEnabled", True)
         # sql results need to be saved to a table
-        .option("materializationProject", "moz-fx-data-shared-prod")
+        .option("materializationProject", "mozdata")
         .option("materializationDataset", "tmp")
+        .option("billingProject", "mozdata")
         .load()
     )
 

--- a/mozetl/bhr_collection/bhr_collection.py
+++ b/mozetl/bhr_collection/bhr_collection.py
@@ -647,10 +647,12 @@ def process_frame(frame, modules):
 
 
 def filter_hang(hang, config):
+    stack = hang.get("stack")
     return (
-        hang["thread"] == config["thread_filter"]
-        and len(hang["stack"]) > 0
-        and len(hang["stack"]) < 300
+        hang.get("thread") == config["thread_filter"]
+        and isinstance(stack, list)
+        and len(stack) > 0
+        and len(stack) < 300
     )
 
 
@@ -1243,6 +1245,12 @@ def etl_job_daily(sc, sql_context, config=None):
             print("No data")
             continue
         transformed, usage_hours = transform_pings(sc, data, final_config)
+
+        # Glean hang_report_v1 does not currently provide usage hours in the
+        # same shape as the legacy telemetry. Keep a dummy value for
+        # compatibility with the existing BHR output schema/UI.
+        usage_hours = {date_str: 1.0}
+
         profile_processor = ProfileProcessor(final_config)
         profile_processor.ingest(transformed, usage_hours)
         profile = profile_processor.process_into_profile()


### PR DESCRIPTION
## Summary

This PR refers to Issue #409.

This migrates `bhr_collection.py` to read BHR hang report data from the Glean table:

`moz-fx-data-shared-prod.firefox_desktop_stable.hang_report_v1`

instead of the legacy telemetry table:

`moz-fx-data-shared-prod.telemetry_stable.bhr_v4`.

## Changes

- Set `mozdata` as the BigQuery billing project  
- Read `client_info`, `ping_info`, and `metrics` from the Glean hang report table  
- Map Glean fields into the existing processing shape  
- Parse Glean hang report/module object metrics before processing  
- Support Glean stack frames shaped as `{frame, module}`  
- Remove the legacy `payload/time_since_last_ping` normalization path  

## Local Validation

Ran locally with:

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) python3 ./mozetl/bhr_collection/bhr_collection.py \
  --date 2025-04-25 \
  --bq-connector-jar=spark-bigquery-latest_2.12.jar \
  --sample-size 0.0002
````

## Results and Comparison

The job completed successfully and wrote:

* `output/hangs_main_20250421.json`
* `output/hangs_main_current.json`

The output files are compared against legacy output:

* Top-level keys match
* Thread keys match
* `sampleTable` keys match
* Date keys match

The output is non-empty for the same thread/date combinations.

**Note:** Exact numeric similarity is no longer expected as the data source has changed to Glean, and the new output no longer normalizes by usage hours.